### PR TITLE
[codex] add macOS DMG automatic updates

### DIFF
--- a/app.go
+++ b/app.go
@@ -655,11 +655,17 @@ func (a *App) PingServer(host string, port int) map[string]interface{} {
 	return PingServer(host, port)
 }
 
-// UpdateApp downloads the new exe from the given url, replaces the current running exe, and restarts the app.
+// UpdateApp downloads a platform update package, verifies it, and starts the
+// platform-specific installation or executable replacement flow.
 func (a *App) UpdateApp(downloadUrl string, filename string) error {
 	// 1. 强制 HTTPS，防止明文下载可执行文件被篡改
 	if !strings.HasPrefix(downloadUrl, "https://") {
 		return fmt.Errorf("更新地址必须使用 HTTPS")
+	}
+	// Release asset names must not escape the temporary/download directory.
+	filename = filepath.Base(strings.TrimSpace(filename))
+	if filename == "." || filename == "" {
+		return fmt.Errorf("更新文件名无效")
 	}
 	// 2. 发起请求下载新文件（带超时，防止慢网络永久阻塞）
 	client := &http.Client{Timeout: 10 * time.Minute}
@@ -691,6 +697,7 @@ func (a *App) UpdateApp(downloadUrl string, filename string) error {
 
 	isDeb := strings.HasSuffix(strings.ToLower(filename), ".deb")
 	isRpm := strings.HasSuffix(strings.ToLower(filename), ".rpm")
+	isDmg := strings.HasSuffix(strings.ToLower(filename), ".dmg")
 	isSetup := strings.Contains(strings.ToLower(filename), "installer") || strings.Contains(strings.ToLower(filename), "setup")
 	var targetPath string
 	var exePath string
@@ -703,8 +710,8 @@ func (a *App) UpdateApp(downloadUrl string, filename string) error {
 	}
 	exePath = exe
 
-	if isSetup || isDeb || isRpm {
-		// 安装包、.deb 和 .rpm 都下载到临时目录
+	if isSetup || isDeb || isRpm || isDmg {
+		// 安装包、.deb、.rpm 和 .dmg 都下载到临时目录
 		targetPath = filepath.Join(os.TempDir(), filename)
 	} else {
 		// 便携版：下载到 exe 同级目录，或权限不足时降级到临时目录
@@ -818,7 +825,16 @@ func (a *App) UpdateApp(downloadUrl string, filename string) error {
 		return nil
 	}
 
-	// 4. 区分 Setup 还是 Portable 替换
+	// 4. macOS DMG 由独立更新进程替换 .app，并在旧进程退出后重启。
+	if isDmg {
+		if err := installDmgPackage(targetPath, exePath); err != nil {
+			return err
+		}
+		os.Exit(0)
+		return nil
+	}
+
+	// Windows 安装包交给系统安装器处理；其他文件走 Portable 替换。
 	if isSetup {
 		if err := launchInstaller(targetPath); err != nil {
 			return err

--- a/frontend/src/hooks/useUpdateChecker.js
+++ b/frontend/src/hooks/useUpdateChecker.js
@@ -24,6 +24,11 @@ function isLinux() {
   return navigator.userAgent.includes('Linux') || navigator.platform.includes('Linux');
 }
 
+// 判断当前是否 macOS 平台
+function isMacOS() {
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform) || navigator.userAgent.includes('Mac OS');
+}
+
 // 匹配下载资源（便携版/安装版/兜底）
 async function resolveDownloadAsset(data) {
   let isPortable = false;
@@ -32,6 +37,14 @@ async function resolveDownloadAsset(data) {
   }
   if (data.assets && data.assets.length > 0) {
     let targetAsset = null;
+
+    // macOS: Release 使用 DMG 分发，忽略配套的 .sha256 文件
+    if (isMacOS()) {
+      targetAsset = data.assets.find(a => a.name.toLowerCase().endsWith('.dmg'));
+      if (targetAsset) {
+        return { url: targetAsset.browser_download_url, filename: targetAsset.name };
+      }
+    }
 
     // Linux: 优先选取 .deb 包，其次 .rpm
     if (isLinux()) {
@@ -57,7 +70,7 @@ async function resolveDownloadAsset(data) {
       return { url: targetAsset.browser_download_url, filename: targetAsset.name };
     }
   }
-  const fallbackName = isLinux() ? 'update.deb' : 'update.exe';
+  const fallbackName = isMacOS() ? 'update.dmg' : (isLinux() ? 'update.deb' : 'update.exe');
   return { url: data.html_url || '', filename: fallbackName };
 }
 
@@ -109,8 +122,9 @@ export function useUpdateChecker({ onResult, onError } = {}) {
   const applyUpdate = useCallback(async (updateInfo) => {
     if (!updateInfo || !updateInfo.url) return;
     if (downloadProgress >= 0) return;
-    // 非 exe/deb/rpm 的链接直接打开浏览器
-    if (!updateInfo.url.endsWith('.exe') && !updateInfo.url.endsWith('.deb') && !updateInfo.url.endsWith('.rpm')) {
+    // 非平台安装包的链接直接打开浏览器
+    const packageName = (updateInfo.filename || updateInfo.url).toLowerCase();
+    if (!/\.(exe|deb|rpm|dmg)$/.test(packageName)) {
       window.runtime?.BrowserOpenURL(updateInfo.url);
       return;
     }
@@ -118,6 +132,7 @@ export function useUpdateChecker({ onResult, onError } = {}) {
     let defaultName = 'update.exe';
     if (updateInfo.url.endsWith('.deb')) defaultName = 'update.deb';
     else if (updateInfo.url.endsWith('.rpm')) defaultName = 'update.rpm';
+    else if (updateInfo.url.endsWith('.dmg')) defaultName = 'update.dmg';
     try {
       await AppGo.UpdateApp(updateInfo.url, updateInfo.filename || defaultName);
     } catch (err) {

--- a/update_darwin.go
+++ b/update_darwin.go
@@ -1,0 +1,200 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// launchInstaller opens the downloaded disk image with Finder. This mirrors
+// the Windows installer flow: hand the platform package to the OS, then let
+// UpdateApp exit the old application.
+func launchInstaller(targetPath string) error {
+	if err := exec.Command("open", targetPath).Start(); err != nil {
+		return fmt.Errorf("failed to open macOS disk image: %w", err)
+	}
+	return nil
+}
+
+// restartApp is only a fallback for non-DMG update paths. Released macOS
+// builds use a DMG and therefore go through launchInstaller.
+func restartApp(exePath string) error {
+	if err := exec.Command("open", exePath).Start(); err != nil {
+		return fmt.Errorf("failed to restart application: %w", err)
+	}
+	return nil
+}
+
+func installDebPackage(_ string) error {
+	return fmt.Errorf("deb packages are not supported on macOS")
+}
+
+func installRpmPackage(_ string) error {
+	return fmt.Errorf("rpm packages are not supported on macOS")
+}
+
+// installDmgPackage mounts the verified DMG and starts a detached updater.
+// The updater waits for this process to exit, backs up and replaces the
+// application bundle, opens the new application, and rolls back on failure.
+func installDmgPackage(dmgPath, exePath string) error {
+	const appMarker = ".app/Contents/MacOS/"
+	markerIndex := strings.Index(exePath, appMarker)
+	if markerIndex < 0 {
+		return fmt.Errorf("cannot locate the current macOS application bundle")
+	}
+
+	targetApp := exePath[:markerIndex+len(".app")]
+	// A bundle launched directly from a DMG is read-only. Install the update
+	// into /Applications in that case.
+	if strings.HasPrefix(targetApp, "/Volumes/") {
+		targetApp = filepath.Join("/Applications", filepath.Base(targetApp))
+	}
+
+	targetParent := filepath.Dir(targetApp)
+	writeProbe, err := os.MkdirTemp(targetParent, ".lumin-update-write-test-")
+	if err != nil {
+		return fmt.Errorf("application directory is not writable: %w", err)
+	}
+	os.Remove(writeProbe)
+
+	mountPoint, err := os.MkdirTemp("", "lumin-update-mount-")
+	if err != nil {
+		return fmt.Errorf("failed to create DMG mount point: %w", err)
+	}
+	mounted := false
+	defer func() {
+		if !mounted {
+			os.Remove(mountPoint)
+		}
+	}()
+
+	attach := exec.Command("hdiutil", "attach", "-readonly", "-nobrowse", "-mountpoint", mountPoint, dmgPath)
+	if output, err := attach.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to mount update DMG: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	mounted = true
+
+	detachOnError := func() {
+		exec.Command("hdiutil", "detach", mountPoint).Run()
+		os.Remove(mountPoint)
+		mounted = false
+	}
+
+	entries, err := os.ReadDir(mountPoint)
+	if err != nil {
+		detachOnError()
+		return fmt.Errorf("failed to inspect update DMG: %w", err)
+	}
+	var sourceApp string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasSuffix(strings.ToLower(entry.Name()), ".app") {
+			sourceApp = filepath.Join(mountPoint, entry.Name())
+			break
+		}
+	}
+	if sourceApp == "" {
+		detachOnError()
+		return fmt.Errorf("update DMG does not contain an application bundle")
+	}
+
+	if output, err := exec.Command("codesign", "--verify", "--deep", "--strict", sourceApp).CombinedOutput(); err != nil {
+		detachOnError()
+		return fmt.Errorf("update application signature verification failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	updaterScript := `#!/bin/sh
+set -u
+TARGET="$1"
+SOURCE="$2"
+MOUNT="$3"
+DMG="$4"
+OLD_PID="$5"
+BACKUP="${TARGET}.old"
+
+cleanup() {
+  /usr/bin/hdiutil detach "$MOUNT" >/dev/null 2>&1 || true
+  /bin/rmdir "$MOUNT" >/dev/null 2>&1 || true
+  /bin/rm -f "$DMG" "$0"
+}
+trap cleanup EXIT
+
+while /bin/kill -0 "$OLD_PID" >/dev/null 2>&1; do
+  /bin/sleep 0.2
+done
+
+/bin/rm -rf "$BACKUP"
+if [ -e "$TARGET" ]; then
+  /bin/mv "$TARGET" "$BACKUP" || exit 1
+fi
+
+if /usr/bin/ditto "$SOURCE" "$TARGET"; then
+  if /usr/bin/open -n "$TARGET"; then
+    /bin/rm -rf "$BACKUP"
+    exit 0
+  fi
+fi
+
+/bin/rm -rf "$TARGET"
+if [ -e "$BACKUP" ]; then
+  /bin/mv "$BACKUP" "$TARGET"
+  /usr/bin/open -n "$TARGET" >/dev/null 2>&1 || true
+fi
+exit 1
+`
+
+	scriptFile, err := os.CreateTemp("", "lumin-updater-*.sh")
+	if err != nil {
+		detachOnError()
+		return fmt.Errorf("failed to create updater script: %w", err)
+	}
+	scriptPath := scriptFile.Name()
+	if _, err := scriptFile.WriteString(updaterScript); err != nil {
+		scriptFile.Close()
+		os.Remove(scriptPath)
+		detachOnError()
+		return fmt.Errorf("failed to write updater script: %w", err)
+	}
+	if err := scriptFile.Close(); err != nil {
+		os.Remove(scriptPath)
+		detachOnError()
+		return fmt.Errorf("failed to close updater script: %w", err)
+	}
+	if err := os.Chmod(scriptPath, 0700); err != nil {
+		os.Remove(scriptPath)
+		detachOnError()
+		return fmt.Errorf("failed to prepare updater script: %w", err)
+	}
+
+	logPath := filepath.Join(os.TempDir(), "Lumin-update.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		os.Remove(scriptPath)
+		detachOnError()
+		return fmt.Errorf("failed to open updater log: %w", err)
+	}
+
+	cmd := exec.Command(scriptPath, targetApp, sourceApp, mountPoint, dmgPath, strconv.Itoa(os.Getpid()))
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		os.Remove(scriptPath)
+		detachOnError()
+		return fmt.Errorf("failed to start macOS updater: %w", err)
+	}
+	logFile.Close()
+
+	// The detached updater owns the mount and temporary files from here.
+	return nil
+}
+
+func applyUpdateElevated(_, _ string) error {
+	return fmt.Errorf("executable replacement is not supported on macOS; use the DMG release")
+}

--- a/update_unix.go
+++ b/update_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package main
 
@@ -60,6 +60,10 @@ func installRpmPackage(rpmPath string) error {
 		}
 	}
 	return nil
+}
+
+func installDmgPackage(_, _ string) error {
+	return fmt.Errorf("dmg packages are not supported on Linux")
 }
 
 // applyUpdateElevated 以提权方式执行便携版热替换。

--- a/update_windows.go
+++ b/update_windows.go
@@ -29,6 +29,7 @@ func restartApp(exePath string) error {
 }
 
 // ponytail: Windows 平台 stubs — Linux 专属的更新路径不会走到
-func installDebPackage(_ string) error           { return nil }
-func installRpmPackage(_ string) error           { return nil }
-func applyUpdateElevated(_, _ string) error      { return nil }
+func installDebPackage(_ string) error      { return nil }
+func installRpmPackage(_ string) error      { return nil }
+func installDmgPackage(_, _ string) error   { return nil }
+func applyUpdateElevated(_, _ string) error { return nil }


### PR DESCRIPTION
## Summary

- select macOS `.dmg` assets from GitHub Releases
- download and verify the DMG, validate the embedded app signature, and replace the installed app through a detached updater
- restart the updated app automatically and restore the previous bundle if replacement or launch fails
- sanitize release asset filenames before writing update files

## Root cause

The update asset resolver only handled Linux packages and Windows executables, so macOS fell through to the Windows `.exe` path. The backend also treated all non-Windows systems as Linux-style executable replacements. Opening a downloaded DMG alone did not install the new app or relaunch it after the old process exited.

## Impact

macOS users can update from a GitHub Release DMG without manually reopening the app. The updater supports apps launched from `/Applications` or directly from a mounted DMG, verifies the bundle, keeps a rollback copy during replacement, and restarts the new version.

## Validation

- `go test ./...`
- `go vet ./...`
- `npm run build`
- Wails production build for `darwin/arm64`
- code-signature verification with `codesign --verify --deep --strict`
- DMG integrity verification with `hdiutil verify`
