### PR TITLE
fix: 优化数据管理弹窗 UI 布局及解决模态框层级冲突

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4999,6 +4999,17 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
       </main>
 
       {/* ── Modals ────────────────────────────────────────── */}
+      {showImportExportDialog && (
+        <ImportExportDialog
+          onClose={() => setShowImportExportDialog(false)}
+          onExport={handleExport}
+          onImport={handleImport}
+          onDownloadTemplate={handleDownloadTemplate}
+          hasCloudProvider={hasCloudProvider}
+          busy={ieBusy}
+        />
+      )}
+
       {showSettings && (
         <SettingsModal
           onClose={() => { setShowSettings(false); loadServers(); }}
@@ -5017,17 +5028,6 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
           onClose={() => { setShowCredentials(false); loadServers(); }}
           onChange={loadServers}
           addToast={addToast}
-        />
-      )}
-
-      {showImportExportDialog && (
-        <ImportExportDialog
-          onClose={() => setShowImportExportDialog(false)}
-          onExport={handleExport}
-          onImport={handleImport}
-          onDownloadTemplate={handleDownloadTemplate}
-          hasCloudProvider={hasCloudProvider}
-          busy={ieBusy}
         />
       )}
 

--- a/frontend/src/components/ImportExportDialog.jsx
+++ b/frontend/src/components/ImportExportDialog.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Database, Upload, Download, FileDown, Eye, EyeOff, X } from 'lucide-react';
 import { useTranslation } from '../i18n.js';
 import Tiptop from './Tiptop.jsx';
+import { Z } from '../constants/zIndex';
 
 /**
  * 数据管理弹窗：导入 / 导出 / 下载模板。
@@ -82,7 +83,7 @@ export default function ImportExportDialog({ onClose, onExport, onImport, onDown
   );
 
   return (
-    <div className="modal-overlay" style={{ zIndex: 9999 }}>
+    <div className="modal-overlay" style={{ zIndex: Z.MODAL }}>
       <div className="modal modal-md" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <div className="modal-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -876,7 +876,7 @@ export default function SettingsModal({
   const isAnyConfigured = isConfigured || r2Configured || ftpConfigured || sftpConfigured;
 
   return (
-    <div className="modal-overlay">
+    <div className="modal-overlay" style={{ zIndex: Z.MODAL }}>
       <div className="modal modal-xl" style={{ display: 'flex', flexDirection: 'column', height: '80vh', background: 'var(--surface-raised)' }}>
         
         {/* Settings Header */}


### PR DESCRIPTION
修复了数据管理（节点导入/导出）弹窗相关的 UI 视觉布局与模态框叠放层级冲突问题：

修复了数据管理弹窗与设置菜单同时打开时，设置菜单被挡在下方的层级冲突。通过为 SettingsModal 补上主遮罩的 z-index，并调整 DOM 渲染顺序，确保当两者同时存在时，设置菜单能够正常显示在最前层。