### PR TITLE
fix: 理顺 UI 叠层层级，避免终端与命令区盖住文件编辑器

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6332,7 +6332,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
       {/* ── 云端同步失败弹窗 ──────────────────────────── */}
       {syncFailed && (
         <div style={{
-          position: 'fixed', bottom: 24, right: 24, zIndex: 1100,
+          position: 'fixed', bottom: 24, right: 24, zIndex: Z.TOAST,
           width: 380, background: 'var(--surface-raised)',
           border: '1px solid var(--border)',
           boxShadow: 'var(--shadow-md)',

--- a/frontend/src/components/FileEditor.jsx
+++ b/frontend/src/components/FileEditor.jsx
@@ -811,12 +811,14 @@ export default function FileEditor({
     );
   }
 
-  // modal mode (default)
-  return (
-    <div className="modal-overlay" onContextMenu={handleContextMenu}>
+  // modal mode (default) — portal to body so file-manager stacking context cannot bury the editor
+  if (typeof document === 'undefined') return null;
+  return createPortal(
+    <div className="modal-overlay" style={{ zIndex: Z.MODAL }} onContextMenu={handleContextMenu}>
       <div className="modal modal-xl" style={{ display: 'flex', flexDirection: 'column', maxHeight: '90vh', marginTop: 48 }}>
         {editorContent}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -885,7 +885,7 @@ function ContextMenu({ pos, item, mode = 'item', isPinned = false, isSystemPinne
     <div
       ref={ref}
       className="context-menu"
-      style={{ left: adjusted.left, top: adjusted.top }}
+      style={{ left: adjusted.left, top: adjusted.top, zIndex: Z.MENU }}
     >
       {item && item.isDirectory && (
         <div className="context-menu-item" onClick={onOpenInNewTab}>

--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -2504,7 +2504,7 @@ export default function Terminal({
             border: 'var(--term-context-border)',
             borderRadius: '8px',
             boxShadow: 'var(--term-context-shadow)',
-            zIndex: Z.MODAL,
+            zIndex: Z.MENU,
             padding: '4px 0',
             minWidth: '190px',
             fontFamily: 'var(--font-ui)',
@@ -2546,7 +2546,7 @@ export default function Terminal({
             style={{
               position: 'fixed',
               inset: 0,
-              zIndex: Z.MODAL - 1,
+              zIndex: Z.MENU_BACKDROP,
               background: 'transparent',
               cursor: 'default',
             }}
@@ -2572,7 +2572,7 @@ export default function Terminal({
               border: 'var(--term-context-border)',
               borderRadius: '8px',
               boxShadow: 'var(--term-context-shadow)',
-              zIndex: Z.MODAL,
+              zIndex: Z.MENU,
               padding: '4px 0',
               minWidth: '200px',
               maxWidth: '360px',
@@ -2630,7 +2630,7 @@ export default function Terminal({
             borderRadius: 8,
             padding: '6px 12px',
             fontSize: 12,
-            zIndex: Z.MODAL,
+            zIndex: Z.POPUP,
             pointerEvents: 'none',
             boxShadow: 'var(--term-context-shadow)',
           }}

--- a/frontend/src/constants/zIndex.js
+++ b/frontend/src/constants/zIndex.js
@@ -13,9 +13,12 @@ export const Z = {
   // ── Local overlays (loading states, etc.) ──
   COMPONENT_OVERLAY: 50,
 
-  // ── Popup panels ──
+  // ── Popup panels (term history/commands, local floating UI) ──
   POPUP_BACKDROP: 99,
   POPUP: 100,
+
+  // ── Anchored popovers under a high parent (e.g. topbar) ──
+  POPOVER: 150,
 
   // ── Nested context menus ──
   MENU_BACKDROP: 199,
@@ -34,11 +37,15 @@ export const Z = {
   TRAY_PANEL: 8000,
   FULLSCREEN_OVERLAY: 9000,
 
-  // ── Global modals / context menus ──
+  // ── Global modals ──
   MODAL: 9999,
 
-  // ── Absolute top ──
+  // ── Chrome / search / floating editor ──
+  TOPBAR: 10000,
   SEARCH_PANEL: 10000,
   FLOATING_EDITOR: 10001,
   FLOATING_EDITOR_MENU: 10002,
+
+  // ── Absolute top (toasts / system notices) ──
+  TOAST: 10003,
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -321,7 +321,7 @@ textarea:focus:not(:focus-visible) {
   --wails-draggable: drag;
   flex-shrink: 0;
   position: relative;
-  z-index: 10000;
+  z-index: 10000; /* Z.TOPBAR */
 }
 
 .topbar-content {
@@ -706,7 +706,7 @@ input::-ms-clear {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 9999; /* Z.MODAL — must outrank terminal/panels/menus */
   animation: fadeIn 0.12s ease;
 }
 
@@ -1146,7 +1146,7 @@ input::-ms-clear {
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
-  z-index: 10001;
+  z-index: 10001; /* above topbar chrome when portaled */
 }
 
 .tiptop-bubble-bottom {
@@ -2576,7 +2576,7 @@ body.theme-light .batch-operation-bar {
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-md);
   padding: var(--space-1);
-  z-index: 2000;
+  z-index: 200; /* Z.MENU — below global modals / floating editor */
   min-width: 160px;
   animation: contextMenuIn 0.12s ease;
   transform-origin: top left;
@@ -2616,7 +2616,7 @@ body.theme-light .batch-operation-bar {
   border-radius: var(--radius-lg);
   padding: var(--space-3) var(--space-4);
   box-shadow: var(--shadow-md);
-  z-index: 3000;
+  z-index: 10003; /* Z.TOAST */
   min-width: 260px;
   animation: slideUp 0.2s ease;
 }
@@ -3445,7 +3445,7 @@ body.theme-light .editor-field-shell.editor-field-shell-shine::after {
   position: fixed;
   top: calc(var(--topbar-h) + var(--space-3));
   right: var(--space-5);
-  z-index: 9999;
+  z-index: 10003; /* Z.TOAST */
   display: flex;
   flex-direction: column;
   pointer-events: none;
@@ -4250,7 +4250,7 @@ body.theme-light .dashboard-server-editor {
 /* ── 标签右键菜单 ───────────────────────────────────────────── */
 .tab-context-menu {
   position: fixed;
-  z-index: 10000;
+  z-index: 200; /* Z.MENU */
   background: var(--surface-overlay);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -4497,7 +4497,7 @@ body.theme-light .dashboard-server-editor {
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-md);
-  z-index: 100;
+  z-index: 100; /* Z.POPUP — below menus/modals/file editor */
 }
 .term-popup-backdrop {
   position: fixed;


### PR DESCRIPTION
## 问题
从文件管理器打开编辑窗口（尤其是「全屏弹窗」模式）时，终端区域与底部命令输入区叠层高于编辑器，导致编辑器被挡住、难以操作。

根因主要有：
1. 文件编辑器 modal 挂在文件管理器内部，父级 `position: absolute; z-index: 1` 形成 stacking context，整体被快捷命令底栏等盖住
2. `.modal-overlay` CSS 为 `z-index: 1000`，与 `Z.MODAL = 9999` 不一致
3. 终端右键/链接菜单误用 `Z.MODAL`，层级过高
4. z-index 常量缺少 `POPOVER`/`TOAST` 等已用项

## 改动
- **FileEditor**：modal 模式 `createPortal` 到 `document.body`，并设置 `zIndex: Z.MODAL`
- **zIndex 刻度**：补充 `POPOVER`、`TOPBAR`、`TOAST`，理顺注释层级
- **Terminal**：右键/链接菜单改为 `Z.MENU` / `Z.MENU_BACKDROP`，局部 toast 用 `Z.POPUP`
- **index.css**：对齐 modal/菜单/toast/顶栏等魔法数与 `Z.*`
- **App / FileManager**：同步失败提示与右键菜单走统一常量

## 预期层级（低 → 高）
面板/终端内容 → 终端弹层(100) → 菜单(200) → 全局 Modal/文件编辑(9999) → 顶栏/浮动编辑(10000+) → Toast(10003)

## 测试建议
1. 打开文件 → 全屏弹窗编辑：应完整盖住终端与底部命令区
2. 浮动面板模式：编辑器仍在最上层
3. 终端右键菜单、链接菜单、命令历史弹层仍可正常使用
4. 设置/凭据等其它 modal 不受影响

## 关联
修复 UI 叠层错乱导致的文件编辑体验问题。