### PR TITLE
feat: 优化代理与 TUN 模式下的可用性及延迟探测，支持设置一键开关

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1230,6 +1230,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
   // ── 新增主页仪表盘状态 ──────────────────────────────────
   const [isRefreshingPing, setIsRefreshingPing] = useState(false);
   const [pingInterval, setPingInterval] = useState(parseInt(localStorage.getItem('pingInterval') || '2', 10));
+  const [pingEnabled, setPingEnabled] = useState(localStorage.getItem('pingEnabled') !== 'false');
 
   useEffect(() => {
     const handler = () => {
@@ -1237,6 +1238,14 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     };
     window.addEventListener('pingIntervalChanged', handler);
     return () => window.removeEventListener('pingIntervalChanged', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => {
+      setPingEnabled(localStorage.getItem('pingEnabled') !== 'false');
+    };
+    window.addEventListener('pingEnabledChanged', handler);
+    return () => window.removeEventListener('pingEnabledChanged', handler);
   }, []);
 
   // ── 初始化全局主题 ──────────────────────────────────────
@@ -1369,7 +1378,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
 
   // ── 刷新延迟 ────────────────────────────────────────────
   const handleRefreshPing = async () => {
-    if (isRefreshingPing) return; // 防止重复点击导致并发竞态
+    if (!pingEnabled || isRefreshingPing) return; // 防止重复点击导致并发竞态
     setIsRefreshingPing(true);
     await pingAll();
     setTimeout(() => { if (mountedRef.current) setIsRefreshingPing(false); }, 800);
@@ -1888,11 +1897,15 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
 
   useEffect(() => {
     if (activeSessionId !== null) return; // ponytail: 不在主页时不 ping
+    if (!pingEnabled) {
+      setPings({});
+      return;
+    }
     pingAll();
     // 修改为动态刷新延迟，降低后台消耗或提高实时性
     pingTimerRef.current = setInterval(pingAll, pingInterval * 1000);
     return () => clearInterval(pingTimerRef.current);
-  }, [pingAll, pingInterval, activeSessionId]);
+  }, [pingAll, pingInterval, activeSessionId, pingEnabled]);
 
   // ── 取消连接 ──────────────────────────────────────────────
   const handleCancelConnection = useCallback((sessionId) => {
@@ -4261,6 +4274,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
             serverListViewMode={serverListViewMode}
             onViewModeChange={(mode) => { setServerListViewMode(mode); localStorage.setItem('serverListViewMode', mode); }}
             servers={servers}
+            pingEnabled={pingEnabled}
             pingCounts={pingCounts}
             isRefreshingPing={isRefreshingPing}
             onRefreshPing={handleRefreshPing}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -10,7 +10,7 @@ export default function Dashboard({
   searchQuery, onSearchChange,
   hideSensitive, onHideSensitiveToggle,
   serverListViewMode, onViewModeChange,
-  servers, pingCounts, isRefreshingPing, onRefreshPing,
+  servers, pingEnabled, pingCounts, isRefreshingPing, onRefreshPing,
   filteredServers, pings, sessions, activeSessionId,
   onConnect, onStartAdd, onEdit, onClone, onDelete, onMoveGroup, addToast,
   onOpenImportExport,
@@ -36,9 +36,11 @@ export default function Dashboard({
           <div className="card-header-icon-title">
             <span className="card-header-icon"><BarChart3 size={18} /></span>
             <span className="card-header-title">{t('系统状态')}</span>
-            <Tiptop text={t('刷新延迟')} placement="bottom">
-              <button className={`btn-icon-spin ${isRefreshingPing ? 'spinning' : ''}`} onClick={onRefreshPing} aria-label={t('刷新延迟')} style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, display: "flex", alignItems: "center" }}><RefreshCw size={14} /></button>
-            </Tiptop>
+            {pingEnabled && (
+              <Tiptop text={t('刷新延迟')} placement="bottom">
+                <button className={`btn-icon-spin ${isRefreshingPing ? 'spinning' : ''}`} onClick={onRefreshPing} aria-label={t('刷新延迟')} style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, display: "flex", alignItems: "center" }}><RefreshCw size={14} /></button>
+              </Tiptop>
+            )}
           </div>
           <div className="stats-grid">
             <div className="stat-item">
@@ -46,11 +48,11 @@ export default function Dashboard({
               <div className="stat-lbl">{t('服务器总数')}</div>
             </div>
             <div className="stat-item">
-              <div className="stat-val" style={{ color: 'var(--success)' }}>{pingCounts.online}</div>
+              <div className="stat-val" style={{ color: 'var(--success)' }}>{pingEnabled ? pingCounts.online : '—'}</div>
               <div className="stat-lbl">{t('在线节点')}</div>
             </div>
             <div className="stat-item">
-              <div className="stat-val" style={{ color: 'var(--danger)' }}>{pingCounts.offline}</div>
+              <div className="stat-val" style={{ color: 'var(--danger)' }}>{pingEnabled ? pingCounts.offline : '—'}</div>
               <div className="stat-lbl">{t('离线节点')}</div>
             </div>
           </div>
@@ -128,6 +130,7 @@ export default function Dashboard({
           <div className="hosts-scroll-area">
             <ServerList
               servers={filteredServers}
+              pingEnabled={pingEnabled}
               pings={pings}
               sessions={sessions}
               activeSessionId={activeSessionId}

--- a/frontend/src/components/ServerList.jsx
+++ b/frontend/src/components/ServerList.jsx
@@ -92,6 +92,7 @@ const getOSInfo = (name = '', os = '', osInfo = null) => {
 
 export default function ServerList({
   servers,
+  pingEnabled,
   pings,
   sessions,
   activeSessionId,
@@ -301,7 +302,7 @@ export default function ServerList({
 
   // Server card 渲染
   const renderServerCard = (server) => {
-    const ping = pings[server.id];
+    const ping = pingEnabled ? pings[server.id] : undefined;
     const latClass = ping ? LATENCY_CLASS(ping.latency) : 'offline';
     const active = isActive(server);
     const connected = hasSession(server);
@@ -483,7 +484,7 @@ export default function ServerList({
                 );
               }
               const server = item.server;
-              const ping = pings[server.id];
+              const ping = pingEnabled ? pings[server.id] : undefined;
               const latClass = ping ? LATENCY_CLASS(ping.latency) : 'offline';
               const active = isActive(server);
               const connected = hasSession(server);

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -286,7 +286,7 @@ export default function SettingsModal({
   const [sftpTestResult, setSftpTestResult] = useState(null);
 
   // Network/Ping state
-  const [pingProtocol, setPingProtocol] = useState(localStorage.getItem('pingProtocol') || 'ssh');
+  const [pingEnabled, setPingEnabled] = useState(localStorage.getItem('pingEnabled') !== 'false');
   const [probeInterval, setProbeInterval] = useState(parseInt(localStorage.getItem('probeInterval') || '3', 10));
   const [pingInterval, setPingInterval] = useState(parseInt(localStorage.getItem('pingInterval') || '2', 10));
 
@@ -866,7 +866,12 @@ export default function SettingsModal({
   };
 
   // ── Tab prop wrappers ──
-  const handlePingProtocolChange = (id) => { setPingProtocol(id); localStorage.setItem('pingProtocol', id); };
+  const handleTogglePingEnabled = () => {
+    const next = !pingEnabled;
+    setPingEnabled(next);
+    localStorage.setItem('pingEnabled', String(next));
+    window.dispatchEvent(new Event('pingEnabledChanged'));
+  };
   const handleProbeIntervalChange = (s) => { setProbeInterval(s); localStorage.setItem('probeInterval', String(s)); window.dispatchEvent(new Event('probeIntervalChanged')); };
   const handlePingIntervalChange = (s) => { setPingInterval(s); localStorage.setItem('pingInterval', String(s)); window.dispatchEvent(new Event('pingIntervalChanged')); };
   const handleTerminalColorThemeChange = (key) => { setTerminalColorTheme(key); localStorage.setItem('terminalColorTheme', key); window.dispatchEvent(new CustomEvent('terminal-theme-changed', { detail: key })); };
@@ -952,8 +957,8 @@ export default function SettingsModal({
 
             {activeTab === 'network' && (
               <NetworkTab
-                pingProtocol={pingProtocol}
-                onPingProtocolChange={handlePingProtocolChange}
+                pingEnabled={pingEnabled}
+                onTogglePingEnabled={handleTogglePingEnabled}
                 probeInterval={probeInterval}
                 onProbeIntervalChange={handleProbeIntervalChange}
                 pingInterval={pingInterval}

--- a/frontend/src/components/settings/NetworkTab.jsx
+++ b/frontend/src/components/settings/NetworkTab.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { t as $t } from '../../i18n.js';
 import { Lightbulb } from 'lucide-react';
-import { RadioOption } from './SharedComponents';
+import { ToggleSwitch } from './SharedComponents';
 import { getAIGlobalSettings, saveAIGlobalSettings } from '../ai/aiGlobalSettingsBridge.js';
 
 const PROXY_NODES_CHANGED_EVENT = 'lumin:proxy-nodes-changed';
@@ -39,7 +39,7 @@ function getIsMobileLayout() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia(MOBILE_MEDIA_QUERY).matches;
 }
 
-export default function NetworkTab({ pingProtocol, onPingProtocolChange, probeInterval, onProbeIntervalChange, pingInterval, onPingIntervalChange }) {
+export default function NetworkTab({ pingEnabled, onTogglePingEnabled, probeInterval, onProbeIntervalChange, pingInterval, onPingIntervalChange }) {
   const [proxyNodes, setProxyNodes] = useState([]);
   const [proxyForm, setProxyForm] = useState(defaultProxyForm);
   const [editingProxyId, setEditingProxyId] = useState('');
@@ -166,18 +166,16 @@ export default function NetworkTab({ pingProtocol, onPingProtocolChange, probeIn
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
       <div>
-        <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 4 }}>{$t('延迟检测协议')}</div>
-        <div style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 20 }}>{$t('选择如何测量服务器网络延迟，不同协议适用于不同的网络环境。')}</div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {[
-            { id: 'ssh', label: <>{$t('SSH Banner RTT')} <span style={{ fontSize: 10, background: 'var(--accent-dim)', border: '1px solid var(--accent-border)', color: 'var(--accent)', padding: '1px 6px', borderRadius: 4, fontWeight: 700 }}>{$t('推荐')}</span></>, desc: $t('通过读取 SSH 握手包测速，穿透 TUN 代理测出真实网络延迟，推荐') },
-            { id: 'tcp', label: $t('TCP Dial'), desc: $t('通过 TCP 连接建立测速，适用于局域网/私有网络或未开代理的环境') },
-          ].map((opt) => (
-            <RadioOption key={opt.id} selected={pingProtocol === opt.id} label={opt.label} description={opt.desc} onClick={() => onPingProtocolChange(opt.id)} />
-          ))}
-        </div>
-        <div style={{ marginTop: 12, padding: '10px 14px', background: 'var(--surface-overlay)', borderRadius: 8, fontSize: 12, color: 'var(--text-tertiary)', lineHeight: 1.7, border: '1px solid var(--border-light)' }}>
-          <span style={{ display: 'inline-flex', alignItems: 'center', verticalAlign: 'middle', marginRight: 4 }}><Lightbulb size={14} /></span> <strong style={{ color: 'var(--text-secondary)' }}>{$t('提示：')}</strong>{$t('如果您使用 TUN 模式代理（Clash/V2Ray），推荐使用 SSH Banner RTT 模式，可以穿透代理测出真实延迟。')}
+        <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', marginBottom: 4 }}>{$t('延迟检测')}</div>
+        <div style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 20 }}>{$t('开启或关闭对主页所有服务器的网络可用性及延迟自动探测。')}</div>
+        <div className="form-group" style={{ background: 'var(--surface-overlay)', padding: 16, borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div>
+              <div style={{ color: 'var(--text-primary)', fontSize: 13 }}>{$t('启用延迟检测')}</div>
+              <div style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{$t('定期向服务器发起轻量级探测，实时了解服务器的在线状态和响应速度')}</div>
+            </div>
+            <ToggleSwitch checked={pingEnabled} onChange={onTogglePingEnabled} />
+          </div>
         </div>
       </div>
       <div>

--- a/ping.go
+++ b/ping.go
@@ -47,18 +47,23 @@ func measureLatency(connConfig Connection) (int64, bool) {
 	defer conn.Close()
 
 	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	usesProxy := connectionUsesProxy(connConfig)
+	isTUN := !usesProxy && dialMs < 50 && !isLocalOrPrivateIP(connConfig.Host)
+
+	// 仅在使用了代理或检测为 TUN 模式时，才写入客户端 Banner 以激活延迟连接，直连模式下发送 0 字节以节省流量
+	var writeErr error
+	if usesProxy || isTUN {
+		_, writeErr = conn.Write([]byte("SSH-2.0-LuminPing\r\n"))
+	}
+
 	buf := make([]byte, 64)
 	n, err := conn.Read(buf)
 	bannerMs := time.Since(connectedAt).Milliseconds()
 
-	usesProxy := connectionUsesProxy(connConfig)
-	isTUN := !usesProxy && dialMs < 5 && !isLocalOrPrivateIP(connConfig.Host)
-
-	if err != nil || n == 0 {
-		if usesProxy || isTUN {
-			return bannerMs, true
-		}
-		return dialMs, true
+	// 如果写入错误、读取错误或读入字节为0，代表 SSH 服务不可用，直接判定为离线
+	if writeErr != nil || err != nil || n == 0 {
+		return 0, false
 	}
 
 	if usesProxy || isTUN {


### PR DESCRIPTION
# 📝 PR Description (描述)

### 💡 背景与问题
1. **TUN 模式下离线节点被判在线**：在开启 Clash TUN 或其他透明代理模式时，由于本地网卡主动应答了 TCP 三次握手，原本不可达的离线节点在 `TCP Dial` 测试中会被误判为 `0ms` 在线。
2. **时钟精度导致 TUN 识别失效**：Windows 系统的默认时钟精度为 `15.6ms`，原判定条件 `dialMs < 5` 过于严格，极易漏判本地 TUN 代理。
3. **设置项冗余**：设置页面中的“延迟检测协议”逻辑未与后端真正联动。

---

### 🛠️ 解决方案与改进

#### 1. 透明代理/TUN 穿透探测优化
* **主动标头写入（Write-then-Read）**：在检测到代理或疑似 TUN 模式时，自动向 Socket 写入 mock 客户端 SSH 版本标识（`SSH-2.0-LuminPing\r\n`），强行唤醒懒加载代理进行真实握手。
* **精准拦截离线信号**：如果远程主机不可达，代理在写或读阶段会立即抛出 `EOF`、`Reset` 或超时。对此，系统将统一将其标记为**离线状态（返回 `0, false`）**，彻底解决了伪在线的问题。
* **时钟精度兼容**：将本地 TUN 的 RTT 判定阈值放宽至 `50ms`，完美兼容 Windows 及多平台的时钟滴答精度与代理转发延迟。

#### 2. 极致性能与流量控制
* **直连 0 字节发送**：该发送机制**仅在代理/TUN 模式下激活**。普通直连节点不会发送任何多余数据包，继续保持无网络开销的只读探测（直连发送流量为 `0` 字节）。

#### 3. 设置选项极简重构与联动
* **化繁为简**：移除了难以理解的 `SSH Banner RTT` 和 `TCP Dial` 协议单选组，重构为统一的 **“启用延迟检测” 开关（ToggleSwitch）**。
* **界面强力联锁**：
  * 关闭延迟检测时，底层的定时探测循环会**完全注销**，手动刷新按钮也会在主页中隐藏。
  * 仪表盘的“在线/离线节点数”显示为 `—`，且各服务器卡片上会**强制隐藏**任何状态圆点与毫秒，消除异步竞态回调对界面的残留影响。

---

### 🔍 变动文件 (Changed Files)
* [`ping.go`](file:///d:/AllCode/golang/Lumin-SSH/ping.go)：升级底层测速逻辑与离线判定。
* [`App.jsx`](file:///d:/AllCode/golang/Lumin-SSH/frontend/src/App.jsx)：全局 `pingEnabled` 定时器注销与缓存清理逻辑。
* [`Dashboard.jsx`](file:///d:/AllCode/golang/Lumin-SSH/frontend/src/components/Dashboard.jsx) & [`ServerList.jsx`](file:///d:/AllCode/golang/Lumin-SSH/frontend/src/components/ServerList.jsx)：主页仪表盘统计与卡片状态的开关隔离。
* [`SettingsModal.jsx`](file:///d:/AllCode/golang/Lumin-SSH/frontend/src/components/SettingsModal.jsx) & [`NetworkTab.jsx`](file:///d:/AllCode/golang/Lumin-SSH/frontend/src/components/settings/NetworkTab.jsx)：重构网格设置项，更换单选组为 ToggleSwitch。