### PR TITLE
fix: 修复 StrictMode 下 mountedRef 失效导致按钮转圈与消息提示不消失

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1296,7 +1296,13 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
   const pingTimerRef = useRef(null);
   const pingInFlightRef = useRef(false);
   const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  // 在 mount 时显式重置为 true：React StrictMode（仅 dev）会先 mount→unmount→再 mount，
+  // 但 useRef 初始化只执行一次，第二次 mount 时不会重新赋值，导致 mountedRef 残留为 false，
+  // 进而让依赖它的异步回调（如新建终端的 loading 清除）在 dev 下失效。
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   // ── 新增主页仪表盘状态 ──────────────────────────────────
   const [isRefreshingPing, setIsRefreshingPing] = useState(false);


### PR DESCRIPTION
## 问题

仅在 \`wails dev\`（React StrictMode 激活）下出现，打包运行正常：

1. **新建终端按钮一直转圈**：点击右上角「新建终端」创建一个终端后，按钮一直处于 loading 状态，无法再次点击。终端本身能创建成功，只是按钮没有复位。
2. **消息提示（toast）消失不掉**：操作后弹出的消息提示永久挂在屏幕上，不会自动消失。

## 根因

\`App\` 组件的 \`mountedRef\` 此前的 effect 只有 unmount 时的 cleanup，缺少 mount 时的重置：

```js
// 修改前
const mountedRef = useRef(true);
useEffect(() => () => { mountedRef.current = false; }, []);
```

React StrictMode 会执行 mount → unmount → 再 mount 的模拟卸载周期，而 \`useRef(true)\` 的初始化**只在首次创建时执行一次**，第二次 mount 时不会重新赋值。导致 \`mountedRef.current\` 在 StrictMode 重新挂载后残留为 \`false\`，并且再也不会变回 \`true\`。

这会让所有依赖 \`mountedRef\` 守卫的异步回调在 dev 下永久短路：

- **新建终端按钮**（\`App.jsx\`）：\`openNewTerminal\` 的 \`finally\` 里 \`if (mountedRef.current) setCreatingTerminalSessionId(null)\` 被拦截，loading 永不清除。
- **消息提示**（\`App.jsx\`）：\`addToast\` 的自动消失定时器和退出动画定时器里的 \`removeToast\` / \`removeToastImmediately\` 被同样拦截，toast 永久挂在屏幕上。

由于生产构建不带 StrictMode 的双调用，\`mountedRef.current\` 保持 \`true\`，所以打包运行一切正常——这也是为什么问题只在 \`wails dev\` 出现。

## 修复

在 effect 的 mount 阶段显式重置 \`mountedRef.current = true\`：

```js
// 修改后
const mountedRef = useRef(true);
useEffect(() => {
  mountedRef.current = true;
  return () => { mountedRef.current = false; };
}, []);
```

这与代码库中其他组件（\`FileManager\` / \`CommandHistory\` / \`NetworkPage\` / \`ProcessPage\` / \`QuickCommands\`）已有的正确写法保持一致——它们都在 mount 时重置了 \`mountedRef\`，唯独 \`App\` 漏了这一步。

## 涉及文件
- \`frontend/src/App.jsx\`（仅 1 处 effect 改动）

## 测试
在 \`wails dev\` 下验证：
- ✅ 新建终端按钮创建终端后能正常复位，可再次点击
- ✅ 消息提示能正常自动消失

两个问题均已修复。