### PR TITLE
fix: 修复侧边编辑配置输入框聚焦边框四角被裁切

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3385,14 +3385,24 @@ body.theme-light .add-supernova-ring {
   position: relative;
   display: block;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
+}
+
+/* Focus ring on shell so overflow:hidden does not clip the 2px glow corners */
+.editor-field-shell:focus-within {
+  box-shadow: 0 0 0 2px var(--accent-dim);
+}
+
+.editor-field-shell .input:focus,
+.dashboard-server-editor .editor-field-shell .input:focus {
+  box-shadow: none;
 }
 
 .editor-field-shell::after {
   content: "";
   position: absolute;
   inset: 1px;
-  border-radius: 7px;
+  border-radius: calc(var(--radius-sm) - 1px);
   pointer-events: none;
   opacity: 0;
 }


### PR DESCRIPTION
## 摘要
- 修复首页侧边「编辑配置」中用户名、终端默认 cd 目录、文件管理器初始目录等输入框在聚焦时蓝色边框四角被切断的问题
- 根因：`.editor-field-shell` 使用 `overflow: hidden`（用于高亮扫光动画）会裁切子元素 `input` 的 focus `box-shadow`
- 将 focus 光晕改到 shell 的 `:focus-within` 上绘制，并取消壳内 input 自身 box-shadow；圆角与输入框统一为 `var(--radius-sm)`

## 测试计划
- [ ] 打开首页侧边栏，编辑任意服务器配置
- [ ] 依次聚焦「用户名」「终端默认 cd 目录」「文件管理器初始目录」输入框
- [ ] 确认蓝色 focus 边框四角完整、无裁切
- [ ] 确认编辑保存时字段扫光高亮动画仍正常