### PR TITLE
优化文件管理器复制粘贴：跨终端共享剪贴板、覆盖确认、操作进度遮罩

### DIFF
--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -618,6 +618,8 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   }, [currentPath]);
   const [clipboard, setClipboard] = useState(null); // { paths: string[], mode: 'copy'|'cut', srcDir: string }
   const [operationProgress, setOperationProgress] = useState(null);
+  // 并发互斥闸门：用 ref 在同步阶段立即生效，避免两个快速事件都读到 stale 的 state 而双双放行
+  const operationInProgressRef = useRef(false);
 
   const updateClipboard = (newClipboard) => {
     if (!window.__luminClipboards) {
@@ -647,6 +649,15 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     window.addEventListener('lumin-clipboard-changed', handleClipboardChange);
     return () => {
       window.removeEventListener('lumin-clipboard-changed', handleClipboardChange);
+    };
+  }, [sessionGroupId]);
+
+  // 卸载或切换 sessionGroup 时清理全局剪贴板缓存，防止内存泄漏与 sessionGroupId 复用时复活幽灵剪贴板
+  useEffect(() => {
+    return () => {
+      if (window.__luminClipboards) {
+        delete window.__luminClipboards[sessionGroupId];
+      }
     };
   }, [sessionGroupId]);
 
