### PR TITLE
feat(pc): 支持双击标题栏空白处最大化/还原窗口

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1481,6 +1481,19 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     WindowToggleMaximise();
   }, []);
 
+  const handleTopbarDoubleClick = useCallback((e) => {
+    if (
+      e.target.closest('button') ||
+      e.target.closest('input') ||
+      e.target.closest('.no-drag') ||
+      e.target.closest('.topbar-logo') ||
+      e.target.closest('.tab-item')
+    ) {
+      return;
+    }
+    handleToggleMaximise();
+  }, [handleToggleMaximise]);
+
   const startDrag = useCallback((e, direction) => {
     e.preventDefault();
     const startX = e.clientX;
@@ -5382,7 +5395,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
   return (
     <div className="app-layout">
       {/* ── Topbar ───────────────────────────────────────── */}
-      <div className="topbar">
+      <div className="topbar" onDoubleClick={handleTopbarDoubleClick}>
         <div className="topbar-content">
           <div className="topbar-logo" onClick={() => { markWorkspaceRestoreNavigationOverride(); setActiveSessionId(null); setActiveTerminalId(null); setShowSettings(false); }}>
             <div


### PR DESCRIPTION
支持双击自定义标题栏空白区域（排除按钮、输入框、Logo区域和标签页等交互元素）来切换窗口最大化与还原状态。