### PR TITLE
[codex] fix macOS systray main-thread crash

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ func main() {
 	// Create an instance of the app structure
 	app := NewApp()
 
+	systrayEnd := prepareSystray(app)
+
 	// Create application with options
 	opts := &options.App{
 		Title:     "Lumin",
@@ -77,12 +79,10 @@ func main() {
 		BackgroundColour: &options.RGBA{R: 8, G: 12, B: 20, A: 255}, // #080c14
 		OnStartup: func(ctx context.Context) {
 			app.startup(ctx)
-			// macOS: 等 Wails 初始化完成后再启动托盘，避免 NSApplication 冲突
-			onReady := func() {
-				setupSystray(app)
-			}
-			onExit := func() {}
-			go systray.Run(onReady, onExit)
+			startSystray(app)
+		},
+		OnShutdown: func(ctx context.Context) {
+			systrayEnd()
 		},
 		// 拦截窗口关闭：弹出对话框让用户选择退出 / 系统托盘 / 取消
 		OnBeforeClose: func(ctx context.Context) bool {

--- a/systray_darwin.go
+++ b/systray_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package main
+
+import "github.com/energye/systray"
+
+// prepareSystray attaches the tray to Wails' AppKit event loop while main is
+// still on the macOS main thread. Wails invokes OnStartup from a goroutine.
+func prepareSystray(app *App) func() {
+	start, end := systray.RunWithExternalLoop(func() {
+		setupSystray(app)
+	}, func() {})
+	start()
+	return end
+}
+
+// The macOS tray is already started by prepareSystray on the main thread.
+func startSystray(app *App) {}

--- a/systray_other.go
+++ b/systray_other.go
@@ -1,0 +1,16 @@
+//go:build linux || windows
+
+package main
+
+import "github.com/energye/systray"
+
+// Keep the existing standalone systray event loop on Windows and Linux.
+func prepareSystray(app *App) func() {
+	return func() {}
+}
+
+func startSystray(app *App) {
+	go systray.Run(func() {
+		setupSystray(app)
+	}, func() {})
+}


### PR DESCRIPTION
## What changed

- Use systray's external-loop integration on macOS so Wails remains the sole AppKit event-loop owner.
- Start the macOS tray on the main thread before `wails.Run`, because Wails invokes `OnStartup` from a goroutine.
- Keep the existing standalone systray loop unchanged on Windows and Linux.
- Shut down the macOS tray through Wails' `OnShutdown` callback.

## Root cause

The tray was started with `systray.Run` from Wails' `OnStartup` goroutine. On macOS this called AppKit's native event loop and created status-bar windows off the main thread, causing `SIGTRAP` or `NSInternalInconsistencyException` during startup.

## Impact

`wails dev` can start normally on macOS while retaining tray behavior. Windows and Linux retain their previous initialization path.

## Validation

- `go test ./...`
- `go vet ./...`
- Windows amd64 cross-platform `go test ./...`
- Linux amd64 cross-platform `go test ./...`
- Clean macOS `wails dev` startup; application remained running without AppKit crashes and exited cleanly
- Frontend `npm run build`