@@ -1761,12 +1772,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
   // Delete
   const handleDelete = async (item) => {
+    if (operationInProgressRef.current) return;
+    operationInProgressRef.current = true;
     const remotePath = joinPath(currentPath, item.name);
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
     if (needConfirm) {
       const ok = await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？${t('此操作不可撤销')}`);
       fileListRef.current?.focus();
-      if (!ok) return;
+      if (!ok) { operationInProgressRef.current = false; return; }
     }
     try {
       setOperationProgress({ message: `${t('正在删除')} ${item.name}` });
@@ -1777,18 +1790,21 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       addToast(`${t('删除失败')}: ${err}`, 'error');
     } finally {
       setOperationProgress(null);
+      operationInProgressRef.current = false;
       fileListRef.current?.focus();
     }
   };
 
   // Delete via rm -rf
   const handleDeleteShell = async (item) => {
+    if (operationInProgressRef.current) return;
+    operationInProgressRef.current = true;
     const remotePath = joinPath(currentPath, item.name);
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
     if (needConfirm) {
       const ok = await window.luminDialog?.confirm(`${t('确定删除')}${item.name}？(rm -rf) ${t('此操作不可撤销')}`);
       fileListRef.current?.focus();
-      if (!ok) return;
+      if (!ok) { operationInProgressRef.current = false; return; }
     }
     try {
       setOperationProgress({ message: `${t('正在删除')} ${item.name}` });
@@ -1799,19 +1815,22 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       addToast(`${t('删除失败')}: ${err}`, 'error');
     } finally {
       setOperationProgress(null);
+      operationInProgressRef.current = false;
       fileListRef.current?.focus();
     }
   };
 
   // Delete multiple selected items
   const handleDeleteItems = async () => {
+    if (operationInProgressRef.current) return;
     if (selectedPaths.length === 0) return;
+    operationInProgressRef.current = true;
     const dirSet = new Set(items.filter(i => i.isDirectory).map(i => joinPath(currentPath, i.name)));
     const needConfirm = localStorage.getItem('skipFileDeleteConfirm') !== 'true';
     if (needConfirm) {
       const ok = await window.luminDialog?.confirm(`${t('确定删除所选')} (${selectedPaths.length}${t('项')})？${t('此操作不可撤销')}`);
       fileListRef.current?.focus();
-      if (!ok) return;
+      if (!ok) { operationInProgressRef.current = false; return; }
     }
     let successCount = 0;
     let failCount = 0;
@@ -1821,7 +1840,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       for (let i = 0; i < total; i++) {
         const path = selectedPaths[i];
         const name = path.split('/').pop();
-        setOperationProgress({ message: `${t('正在删除')} ${name}`, current: i, total });
+        setOperationProgress({ message: `${t('正在删除')} ${name}`, current: i + 1, total });
         try {
           await AppGo.DeleteItem(sessionId, path, dirSet.has(path));
           successCount++;
@@ -1832,6 +1851,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       }
     } finally {
       setOperationProgress(null);
+      operationInProgressRef.current = false;
     }
     if (successCount > 0) addToast(`${t('已删除')} ${successCount} ${t('项')}`, 'success');
     if (failCount > 0) addToast(`${t('删除失败')}: ${failCount} ${t('项')}`, 'error');
@@ -1842,6 +1862,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
   // Keyboard shortcuts for file list
   const handleFileListKeyDown = (e) => {
+    if (operationInProgressRef.current) return;
     if (renamingItem) return;
     const isCtrl = e.ctrlKey || e.metaKey;
     if (e.key === 'Delete' || e.key === 'Del') {
@@ -1877,12 +1898,15 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   };
 
   const handlePaste = async () => {
+    if (operationInProgressRef.current) return;
     if (!clipboard || clipboard.paths.length === 0) return;
     if (clipboard.srcDir === currentPath && clipboard.mode === 'cut') {
       addToast(t('源目录与目标目录相同，无需移动'), 'warning');
       return;
     }
+    operationInProgressRef.current = true;
     let count = 0;
+    // 注意：existing 在循环内会被更新，反映本次粘贴已产生的文件名，避免同批同名互覆盖
     const existing = new Set(items.map(i => i.name));
     const total = clipboard.paths.length;
     setOperationProgress({ message: t('正在粘贴中...'), current: 0, total });
@@ -1890,12 +1914,8 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       for (let i = 0; i < total; i++) {
         const srcPath = clipboard.paths[i];
         const name = srcPath.split('/').pop();
-        setOperationProgress({
-          message: `${clipboard.mode === 'copy' ? t('正在复制') : t('正在移动')} ${name}`,
-          current: i,
-          total
-        });
         let destPath = joinPath(currentPath, name);
+        let destName = name;
         if (clipboard.mode === 'copy' && clipboard.srcDir === currentPath) {
           const base = name.replace(/(\.[^.]+)$/, '');
           const ext = name !== base ? name.slice(base.length) : '';
@@ -1905,21 +1925,36 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
             idx++;
             copyName = `${base}_copy${idx}${ext}`;
           }
+          destName = copyName;
           destPath = joinPath(currentPath, copyName);
         } else {
           if (existing.has(name)) {
-            const ok = await window.luminDialog?.confirm(
+            // 确认对话框缺失时显式报错并跳过，避免静默吞掉覆盖操作
+            if (typeof window.luminDialog?.confirm !== 'function') {
+              addToast(`${t('无法确认覆盖操作，已跳过')} ${name}`, 'error');
+              continue;
+            }
+            const ok = await window.luminDialog.confirm(
               `${t('目标已存在同名项目')} "${name}"，${t('是否覆盖？')}`
             );
             if (!ok) continue;
           }
         }
+
+        // Only update progress and show the copy/move text after confirmation passes
+        setOperationProgress({
+          message: `${clipboard.mode === 'copy' ? t('正在复制') : t('正在移动')} ${name}`,
+          current: i + 1,
+          total
+        });
         try {
           if (clipboard.mode === 'copy') {
             await AppGo.CopyItem(sessionId, srcPath, destPath);
           } else {
             await AppGo.MoveItem(sessionId, srcPath, destPath);
           }
+          // 把刚产生的目标名加入 existing，让同批后续迭代可见
+          existing.add(destName);
           count++;
         } catch (err) {
           addToast(`${t('操作失败')}: ${name} - ${err}`, 'error');
@@ -1927,10 +1962,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       }
     } finally {
       setOperationProgress(null);
+      operationInProgressRef.current = false;
     }
     if (count > 0) {
       addToast(`${t('操作完成')}: ${count} ${t('项')}`, 'success');
-      if (clipboard.mode === 'cut') updateClipboard(null);
+      // cut 成功移动后清空剪贴板，避免对已移动的源再次粘贴（标准文件管理器行为）
+      if (clipboard.mode === 'cut') {
+        updateClipboard(null);
+      }
     }
     await loadDir(currentPath);
   };
@@ -2257,7 +2296,13 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
               <button
                 className="btn file-toolbar-outline-btn"
                 aria-label={t('粘贴')}
-                onClick={() => void handlePaste()}
+                onClick={() => {
+                  if (operationInProgressRef.current) {
+                    addToast(t('有操作正在进行，请稍候'), 'warning');
+                  } else {
+                    void handlePaste();
+                  }
+                }}
               >
                 <ClipboardPaste size={14} />
               </button>
@@ -2394,6 +2439,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
               }}
               onClick={(e) => {
                 if ((e.detail || 1) >= 2) return;
+                setSelectedPaths([]);
                 fileListRef.current?.focus();
               }}
             >
@@ -2534,7 +2580,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
                       className="btn btn-ghost btn-sm btn-icon"
                       aria-label={t('删除')}
                       style={{ color: 'var(--danger)' }}
-                      onClick={(e) => { e.stopPropagation(); handleDelete(item); }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (operationInProgressRef.current) {
+                          addToast(t('有操作正在进行，请稍候'), 'warning');
+                        } else {
+                          handleDelete(item);
+                        }
+                      }}
                     ><Trash2 size={14} /></button>
                   </Tiptop>
                 </div>
@@ -2564,8 +2617,22 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
           onEdit={() => { handleEdit(contextMenu.item); closeContextMenu(); }}
           onRename={() => { startRename(contextMenu.item); closeContextMenu(); }}
           onChmod={() => { void handleChmod(contextMenu.item); closeContextMenu(); }}
-          onDelete={() => { handleDelete(contextMenu.item); closeContextMenu(); }}
-          onDeleteShell={() => { handleDeleteShell(contextMenu.item); closeContextMenu(); }}
+          onDelete={() => {
+            if (operationInProgressRef.current) {
+              addToast(t('有操作正在进行，请稍候'), 'warning');
+            } else {
+              handleDelete(contextMenu.item);
+            }
+            closeContextMenu();
+          }}
+          onDeleteShell={() => {
+            if (operationInProgressRef.current) {
+              addToast(t('有操作正在进行，请稍候'), 'warning');
+            } else {
+              handleDeleteShell(contextMenu.item);
+            }
+            closeContextMenu();
+          }}
           onMkdir={() => { handleMkdir(); closeContextMenu(); }}
           onNewFile={() => { handleNewFile(); closeContextMenu(); }}
           onCompress={() => { handleCompress(contextMenu.item); closeContextMenu(); }}

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -2299,9 +2299,13 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
           {currentPath !== '/' && (
             <div
               className="file-item"
-              onClick={() => {
+              onDoubleClick={() => {
                 const parent = currentPath.substring(0, currentPath.lastIndexOf('/')) || '/';
                 loadDir(parent);
+              }}
+              onClick={(e) => {
+                if ((e.detail || 1) >= 2) return;
+                fileListRef.current?.focus();
               }}
             >
               <div className="file-name-cell">

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -13,6 +13,7 @@ import {
   FileArchive, Settings, ClipboardList, Wrench, Image, Code, Globe,
   Palette, Database, Terminal, Film, Music, Archive, HardDrive, BookOpen,
   Pencil, PenLine, Download, Upload, Trash2, RefreshCw, Lock, FolderUp, SquarePen, Copy,
+  X, ClipboardPaste,
 } from 'lucide-react';
 
 // 格式化文件大小
@@ -616,6 +617,38 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     lastClickedPathRef.current = null;
   }, [currentPath]);
   const [clipboard, setClipboard] = useState(null); // { paths: string[], mode: 'copy'|'cut', srcDir: string }
+
+  const updateClipboard = (newClipboard) => {
+    if (!window.__luminClipboards) {
+      window.__luminClipboards = {};
+    }
+    if (newClipboard) {
+      window.__luminClipboards[sessionGroupId] = newClipboard;
+    } else {
+      delete window.__luminClipboards[sessionGroupId];
+    }
+    setClipboard(newClipboard);
+    window.dispatchEvent(new CustomEvent('lumin-clipboard-changed', {
+      detail: { sessionGroupId, clipboard: newClipboard }
+    }));
+  };
+
+  useEffect(() => {
+    const cached = (window.__luminClipboards && window.__luminClipboards[sessionGroupId]) || null;
+    setClipboard(cached);
+
+    const handleClipboardChange = (e) => {
+      if (e.detail && e.detail.sessionGroupId === sessionGroupId) {
+        setClipboard(e.detail.clipboard);
+      }
+    };
+
+    window.addEventListener('lumin-clipboard-changed', handleClipboardChange);
+    return () => {
+      window.removeEventListener('lumin-clipboard-changed', handleClipboardChange);
+    };
+  }, [sessionGroupId]);
+
   const [renamingItem, setRenamingItem] = useState(null);
   const [renameValue, setRenameValue] = useState('');
   const [chmodTarget, setChmodTarget] = useState(null); // { item, path, mode, includeSubdirectories, showIncludeSubdirectories }
@@ -1810,14 +1843,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     if (isCtrl && e.key === 'c') {
       e.preventDefault();
       if (selectedPaths.length === 0) return;
-      setClipboard({ paths: [...selectedPaths], mode: 'copy', srcDir: currentPath });
+      updateClipboard({ paths: [...selectedPaths], mode: 'copy', srcDir: currentPath });
       addToast(t('已复制'), 'info');
       return;
     }
     if (isCtrl && e.key === 'x') {
       e.preventDefault();
       if (selectedPaths.length === 0) return;
-      setClipboard({ paths: [...selectedPaths], mode: 'cut', srcDir: currentPath });
+      updateClipboard({ paths: [...selectedPaths], mode: 'cut', srcDir: currentPath });
       addToast(t('已剪切'), 'info');
       return;
     }
@@ -1836,13 +1869,13 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       return;
     }
     let count = 0;
+    const existing = new Set(items.map(i => i.name));
     for (const srcPath of clipboard.paths) {
       const name = srcPath.split('/').pop();
       let destPath = joinPath(currentPath, name);
       if (clipboard.mode === 'copy' && clipboard.srcDir === currentPath) {
         const base = name.replace(/(\.[^.]+)$/, '');
         const ext = name !== base ? name.slice(base.length) : '';
-        const existing = new Set(items.map(i => i.name));
         let copyName = `${base}_copy${ext}`;
         let idx = 1;
         while (existing.has(copyName)) {
@@ -1850,6 +1883,13 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
           copyName = `${base}_copy${idx}${ext}`;
         }
         destPath = joinPath(currentPath, copyName);
+      } else {
+        if (existing.has(name)) {
+          const ok = await window.luminDialog?.confirm(
+            `${t('目标已存在同名项目')} "${name}"，${t('是否覆盖？')}`
+          );
+          if (!ok) continue;
+        }
       }
       try {
         if (clipboard.mode === 'copy') {
@@ -1864,7 +1904,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     if (count > 0) {
       addToast(`${t('操作完成')}: ${count} ${t('项')}`, 'success');
-      if (clipboard.mode === 'cut') setClipboard(null);
+      if (clipboard.mode === 'cut') updateClipboard(null);
     }
     await loadDir(currentPath);
   };
@@ -2184,6 +2224,29 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
           }}
           style={{ flex: 1, minWidth: 0 }}
         />
+
+        {clipboard && (
+          <>
+            <Tiptop text={t('粘贴')} placement="bottom">
+              <button
+                className="btn file-toolbar-outline-btn"
+                aria-label={t('粘贴')}
+                onClick={() => void handlePaste()}
+              >
+                <ClipboardPaste size={14} />
+              </button>
+            </Tiptop>
+            <Tiptop text={t('取消')} placement="bottom">
+              <button
+                className="btn file-toolbar-outline-btn"
+                aria-label={t('取消')}
+                onClick={() => updateClipboard(null)}
+              >
+                <X size={14} />
+              </button>
+            </Tiptop>
+          </>
+        )}
 
         <div className="file-toolbar-actions">
           <Tiptop text={t('新建文件')} placement="bottom">

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -617,6 +617,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     lastClickedPathRef.current = null;
   }, [currentPath]);
   const [clipboard, setClipboard] = useState(null); // { paths: string[], mode: 'copy'|'cut', srcDir: string }
+  const [operationProgress, setOperationProgress] = useState(null);
 
   const updateClipboard = (newClipboard) => {
     if (!window.__luminClipboards) {
@@ -1768,12 +1769,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       if (!ok) return;
     }
     try {
+      setOperationProgress({ message: `${t('正在删除')} ${item.name}` });
       await AppGo.DeleteItem(sessionId, remotePath, item.isDirectory);
       setSelectedPaths(prev => prev.filter(p => p !== remotePath));
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');
     } finally {
+      setOperationProgress(null);
       fileListRef.current?.focus();
     }
   };
@@ -1788,12 +1791,14 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
       if (!ok) return;
     }
     try {
+      setOperationProgress({ message: `${t('正在删除')} ${item.name}` });
       await AppGo.DeleteItemShell(sessionId, remotePath);
       setSelectedPaths(prev => prev.filter(p => p !== remotePath));
       await loadDir(currentPath);
     } catch (err) {
       addToast(`${t('删除失败')}: ${err}`, 'error');
     } finally {
+      setOperationProgress(null);
       fileListRef.current?.focus();
     }
   };
@@ -1810,14 +1815,23 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     let successCount = 0;
     let failCount = 0;
-    for (const path of selectedPaths) {
-      try {
-        await AppGo.DeleteItem(sessionId, path, dirSet.has(path));
-        successCount++;
-      } catch (err) {
-        failCount++;
-        console.error('delete item failed:', path, err);
+    const total = selectedPaths.length;
+    setOperationProgress({ message: t('正在删除中...'), current: 0, total });
+    try {
+      for (let i = 0; i < total; i++) {
+        const path = selectedPaths[i];
+        const name = path.split('/').pop();
+        setOperationProgress({ message: `${t('正在删除')} ${name}`, current: i, total });
+        try {
+          await AppGo.DeleteItem(sessionId, path, dirSet.has(path));
+          successCount++;
+        } catch (err) {
+          failCount++;
+          console.error('delete item failed:', path, err);
+        }
       }
+    } finally {
+      setOperationProgress(null);
     }
     if (successCount > 0) addToast(`${t('已删除')} ${successCount} ${t('项')}`, 'success');
     if (failCount > 0) addToast(`${t('删除失败')}: ${failCount} ${t('项')}`, 'error');
@@ -1870,37 +1884,49 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     let count = 0;
     const existing = new Set(items.map(i => i.name));
-    for (const srcPath of clipboard.paths) {
-      const name = srcPath.split('/').pop();
-      let destPath = joinPath(currentPath, name);
-      if (clipboard.mode === 'copy' && clipboard.srcDir === currentPath) {
-        const base = name.replace(/(\.[^.]+)$/, '');
-        const ext = name !== base ? name.slice(base.length) : '';
-        let copyName = `${base}_copy${ext}`;
-        let idx = 1;
-        while (existing.has(copyName)) {
-          idx++;
-          copyName = `${base}_copy${idx}${ext}`;
-        }
-        destPath = joinPath(currentPath, copyName);
-      } else {
-        if (existing.has(name)) {
-          const ok = await window.luminDialog?.confirm(
-            `${t('目标已存在同名项目')} "${name}"，${t('是否覆盖？')}`
-          );
-          if (!ok) continue;
-        }
-      }
-      try {
-        if (clipboard.mode === 'copy') {
-          await AppGo.CopyItem(sessionId, srcPath, destPath);
+    const total = clipboard.paths.length;
+    setOperationProgress({ message: t('正在粘贴中...'), current: 0, total });
+    try {
+      for (let i = 0; i < total; i++) {
+        const srcPath = clipboard.paths[i];
+        const name = srcPath.split('/').pop();
+        setOperationProgress({
+          message: `${clipboard.mode === 'copy' ? t('正在复制') : t('正在移动')} ${name}`,
+          current: i,
+          total
+        });
+        let destPath = joinPath(currentPath, name);
+        if (clipboard.mode === 'copy' && clipboard.srcDir === currentPath) {
+          const base = name.replace(/(\.[^.]+)$/, '');
+          const ext = name !== base ? name.slice(base.length) : '';
+          let copyName = `${base}_copy${ext}`;
+          let idx = 1;
+          while (existing.has(copyName)) {
+            idx++;
+            copyName = `${base}_copy${idx}${ext}`;
+          }
+          destPath = joinPath(currentPath, copyName);
         } else {
-          await AppGo.MoveItem(sessionId, srcPath, destPath);
+          if (existing.has(name)) {
+            const ok = await window.luminDialog?.confirm(
+              `${t('目标已存在同名项目')} "${name}"，${t('是否覆盖？')}`
+            );
+            if (!ok) continue;
+          }
         }
-        count++;
-      } catch (err) {
-        addToast(`${t('操作失败')}: ${name} - ${err}`, 'error');
+        try {
+          if (clipboard.mode === 'copy') {
+            await AppGo.CopyItem(sessionId, srcPath, destPath);
+          } else {
+            await AppGo.MoveItem(sessionId, srcPath, destPath);
+          }
+          count++;
+        } catch (err) {
+          addToast(`${t('操作失败')}: ${name} - ${err}`, 'error');
+        }
       }
+    } finally {
+      setOperationProgress(null);
     }
     if (count > 0) {
       addToast(`${t('操作完成')}: ${count} ${t('项')}`, 'success');
@@ -2593,6 +2619,35 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
           onClose={() => setChmodTarget(null)}
           t={t}
         />
+      )}
+
+      {/* Operation Progress Overlay */}
+      {operationProgress && (
+        <div className="file-operation-overlay">
+          <div className="file-operation-card">
+            <div className="file-operation-title">
+              {operationProgress.message}
+            </div>
+            {operationProgress.total > 0 ? (
+              <>
+                <div className="file-operation-progress-container">
+                  <div
+                    className="file-operation-progress-bar"
+                    style={{ width: `${(operationProgress.current / operationProgress.total) * 100}%` }}
+                  />
+                </div>
+                <div className="file-operation-details">
+                  <span>{Math.round((operationProgress.current / operationProgress.total) * 100)}%</span>
+                  <span>{operationProgress.current} / {operationProgress.total}</span>
+                </div>
+              </>
+            ) : (
+              <div className="file-operation-spinner">
+                <RefreshCw className="spin" size={20} />
+              </div>
+            )}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3787,3 +3787,55 @@ body.theme-light .dashboard-server-editor {
   color: var(--text-primary);
   border-color: var(--border-focus);
 }
+
+.file-operation-overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.file-operation-card {
+  background: var(--surface-overlay);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  width: 320px;
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.file-operation-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+.file-operation-progress-container {
+  width: 100%;
+  background: var(--surface-sunken);
+  border-radius: var(--radius-sm);
+  height: 6px;
+  overflow: hidden;
+}
+.file-operation-progress-bar {
+  background: var(--accent);
+  height: 100%;
+  transition: width 0.15s ease-out;
+}
+.file-operation-details {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+.file-operation-spinner {
+  display: flex;
+  justify-content: center;
+  color: var(--accent);
+}
+


### PR DESCRIPTION
## 背景

优化文件管理器的复制/粘贴体验，主要解决以下痛点：

- 同一台服务器的多个终端标签之间无法共享剪贴板（每个标签各自独立，复制后切换标签就丢了）
- cut 粘贴遇到同名目标时会直接覆盖，没有确认，存在误操作风险
- 批量删除 / 粘贴大文件时没有任何进度反馈，看起来像卡住

## 改动内容

### 1. 父目录项改为双击进入
单击 \`..\` 仅清空选中并聚焦文件列表，双击才进入上级目录，避免误触跳转。

### 2. 跨终端剪贴板共享 + 粘贴/取消按钮 + 覆盖确认
- 通过 \`window.__luminClipboards\` 按 \`sessionGroupId\` 维护剪贴板，配合 \`lumin-clipboard-changed\` 自定义事件，实现同一服务器多个终端标签之间的剪贴板共享
- \`sessionGroupId\` 变化时重新水合对应剪贴板状态
- 路径工具栏新增「粘贴」与「取消」图标按钮
- cut/copy 粘贴遇到同名目标时弹出确认框，确认后才覆盖

### 3. 删除与粘贴操作新增进度遮罩
- 引入 \`operationProgress\` 状态，删除/粘贴过程中显示进度遮罩
- 批量删除与粘贴显示进度条与百分比，单项操作显示旋转指示
- 确认覆盖后再切换进度文案，避免确认期间文案先跳变

### 4. 加固剪贴板操作的并发与健壮性
- 用 ref 替代 React state 作为并发守卫，避免快速连按触发多个删除/粘贴循环并发执行
- 覆盖确认对话框未就绪时显式报错并跳过，不再静默吞掉覆盖操作
- sessionGroup 卸载或切换时清理 \`window.__luminClipboards\` 缓存，防止内存泄漏与幽灵剪贴板
- 粘贴循环内同步更新已存在文件名集合，避免同批同名文件相互覆盖
- 简化 cut 模式粘贴后的剪贴板清空逻辑
- 操作进行中点击删除/粘贴入口时给出提示，而非静默无反馈

## 涉及文件
- \`frontend/src/components/FileManager.jsx\`
- \`frontend/src/index.css\`（仅新增进度遮罩样式）

## 测试
手动测试了复制/剪切/粘贴（同目录、跨目录、跨终端标签）、同名覆盖确认、批量删除进度、取消剪贴板等功能，均正常。前端构建通过。

> 注：本 PR 仅包含功能代码，未含设计文档。