### PR TITLE
feat: 文件管理器多选、复制/剪切/粘贴/删除及全局快捷键与焦点优化

### DIFF
--- a/ai_wails_bindings.go
+++ b/ai_wails_bindings.go
@@ -281,6 +281,20 @@ func (d aiSSHDelegate) DeleteItemContext(ctx context.Context, sessionID string, 
 	return d.manager.DeleteItemContext(ctx, sessionID, remotePath, isDir)
 }
 
+func (d aiSSHDelegate) CopyItemContext(ctx context.Context, sessionID string, srcPath string, dstPath string) error {
+	if d.manager == nil {
+		return fmt.Errorf("ssh manager unavailable")
+	}
+	return d.manager.CopyItemContext(ctx, sessionID, srcPath, dstPath)
+}
+
+func (d aiSSHDelegate) MoveItemContext(ctx context.Context, sessionID string, srcPath string, dstPath string) error {
+	if d.manager == nil {
+		return fmt.Errorf("ssh manager unavailable")
+	}
+	return d.manager.MoveItemContext(ctx, sessionID, srcPath, dstPath)
+}
+
 func (d aiSSHDelegate) MkdirContext(ctx context.Context, sessionID string, remotePath string) error {
 	if d.manager == nil {
 		return fmt.Errorf("ssh manager unavailable")

--- a/app.go
+++ b/app.go
@@ -739,6 +739,16 @@ func (a *App) RenameItem(sessionId string, oldPath string, newPath string) error
 	return a.sshManager.RenameItem(sessionId, oldPath, newPath)
 }
 
+// CopyItem copies a file or directory within the same server (server-local cp -a).
+func (a *App) CopyItem(sessionId string, srcPath string, dstPath string) error {
+	return a.sshManager.CopyItem(sessionId, srcPath, dstPath)
+}
+
+// MoveItem moves a file or directory within the same server (server-local mv).
+func (a *App) MoveItem(sessionId string, srcPath string, dstPath string) error {
+	return a.sshManager.MoveItem(sessionId, srcPath, dstPath)
+}
+
 // GetChmodDialogSettings returns remembered chmod dialog preferences
 func (a *App) GetChmodDialogSettings() map[string]interface{} {
 	return a.configManager.GetChmodDialogSettings()

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -609,6 +609,9 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   const fileListRef = useRef(null);
   useEffect(() => { mountedRef.current = true; return () => { mountedRef.current = false; }; }, []);
   const [contextMenu, setContextMenu] = useState(null); // { pos, item }
+  const [selectedPaths, setSelectedPaths] = useState([]);
+  const lastClickedPathRef = useRef(null);
+  const [clipboard, setClipboard] = useState(null); // { paths: string[], mode: 'copy'|'cut', srcDir: string }
   const [renamingItem, setRenamingItem] = useState(null);
   const [renameValue, setRenameValue] = useState('');
   const [chmodTarget, setChmodTarget] = useState(null); // { item, path, mode, includeSubdirectories, showIncludeSubdirectories }
@@ -1730,6 +1733,104 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
   };
 
+  // Delete multiple selected items
+  const handleDeleteItems = async () => {
+    if (selectedPaths.length === 0) return;
+    const dirSet = new Set(items.filter(i => i.isDirectory).map(i => joinPath(currentPath, i.name)));
+    const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
+    if (needConfirm && !(await window.luminDialog?.confirm(`${t('确定删除所选')} (${selectedPaths.length}${t('项')})？${t('此操作不可撤销')}`))) return;
+    let successCount = 0;
+    let failCount = 0;
+    for (const path of selectedPaths) {
+      try {
+        await AppGo.DeleteItem(sessionId, path, dirSet.has(path));
+        successCount++;
+      } catch (err) {
+        failCount++;
+        console.error('delete item failed:', path, err);
+      }
+    }
+    if (successCount > 0) addToast(`${t('已删除')} ${successCount} ${t('项')}`, 'success');
+    if (failCount > 0) addToast(`${t('删除失败')}: ${failCount} ${t('项')}`, 'error');
+    setSelectedPaths([]);
+    await loadDir(currentPath);
+  };
+
+  // Keyboard shortcuts for file list
+  const handleFileListKeyDown = (e) => {
+    const isCtrl = e.ctrlKey || e.metaKey;
+    if (e.key === 'Delete' || e.key === 'Del') {
+      e.preventDefault();
+      void handleDeleteItems();
+      return;
+    }
+    if (isCtrl && e.key === 'a') {
+      e.preventDefault();
+      setSelectedPaths(sortedItems.map(i => joinPath(currentPath, i.name)));
+      return;
+    }
+    if (isCtrl && e.key === 'c') {
+      e.preventDefault();
+      if (selectedPaths.length === 0) return;
+      setClipboard({ paths: [...selectedPaths], mode: 'copy', srcDir: currentPath });
+      addToast(t('已复制'), 'info');
+      return;
+    }
+    if (isCtrl && e.key === 'x') {
+      e.preventDefault();
+      if (selectedPaths.length === 0) return;
+      setClipboard({ paths: [...selectedPaths], mode: 'cut', srcDir: currentPath });
+      addToast(t('已剪切'), 'info');
+      return;
+    }
+    if (isCtrl && e.key === 'v') {
+      e.preventDefault();
+      if (!clipboard) return;
+      void handlePaste();
+      return;
+    }
+  };
+
+  const handlePaste = async () => {
+    if (!clipboard || clipboard.paths.length === 0) return;
+    if (clipboard.srcDir === currentPath && clipboard.mode === 'cut') {
+      addToast(t('源目录与目标目录相同，无需移动'), 'warning');
+      return;
+    }
+    let count = 0;
+    for (const srcPath of clipboard.paths) {
+      const name = srcPath.split('/').pop();
+      let destPath = joinPath(currentPath, name);
+      if (clipboard.mode === 'copy' && clipboard.srcDir === currentPath) {
+        const base = name.replace(/(\.[^.]+)$/, '');
+        const ext = name !== base ? name.slice(base.length) : '';
+        const existing = new Set(items.map(i => i.name));
+        let copyName = `${base}_copy${ext}`;
+        let idx = 1;
+        while (existing.has(copyName)) {
+          idx++;
+          copyName = `${base}_copy${idx}${ext}`;
+        }
+        destPath = joinPath(currentPath, copyName);
+      }
+      try {
+        if (clipboard.mode === 'copy') {
+          await AppGo.CopyItem(sessionId, srcPath, destPath);
+        } else {
+          await AppGo.MoveItem(sessionId, srcPath, destPath);
+        }
+        count++;
+      } catch (err) {
+        addToast(`${t('操作失败')}: ${name} - ${err}`, 'error');
+      }
+    }
+    if (count > 0) {
+      addToast(`${t('操作完成')}: ${count} ${t('项')}`, 'success');
+      if (clipboard.mode === 'cut') setClipboard(null);
+    }
+    await loadDir(currentPath);
+  };
+
   // Create directory
   const handleMkdir = async () => {
     const name = await window.luminDialog?.prompt(t('新文件夹名称:'));
@@ -2128,7 +2229,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       {/* Content area: file list + optional split editor */}
       <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         {/* File List */}
-        <div className="file-list" ref={fileListRef} style={{ flex: 1, minWidth: 0 }}>
+        <div className="file-list" ref={fileListRef} tabIndex={0} onKeyDown={handleFileListKeyDown} style={{ flex: 1, minWidth: 0 }}>
           <div className="file-list-header">
             <span onClick={() => handleSort('name')} style={{ cursor: 'pointer' }}>
               {t('名称')} {sortField === 'name' ? (sortDir === 'asc' ? '↑' : '↓') : ''}
@@ -2181,13 +2282,49 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
           {!loading && sortedItems.map((item) => {
             const isRenaming = renamingItem?.name === item.name;
+            const itemPath = joinPath(currentPath, item.name);
+            const isSelected = selectedPaths.includes(itemPath);
+
+            const handleItemClick = (e) => {
+              if (isRenaming) return;
+              // e.detail 为连击次数：1=单击，2=双击。双击时交由 onDoubleClick 处理，
+              // 这里直接跳过，避免双击先触发一次选中再触发操作的副作用。
+              if ((e.detail || 1) >= 2) return;
+              fileListRef.current?.focus();
+              if (e.ctrlKey || e.metaKey) {
+                setSelectedPaths(prev =>
+                  prev.includes(itemPath) ? prev.filter(p => p !== itemPath) : [...prev, itemPath]
+                );
+                lastClickedPathRef.current = itemPath;
+              } else if (e.shiftKey && lastClickedPathRef.current) {
+                const lastIdx = sortedItems.findIndex(i => joinPath(currentPath, i.name) === lastClickedPathRef.current);
+                const currentIdx = sortedItems.findIndex(i => i.name === item.name);
+                if (lastIdx >= 0 && currentIdx >= 0) {
+                  const start = Math.min(lastIdx, currentIdx);
+                  const end = Math.max(lastIdx, currentIdx);
+                  setSelectedPaths(sortedItems.slice(start, end + 1).map(i => joinPath(currentPath, i.name)));
+                }
+              } else {
+                setSelectedPaths([itemPath]);
+                lastClickedPathRef.current = itemPath;
+              }
+            };
 
             return (
               <div
                 key={item.name}
-                className="file-item"
-                onDoubleClick={() => item.isDirectory ? navigate(item) : isEditable(item.name) && handleEdit(item)}
-                onClick={() => item.isDirectory && navigate(item)}
+                className={`file-item${isSelected ? ' selected' : ''}`}
+                onClick={handleItemClick}
+                onDoubleClick={() => {
+                  // 双击打开/编辑前，把该项设为唯一选中，行为与单资源管理器一致。
+                  setSelectedPaths([itemPath]);
+                  lastClickedPathRef.current = itemPath;
+                  if (item.isDirectory) {
+                    navigate(item);
+                  } else if (isEditable(item.name)) {
+                    handleEdit(item);
+                  }
+                }}
                 onContextMenu={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -611,6 +611,10 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   const [contextMenu, setContextMenu] = useState(null); // { pos, item }
   const [selectedPaths, setSelectedPaths] = useState([]);
   const lastClickedPathRef = useRef(null);
+  useEffect(() => {
+    setSelectedPaths([]);
+    lastClickedPathRef.current = null;
+  }, [currentPath]);
   const [clipboard, setClipboard] = useState(null); // { paths: string[], mode: 'copy'|'cut', srcDir: string }
   const [renamingItem, setRenamingItem] = useState(null);
   const [renameValue, setRenameValue] = useState('');
@@ -1758,6 +1762,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
   // Keyboard shortcuts for file list
   const handleFileListKeyDown = (e) => {
+    if (renamingItem) return;
     const isCtrl = e.ctrlKey || e.metaKey;
     if (e.key === 'Delete' || e.key === 'Del') {
       e.preventDefault();
@@ -2297,6 +2302,8 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
                 );
                 lastClickedPathRef.current = itemPath;
               } else if (e.shiftKey && lastClickedPathRef.current) {
+                // Clear browser selection when shift-clicking to prevent text range highlighting
+                window.getSelection()?.removeAllRanges();
                 const lastIdx = sortedItems.findIndex(i => joinPath(currentPath, i.name) === lastClickedPathRef.current);
                 const currentIdx = sortedItems.findIndex(i => i.name === item.name);
                 if (lastIdx >= 0 && currentIdx >= 0) {

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -1722,6 +1722,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     try {
       await AppGo.DeleteItem(sessionId, remotePath, item.isDirectory);
+      setSelectedPaths(prev => prev.filter(p => p !== remotePath));
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');
@@ -1741,6 +1742,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     try {
       await AppGo.DeleteItemShell(sessionId, remotePath);
+      setSelectedPaths(prev => prev.filter(p => p !== remotePath));
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -1715,12 +1715,18 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   const handleDelete = async (item) => {
     const remotePath = joinPath(currentPath, item.name);
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
-    if (needConfirm && !(await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？${t('此操作不可撤销')}`))) return;
+    if (needConfirm) {
+      const ok = await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？${t('此操作不可撤销')}`);
+      fileListRef.current?.focus();
+      if (!ok) return;
+    }
     try {
       await AppGo.DeleteItem(sessionId, remotePath, item.isDirectory);
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');
+    } finally {
+      fileListRef.current?.focus();
     }
   };
 
@@ -1728,12 +1734,18 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   const handleDeleteShell = async (item) => {
     const remotePath = joinPath(currentPath, item.name);
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
-    if (needConfirm && !(await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？(rm -rf) ${t('此操作不可撤销')}`))) return;
+    if (needConfirm) {
+      const ok = await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？(rm -rf) ${t('此操作不可撤销')}`);
+      fileListRef.current?.focus();
+      if (!ok) return;
+    }
     try {
       await AppGo.DeleteItemShell(sessionId, remotePath);
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');
+    } finally {
+      fileListRef.current?.focus();
     }
   };
 
@@ -1742,7 +1754,11 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     if (selectedPaths.length === 0) return;
     const dirSet = new Set(items.filter(i => i.isDirectory).map(i => joinPath(currentPath, i.name)));
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
-    if (needConfirm && !(await window.luminDialog?.confirm(`${t('确定删除所选')} (${selectedPaths.length}${t('项')})？${t('此操作不可撤销')}`))) return;
+    if (needConfirm) {
+      const ok = await window.luminDialog?.confirm(`${t('确定删除所选')} (${selectedPaths.length}${t('项')})？${t('此操作不可撤销')}`);
+      fileListRef.current?.focus();
+      if (!ok) return;
+    }
     let successCount = 0;
     let failCount = 0;
     for (const path of selectedPaths) {
@@ -1758,6 +1774,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     if (failCount > 0) addToast(`${t('删除失败')}: ${failCount} ${t('项')}`, 'error');
     setSelectedPaths([]);
     await loadDir(currentPath);
+    fileListRef.current?.focus();
   };
 
   // Keyboard shortcuts for file list
@@ -1900,9 +1917,10 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     setRenameValue(item.name);
   };
 
-  const confirmRename = async () => {
+  const confirmRename = async (refocus = false) => {
     if (!renamingItem || !renameValue.trim() || renameValue === renamingItem.name) {
       setRenamingItem(null);
+      if (refocus) fileListRef.current?.focus();
       return;
     }
     const oldPath = joinPath(currentPath, renamingItem.name);
@@ -1915,6 +1933,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       addToast(`${t('重命名失败')}: ${err}`, 'error');
     } finally {
       setRenamingItem(null);
+      if (refocus) fileListRef.current?.focus();
     }
   };
 
@@ -2345,10 +2364,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
                       className="rename-input"
                       value={renameValue}
                       onChange={(e) => setRenameValue(e.target.value)}
-                      onBlur={confirmRename}
+                      onBlur={() => confirmRename(false)}
                       onKeyDown={(e) => {
-                        if (e.key === 'Enter') confirmRename();
-                        if (e.key === 'Escape') setRenamingItem(null);
+                        e.stopPropagation();
+                        if (e.key === 'Enter') confirmRename(true);
+                        if (e.key === 'Escape') {
+                          setRenamingItem(null);
+                          fileListRef.current?.focus();
+                        }
                       }}
                       autoFocus
                       onClick={(e) => e.stopPropagation()}

--- a/frontend/src/components/GlobalDialog.jsx
+++ b/frontend/src/components/GlobalDialog.jsx
@@ -122,6 +122,35 @@ function DialogContent({ current, onClose, onConfirm, onChoice }) {
   const isPasswordInput = current.inputType === 'password' || !!current.checkboxLabel;
   const isLongTextAlert = current.type === 'alert' && (messageText.includes('\n') || messageText.length > 160);
 
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'Enter') {
+        const tagName = document.activeElement?.tagName;
+        if (tagName === 'BUTTON' || tagName === 'TEXTAREA') {
+          return;
+        }
+        e.preventDefault();
+        if (current.type === 'prompt') {
+          onConfirm(inputValue, checked);
+        } else if (current.type === 'confirm') {
+          onConfirm(true, checked);
+        } else if (current.type === 'choice') {
+          const primaryBtn = current.buttons?.find(btn => btn.primary);
+          if (primaryBtn) {
+            onChoice(primaryBtn.value, checked);
+          }
+        } else {
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  }, [current, inputValue, checked, onClose, onConfirm, onChoice]);
+
   const handleCopyMessage = async () => {
     if (!messageText) {
       return;
@@ -219,10 +248,6 @@ function DialogContent({ current, onClose, onConfirm, onChoice }) {
               value={inputValue}
               onChange={e => setInputValue(e.target.value)}
               type={isPasswordInput && !showPassword ? 'password' : 'text'}
-              onKeyDown={e => {
-                if (e.key === 'Enter') onConfirm(inputValue, checked);
-                if (e.key === 'Escape') onClose();
-              }}
             />
             {isPasswordInput && (
               <Tiptop

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1868,6 +1868,8 @@ body.theme-light .batch-operation-bar {
   align-items: center;
 }
 .file-item:hover { background: var(--surface-hover); }
+.file-item.selected { background: color-mix(in srgb, var(--accent) 15%, var(--surface-base)); }
+.file-item.selected:hover { background: color-mix(in srgb, var(--accent) 22%, var(--surface-hover)); }
 .file-item:hover .file-actions { opacity: 1; }
 
 .file-name-cell { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1838,7 +1838,14 @@ body.theme-light .batch-operation-bar {
 }
 .path-input:focus { border-color: var(--border-focus); }
 
-.file-list { flex: 1; overflow-y: auto; overflow-x: auto; }
+.file-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: auto;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+}
 
 .file-list-header {
   display: grid;
@@ -2968,6 +2975,9 @@ body.theme-light .editor-field-shell.editor-field-shell-shine::after {
   font-family: inherit;
   outline: none;
   width: 100%;
+  user-select: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
 }
 
 /* ── 分割线 ─────────────────────────────────────────────────── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1877,6 +1877,12 @@ body.theme-light .batch-operation-bar {
 .file-item:hover { background: var(--surface-hover); }
 .file-item.selected { background: color-mix(in srgb, var(--accent) 15%, var(--surface-base)); }
 .file-item.selected:hover { background: color-mix(in srgb, var(--accent) 22%, var(--surface-hover)); }
+.file-list:not(:focus-within) .file-item.selected {
+  background: color-mix(in srgb, var(--text-tertiary) 8%, var(--surface-base));
+}
+.file-list:not(:focus-within) .file-item.selected:hover {
+  background: color-mix(in srgb, var(--text-tertiary) 12%, var(--surface-hover));
+}
 .file-item:hover .file-actions { opacity: 1; }
 
 .file-name-cell { display: flex; align-items: center; gap: var(--space-2); min-width: 0; }

--- a/mcp_bridge.go
+++ b/mcp_bridge.go
@@ -314,6 +314,20 @@ func (h mcpHost) DeleteItemContext(ctx context.Context, sessionID string, remote
 	return h.app.sshManager.DeleteItemContext(ctx, sessionID, remotePath, isDir)
 }
 
+func (h mcpHost) CopyItemContext(ctx context.Context, sessionID string, srcPath string, dstPath string) error {
+	if h.app == nil || h.app.sshManager == nil {
+		return fmt.Errorf("ssh manager unavailable")
+	}
+	return h.app.sshManager.CopyItemContext(ctx, sessionID, srcPath, dstPath)
+}
+
+func (h mcpHost) MoveItemContext(ctx context.Context, sessionID string, srcPath string, dstPath string) error {
+	if h.app == nil || h.app.sshManager == nil {
+		return fmt.Errorf("ssh manager unavailable")
+	}
+	return h.app.sshManager.MoveItemContext(ctx, sessionID, srcPath, dstPath)
+}
+
 func (h mcpHost) MkdirContext(ctx context.Context, sessionID string, remotePath string) error {
 	if h.app == nil || h.app.sshManager == nil {
 		return fmt.Errorf("ssh manager unavailable")

--- a/ssh.go
+++ b/ssh.go
@@ -2552,6 +2552,29 @@ func rmRfCmd(path string) string {
 	return "rm -rf " + shellQuotePath(path)
 }
 
+// remoteCmdLongTimeout 是文件复制/移动这类可能很耗时操作（大文件 cp/mv）的超时上限。
+// executeCmdWithClientContext 固定 30 秒，对大文件 cp 会过早超时，故这里使用更长上限。
+const remoteCmdLongTimeout = 30 * time.Minute
+
+// execRemoteCmdLong 在 sessionId 对应服务器上执行命令，使用长超时，
+// 适用于 cp/mv 等可能耗时较久的文件操作。返回命令的退出错误。
+func (m *SSHManager) execRemoteCmdLong(ctx context.Context, sessionId string, cmd string) error {
+	if err := ensureContextActive(ctx); err != nil {
+		return err
+	}
+	client, _, err := m.getClientEntry(sessionId)
+	if err != nil {
+		return err
+	}
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+	_, err = runCommandWithSessionContext(ctx, session, cmd, remoteCmdLongTimeout)
+	return err
+}
+
 func (m *SSHManager) DeleteItem(sessionId string, path string, isDir bool) error {
 	return m.DeleteItemContext(context.Background(), sessionId, path, isDir)
 }
@@ -2636,6 +2659,40 @@ func (m *SSHManager) RenameItemContext(ctx context.Context, sessionId string, ol
 		return err
 	}
 	return sftpClient.Rename(oldPath, newPath)
+}
+
+func (m *SSHManager) CopyItem(sessionId string, srcPath string, dstPath string) error {
+	return m.CopyItemContext(context.Background(), sessionId, srcPath, dstPath)
+}
+
+// CopyItemContext 在同一台服务器内复制文件或目录。
+// 直接在服务器上执行 cp -a：数据只在服务器本地磁盘流动，不走网络，
+// 远快于 SFTP 逐块读写。-a 保留权限/属主/时间戳，递归复制目录，并保留符号链接（不跟随）。
+func (m *SSHManager) CopyItemContext(ctx context.Context, sessionId string, srcPath string, dstPath string) error {
+	if err := ensureContextActive(ctx); err != nil {
+		return err
+	}
+	if isDangerousPath(srcPath) || isDangerousPath(dstPath) {
+		return fmt.Errorf("refusing to copy dangerous path")
+	}
+	return m.execRemoteCmdLong(ctx, sessionId, fmt.Sprintf("cp -a %s %s", shellQuotePath(srcPath), shellQuotePath(dstPath)))
+}
+
+func (m *SSHManager) MoveItem(sessionId string, srcPath string, dstPath string) error {
+	return m.MoveItemContext(context.Background(), sessionId, srcPath, dstPath)
+}
+
+// MoveItemContext 在同一台服务器内移动文件或目录。
+// 直接在服务器上执行 mv：同文件系统上仅改 inode 引用（瞬时），跨文件系统时
+// 由 mv 自动完成 cp + rm，数据只在服务器本地流动。
+func (m *SSHManager) MoveItemContext(ctx context.Context, sessionId string, srcPath string, dstPath string) error {
+	if err := ensureContextActive(ctx); err != nil {
+		return err
+	}
+	if isDangerousPath(srcPath) || isDangerousPath(dstPath) {
+		return fmt.Errorf("refusing to move dangerous path")
+	}
+	return m.execRemoteCmdLong(ctx, sessionId, fmt.Sprintf("mv %s %s", shellQuotePath(srcPath), shellQuotePath(dstPath)))
 }
 
 // progressReader wraps an io.Reader and emits progress events via Wails.


### PR DESCRIPTION
### 介绍 / Description
本 PR 实现了文件管理器的多选、复制、剪切、粘贴、删除功能，并优化了相关的键盘快捷键交互、全局弹窗焦点及按键交互体验。

### 主要改动 / Key Changes
1. **文件管理器核心功能**：
   - 实现了单击选中、双击打开/编辑。
   - 支持 `Shift` 范围多选、`Ctrl`/`Cmd` 单击多选、`Ctrl`/`Cmd + A` 全选。
   - 支持快捷键 `Delete`/`Del` 批量删除、`Ctrl`/`Cmd + C/X` 复制与剪切、`Ctrl`/`Cmd + V` 粘贴。
   - 同目录复制自动重命名（支持带后缀文件的递增命名，例如 `file_copy.txt`, `file_copy2.txt`）。
   - 后端新增 `CopyItem`/`MoveItem`，同服务器内复制/移动直接使用高效的 `cp -a` / `mv` 指令在服务器本地执行，避免不必要的网络流量，文件传输由分钟级降至亚秒级。
   - 命令执行带长超时（30 分钟），防止大文件复制被默认 30 秒超时切断。

2. **交互体验与边界缺陷修复 (UX & Bug Fixes)**：
   - **屏蔽重命名时的热键冲突**：在行内重命名文本框处于激活状态时，阻断全局快捷键，避免按 `Delete` 或 `Ctrl+A` 误删或全选文件列表。
   - **失焦选区变灰指示**：在 CSS 中通过 `:not(:focus-within)` 过滤，当文件管理器失去焦点（例如终端被点击或弹窗打开）时，被选中的行从蓝色背景自动变为淡灰色背景，提示用户当前焦点已离开。
   - **焦点自动跟随恢复**：在删除确认弹窗确定/取消、以及重命名成功/取消时，自动重新将焦点聚焦到文件列表容器，确保键盘快捷键（如方向键、复制粘贴等）立即可用，避免焦点丢失。
   - **清除失效选区**：切换路径时，以及单项/批量删除成功后，自动将对应失效路径移出 `selectedPaths`，防止残留导致后续操作出错。
   - **阻止文本块高亮**：在 shift 连选时禁止触发浏览器的默认文本框蓝色高亮，带来更原生的桌面文件管理器体验。

3. **全局弹窗快捷键支持 (Enter / Escape)**：
   - 在 `GlobalDialog.jsx` 中注册了全局捕获级键盘事件，在确认弹窗弹起时支持按 `Enter` 回车一键确认、`Escape` 一键取消（例如删除文件后可以直接敲回车确认删除）。
   - 自动规避了按钮激活聚焦和 `textarea` 输入时的 Enter 回车冲突，完全保留原生表单交互。
