### PR TITLE
style/feat: 修复搜索框焦点裁剪与合并分组折叠按钮

### DIFF
--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -189,7 +189,7 @@ export default function Dashboard({
                   }}
                   style={{ height: 30, padding: '0 10px', fontSize: 12, border: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 6 }}
                 >
-                  {allCollapsed ? <FolderOpen size={14} /> : <Folder size={14} />}
+                  {allCollapsed ? <Folder size={14} /> : <FolderOpen size={14} />}
                   <span>{allCollapsed ? t('打开分组') : t('收起分组')}</span>
                 </button>
               )}

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { BarChart3, Monitor, Search, LayoutGrid, List, Eye, EyeOff, RefreshCw, Database, CheckSquare, Folder, Copy, Download, Trash2, X, Plus } from 'lucide-react';
+import { BarChart3, Monitor, Search, LayoutGrid, List, Eye, EyeOff, RefreshCw, Database, CheckSquare, Folder, FolderOpen, Copy, Download, Trash2, X, Plus } from 'lucide-react';
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { useTranslation } from '../i18n.js';
 import AddServerModal from './AddServerModal.jsx';
@@ -63,6 +63,11 @@ export default function Dashboard({
     return Array.from(groups);
   }, [filteredServers]);
   const hasVisibleGroupHeaders = visibleGroupNames.length > 1 || (visibleGroupNames.length === 1 && visibleGroupNames[0] !== '');
+
+  const allCollapsed = useMemo(() => {
+    if (visibleGroupNames.length === 0) return false;
+    return visibleGroupNames.every(name => collapsedGroups.has(name));
+  }, [visibleGroupNames, collapsedGroups]);
 
   return (
     <div className="dashboard-container">
@@ -173,22 +178,20 @@ export default function Dashboard({
                 </button>
               </Tiptop>
               {hasVisibleGroupHeaders && (
-                <>
-                  <button
-                    className="btn btn-ghost"
-                    onClick={() => setCollapsedGroups(new Set(visibleGroupNames))}
-                    style={{ height: 30, padding: '0 10px', fontSize: 12, border: '1px solid var(--border)' }}
-                  >
-                    {t('收起分组')}
-                  </button>
-                  <button
-                    className="btn btn-ghost"
-                    onClick={() => setCollapsedGroups(new Set())}
-                    style={{ height: 30, padding: '0 10px', fontSize: 12, border: '1px solid var(--border)' }}
-                  >
-                    {t('打开分组')}
-                  </button>
-                </>
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => {
+                    if (allCollapsed) {
+                      setCollapsedGroups(new Set());
+                    } else {
+                      setCollapsedGroups(new Set(visibleGroupNames));
+                    }
+                  }}
+                  style={{ height: 30, padding: '0 10px', fontSize: 12, border: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 6 }}
+                >
+                  {allCollapsed ? <FolderOpen size={14} /> : <Folder size={14} />}
+                  <span>{allCollapsed ? t('打开分组') : t('收起分组')}</span>
+                </button>
               )}
               {/* 数据管理（导入/导出） */}
               <Tiptop text={t('数据管理')} placement="bottom">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3397,7 +3397,25 @@ body.theme-light .dashboard-server-editor {
 .stat-lbl { font-size: var(--text-xs); color: var(--text-tertiary); margin-top: 1px; }
 
 /* 主机区域 */
-.section-title-container { display: flex; align-items: center; gap: var(--space-2); margin-bottom: 0; }
+.section-title-container { 
+  display: flex; 
+  align-items: center; 
+  gap: var(--space-2); 
+  margin-bottom: 0; 
+  padding-top: 4px; 
+  padding-bottom: 4px; 
+}
+
+.input-compact {
+  outline: none;
+  transition: var(--transition-fast) !important;
+}
+
+.input-compact:focus {
+  border-color: var(--border-focus) !important;
+  box-shadow: 0 0 0 2px var(--accent-dim) !important;
+  outline: none;
+}
 .section-title-icon { font-size: var(--text-md); display: flex; align-items: center; color: var(--text-secondary); }
 .section-title { font-size: var(--text-sm); font-weight: 650; color: var(--text-primary); }
 


### PR DESCRIPTION
### 变更说明
本 PR 包含以下两项 UI 与交互方面的优化：

1. **修复主机搜索框焦点裁剪问题 (CSS)**:
   - 在 `.section-title-container` 中添加了上下各 4px 的内边距，确保处于最上方的搜索框在获得焦点时，外围蓝色的 focus-ring/shadow 不会被容器裁剪。
   - 为 `.input-compact` 自定义了 focus 状态下的边框颜色和 `box-shadow` 阴影环，代替了浏览器默认的 outline 焦点圈，整体视觉更加精致美观。

2. **合并分组折叠/展开按钮为单个智能切换按钮**:
   - 在 `Dashboard.jsx` 中新增了 `allCollapsed` 的状态计算。
   - 将原本分立的 "收起分组" 和 "打开分组" 按钮合并为一个按钮。
   - 该按钮会智能根据当前是否所有分组均已折叠来自动切换文本（“收起分组” / “展开分组”）和对应的文件夹图标（展开/收起）。
   - 文件夹图标状态与实际折叠状态保持一致。
