### PR TITLE
style(theme): 优化 Lumin Default, Tokyo Night 和 Dracula 浅色终端配色对比度

### DIFF
--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -101,11 +101,11 @@ const TERMINAL_THEMES = {
         cursorAccent: '#ffffff', selectionBackground: '#1d4ed8',
         selectionForeground: '#ffffff',
         selectionInactiveBackground: '#1d4ed8',
-        black: '#0c0e18', red: '#ef4444', green: '#65a30d', yellow: '#eab308',
-        blue: '#3b82f6', magenta: '#8b5cf6', cyan: '#06b6d4', white: '#d5d9e8',
-        brightBlack: '#5b6388', brightRed: '#f87171', brightGreen: '#84cc16',
-        brightYellow: '#facc15', brightBlue: '#93c5fd', brightMagenta: '#a78bfa',
-        brightCyan: '#67e8f9', brightWhite: '#f4f5f9',
+        black: '#0c0e18', red: '#b8344e', green: '#286214', yellow: '#724905',
+        blue: '#1d57c4', magenta: '#7a30cb', cyan: '#005b76', white: '#d5d9e8',
+        brightBlack: '#444b6a', brightRed: '#cf2d4c', brightGreen: '#387a21',
+        brightYellow: '#8f5e15', brightBlue: '#245fcb', brightMagenta: '#8536f5',
+        brightCyan: '#007197', brightWhite: '#f4f5f9',
       },
       container: {
         // 冷蓝灰 + 靛蓝：Tokyo 浅色

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -42,11 +42,11 @@ const TERMINAL_THEMES = {
         cursorAccent: '#ffffff', selectionBackground: '#2563eb',
         selectionForeground: '#ffffff',
         selectionInactiveBackground: '#2563eb',
-        black: '#0a0f1a', red: '#ef4444', green: '#22c55e', yellow: '#eab308',
-        blue: '#3b82f6', magenta: '#a855f7', cyan: '#06b6d4', white: '#e2e8f0',
-        brightBlack: '#64748b', brightRed: '#f87171', brightGreen: '#4ade80',
-        brightYellow: '#facc15', brightBlue: '#93c5fd', brightMagenta: '#c084fc',
-        brightCyan: '#67e8f9', brightWhite: '#f8fafc',
+        black: '#0a0f1a', red: '#b91c1c', green: '#15803d', yellow: '#854d0e',
+        blue: '#1d4ed8', magenta: '#7e22ce', cyan: '#0f766e', white: '#e2e8f0',
+        brightBlack: '#475569', brightRed: '#dc2626', brightGreen: '#16a34a',
+        brightYellow: '#a16207', brightBlue: '#2563eb', brightMagenta: '#9333ea',
+        brightCyan: '#0891b2', brightWhite: '#f8fafc',
       },
       container: {
         // 暖白 + 蓝：Lumin 浅色

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -221,11 +221,11 @@ const TERMINAL_THEMES = {
         cursorAccent: '#ffffff', selectionBackground: '#7c3aed',
         selectionForeground: '#ffffff',
         selectionInactiveBackground: '#7c3aed',
-        black: '#0a0a0f', red: '#e11d48', green: '#16a34a', yellow: '#ca8a04',
-        blue: '#7c3aed', magenta: '#db2777', cyan: '#0e7490', white: '#9ca3af',
-        brightBlack: '#4b5563', brightRed: '#f43f5e', brightGreen: '#22c55e',
-        brightYellow: '#eab308', brightBlue: '#a78bfa', brightMagenta: '#ec4899',
-        brightCyan: '#0891b2', brightWhite: '#f3f4f6',
+        black: '#0a0a0f', red: '#b91c1c', green: '#15803d', yellow: '#854d0e',
+        blue: '#6d28d9', magenta: '#be185d', cyan: '#0e7490', white: '#9ca3af',
+        brightBlack: '#4b5563', brightRed: '#dc2626', brightGreen: '#16a34a',
+        brightYellow: '#a16207', brightBlue: '#5b21b6', brightMagenta: '#9d174d',
+        brightCyan: '#007788', brightWhite: '#f3f4f6',
       },
       container: {
         // 近中性浅灰底，粉只留在状态栏识别，减少整屏粉雾


### PR DESCRIPTION
优化了浅色底色下的 ANSI 16 色与亮前景色彩的对比度，大幅度提升了各主题在浅色模式下的文件、文件夹名、命令及各种语义化状态提示信息的可读性。

### 具体改动：
1. **Lumin Default**：提升绿色、蓝色、黄色、紫色、青色等前景色与亮前景色的对比度。
2. **Tokyo Night**：提升亮蓝、亮绿、亮黄、亮青等颜色对比度，解决浅色底色下文件与文件夹显示发飘看不清的问题。
3. **Dracula**：优化 brightBlue 等颜色对比度，解决浅色底色下文件夹颜色（原亮紫蓝 \#a78bfa\ 对比度仅 1.9:1）极难识别的问题。