### PR TITLE
feat(pc): 服务器标签支持双击与中键关闭连接

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5409,6 +5409,13 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                       key={s.id}
                       className={`tab-item no-drag ${activeSessionId === s.id ? 'active' : ''}`}
                       onClick={() => handleTabClick(s.id)}
+                      onDoubleClick={(e) => { void closeSession(s.id, e); }}
+                      onMouseDown={(e) => {
+                        if (e.button !== 1) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        void closeSession(s.id, e);
+                      }}
                       onContextMenu={(e) => {
                         e.preventDefault();
                         const rect = e.currentTarget.getBoundingClientRect();
@@ -5432,6 +5439,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                               e.stopPropagation();
                               reconnectSession(s);
                             }}
+                            onDoubleClick={(e) => e.stopPropagation()}
                             aria-label={t('重新连接')}
                             style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}
                           >
@@ -5439,7 +5447,13 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                           </span>
                         </Tiptop>
                       )}
-                      <span className="tab-close no-drag" onClick={(e) => closeSession(s.id, e)}><X size={12} /></span>
+                      <span
+                        className="tab-close no-drag"
+                        onClick={(e) => closeSession(s.id, e)}
+                        onDoubleClick={(e) => e.stopPropagation()}
+                      >
+                        <X size={12} />
+                      </span>
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- 顶部服务器 session 标签支持**双击**关闭连接
- 支持**中键**（`button === 1`）关闭连接（Win/Linux 及 Mac 外接中键鼠标；Mac 触控板无中键时以双击为主）
- 关闭逻辑复用现有 `closeSession`，确认弹窗与点 X 一致（含「不再询问」）
- X 按钮 / 右键关闭 / 关闭全部行为不变

## Test plan
- [x] 多开两个以上 session，双击标签可关闭（确认弹窗与 X 一致）
- [x] 有中键设备：中键点击标签可关闭
- [x] 单击标签仍可正常切换
- [x] 点 X、右键「关闭连接」、关闭全部仍正常
- [x] 双击 X / 重连图标区域不出现异常重复关闭