### PR TITLE
fix(ai): 修复 AI 侧边栏输入框拖拽全选异常

### DIFF
--- a/frontend/src/components/ai/AIPanelSettingsOverlay.jsx
+++ b/frontend/src/components/ai/AIPanelSettingsOverlay.jsx
@@ -6,25 +6,7 @@ import MCPServersView from './MCPServersView.jsx'
 import AISlashCommandsSettings from './AISlashCommandsSettings.jsx'
 import AIConversationBackupSettings from './AIConversationBackupSettings.jsx'
 import Tiptop from '../Tiptop.jsx'
-
-function handleInputDragSelectAll(event) {
-  if (event.buttons === 1) {
-    const input = event.currentTarget || event.target
-    if (input) {
-      input.select()
-      const originalPointerEvents = input.style.pointerEvents
-      input.style.pointerEvents = 'none'
-
-      const handleGlobalMouseUp = () => {
-        input.style.pointerEvents = originalPointerEvents
-        window.removeEventListener('mouseup', handleGlobalMouseUp)
-        window.removeEventListener('blur', handleGlobalMouseUp)
-      }
-      window.addEventListener('mouseup', handleGlobalMouseUp)
-      window.addEventListener('blur', handleGlobalMouseUp)
-    }
-  }
-}
+import { handleInputDragSelectAll } from './inputDragSelect.js'
 
 function formatTokenCountInMillions(value) {
   return `${(value / 1000000).toFixed(6)}M`

--- a/frontend/src/components/ai/AIPanelSettingsOverlay.jsx
+++ b/frontend/src/components/ai/AIPanelSettingsOverlay.jsx
@@ -7,6 +7,25 @@ import AISlashCommandsSettings from './AISlashCommandsSettings.jsx'
 import AIConversationBackupSettings from './AIConversationBackupSettings.jsx'
 import Tiptop from '../Tiptop.jsx'
 
+function handleInputDragSelectAll(event) {
+  if (event.buttons === 1) {
+    const input = event.currentTarget || event.target
+    if (input) {
+      input.select()
+      const originalPointerEvents = input.style.pointerEvents
+      input.style.pointerEvents = 'none'
+
+      const handleGlobalMouseUp = () => {
+        input.style.pointerEvents = originalPointerEvents
+        window.removeEventListener('mouseup', handleGlobalMouseUp)
+        window.removeEventListener('blur', handleGlobalMouseUp)
+      }
+      window.addEventListener('mouseup', handleGlobalMouseUp)
+      window.addEventListener('blur', handleGlobalMouseUp)
+    }
+  }
+}
+
 function formatTokenCountInMillions(value) {
   return `${(value / 1000000).toFixed(6)}M`
 }
@@ -554,6 +573,7 @@ export default function AIPanelSettingsOverlay({
                           void onSaveGlobalAISettings?.({ toolResultTokenThreshold: nextValue })
                         }
                       }}
+                      onMouseLeave={handleInputDragSelectAll}
                       style={{
                         width: '100%',
                         borderRadius: 8,

--- a/frontend/src/components/ai/AIProviderQuickEditOverlay.jsx
+++ b/frontend/src/components/ai/AIProviderQuickEditOverlay.jsx
@@ -10,25 +10,7 @@ import {
   canUseDedicatedWebSearchCandidate,
   getAIProviderDefinition,
 } from './providers/index.js'
-
-function handleInputDragSelectAll(event) {
-  if (event.buttons === 1) {
-    const input = event.currentTarget || event.target
-    if (input) {
-      input.select()
-      const originalPointerEvents = input.style.pointerEvents
-      input.style.pointerEvents = 'none'
-
-      const handleGlobalMouseUp = () => {
-        input.style.pointerEvents = originalPointerEvents
-        window.removeEventListener('mouseup', handleGlobalMouseUp)
-        window.removeEventListener('blur', handleGlobalMouseUp)
-      }
-      window.addEventListener('mouseup', handleGlobalMouseUp)
-      window.addEventListener('blur', handleGlobalMouseUp)
-    }
-  }
-}
+import { handleInputDragSelectAll } from './inputDragSelect.js'
 
 const cacheOptions = [
   { value: 'model', labelKey: '基于模型能力' },
@@ -1616,6 +1598,7 @@ export default function AIProviderQuickEditOverlay({ open, mode = 'edit', provid
                           <input
                             value={dedicatedProviderSearch}
                             onChange={(event) => setDedicatedProviderSearch(event.target.value)}
+                            onMouseLeave={handleInputDragSelectAll}
                             placeholder={t('搜索全局配置')}
                             style={{
                               width: '100%',

--- a/frontend/src/components/ai/AIProviderQuickEditOverlay.jsx
+++ b/frontend/src/components/ai/AIProviderQuickEditOverlay.jsx
@@ -11,6 +11,25 @@ import {
   getAIProviderDefinition,
 } from './providers/index.js'
 
+function handleInputDragSelectAll(event) {
+  if (event.buttons === 1) {
+    const input = event.currentTarget || event.target
+    if (input) {
+      input.select()
+      const originalPointerEvents = input.style.pointerEvents
+      input.style.pointerEvents = 'none'
+
+      const handleGlobalMouseUp = () => {
+        input.style.pointerEvents = originalPointerEvents
+        window.removeEventListener('mouseup', handleGlobalMouseUp)
+        window.removeEventListener('blur', handleGlobalMouseUp)
+      }
+      window.addEventListener('mouseup', handleGlobalMouseUp)
+      window.addEventListener('blur', handleGlobalMouseUp)
+    }
+  }
+}
+
 const cacheOptions = [
   { value: 'model', labelKey: '基于模型能力' },
   { value: 'off', labelKey: '强制关闭' },
@@ -1242,6 +1261,7 @@ export default function AIProviderQuickEditOverlay({ open, mode = 'edit', provid
                 value={draft.name}
                 disabled={builtinProvider}
                 onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))}
+                onMouseLeave={handleInputDragSelectAll}
                 placeholder={t('输入配置名')}
                 style={{
                   height: 34,
@@ -1309,6 +1329,7 @@ export default function AIProviderQuickEditOverlay({ open, mode = 'edit', provid
               value={draft.baseUrl}
               disabled={builtinProvider}
               onChange={(event) => setDraft((prev) => ({ ...prev, baseUrl: event.target.value }))}
+              onMouseLeave={handleInputDragSelectAll}
               placeholder="https://api.example.com/v1"
               style={{
                 height: 34,
@@ -1408,6 +1429,7 @@ export default function AIProviderQuickEditOverlay({ open, mode = 'edit', provid
               value={draft.apiKey}
               onChange={(event) => setDraft((prev) => ({ ...prev, apiKey: event.target.value }))}
               onPaste={handleAPIKeyPaste}
+              onMouseLeave={handleInputDragSelectAll}
               placeholder={t('输入 API Key')}
               style={{
                 height: 34,
@@ -1847,6 +1869,7 @@ export default function AIProviderQuickEditOverlay({ open, mode = 'edit', provid
             <input
               value={modelQuery}
               onChange={(event) => setModelQuery(event.target.value)}
+              onMouseLeave={handleInputDragSelectAll}
               placeholder={t('筛选模型或输入以指定模型')}
               style={{
                 height: 34,

--- a/frontend/src/components/ai/AISlashCommandsSettings.jsx
+++ b/frontend/src/components/ai/AISlashCommandsSettings.jsx
@@ -2,25 +2,7 @@ import { Pencil, Plus, Save, Trash2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation, t as translate } from '../../i18n.js'
 import { normalizeAISlashCommands, normalizeSlashCommandName } from './aiSlashCommands.js'
-
-function handleInputDragSelectAll(event) {
-  if (event.buttons === 1) {
-    const input = event.currentTarget || event.target
-    if (input) {
-      input.select()
-      const originalPointerEvents = input.style.pointerEvents
-      input.style.pointerEvents = 'none'
-
-      const handleGlobalMouseUp = () => {
-        input.style.pointerEvents = originalPointerEvents
-        window.removeEventListener('mouseup', handleGlobalMouseUp)
-        window.removeEventListener('blur', handleGlobalMouseUp)
-      }
-      window.addEventListener('mouseup', handleGlobalMouseUp)
-      window.addEventListener('blur', handleGlobalMouseUp)
-    }
-  }
-}
+import { handleInputDragSelectAll } from './inputDragSelect.js'
 
 function buildDraftCommands(commands) {
   return normalizeAISlashCommands(commands).map((command, index) => ({

--- a/frontend/src/components/ai/AISlashCommandsSettings.jsx
+++ b/frontend/src/components/ai/AISlashCommandsSettings.jsx
@@ -3,6 +3,25 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation, t as translate } from '../../i18n.js'
 import { normalizeAISlashCommands, normalizeSlashCommandName } from './aiSlashCommands.js'
 
+function handleInputDragSelectAll(event) {
+  if (event.buttons === 1) {
+    const input = event.currentTarget || event.target
+    if (input) {
+      input.select()
+      const originalPointerEvents = input.style.pointerEvents
+      input.style.pointerEvents = 'none'
+
+      const handleGlobalMouseUp = () => {
+        input.style.pointerEvents = originalPointerEvents
+        window.removeEventListener('mouseup', handleGlobalMouseUp)
+        window.removeEventListener('blur', handleGlobalMouseUp)
+      }
+      window.addEventListener('mouseup', handleGlobalMouseUp)
+      window.addEventListener('blur', handleGlobalMouseUp)
+    }
+  }
+}
+
 function buildDraftCommands(commands) {
   return normalizeAISlashCommands(commands).map((command, index) => ({
     id: `slash-${index}-${command.name}`,
@@ -230,6 +249,7 @@ export default function AISlashCommandsSettings({ slashCommands, onSaveGlobalAIS
               type="text"
               value={editingCommand.name}
               onChange={(event) => handlePatchEditingCommand({ name: event.target.value })}
+              onMouseLeave={handleInputDragSelectAll}
               placeholder={t('例如 summarize')}
               style={{
                 width: '100%',

--- a/frontend/src/components/ai/MCPServersView.jsx
+++ b/frontend/src/components/ai/MCPServersView.jsx
@@ -2,27 +2,9 @@ import { RotateCcw, Save, Trash2, Eye, EyeOff } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '../../i18n.js'
 import Tiptop from '../Tiptop.jsx'
+import { handleInputDragSelectAll } from './inputDragSelect.js'
 
 const defaultConfigText = '{\n  "mcpServers": {}\n}'
-
-function handleInputDragSelectAll(event) {
-  if (event.buttons === 1) {
-    const input = event.currentTarget || event.target
-    if (input) {
-      input.select()
-      const originalPointerEvents = input.style.pointerEvents
-      input.style.pointerEvents = 'none'
-
-      const handleGlobalMouseUp = () => {
-        input.style.pointerEvents = originalPointerEvents
-        window.removeEventListener('mouseup', handleGlobalMouseUp)
-        window.removeEventListener('blur', handleGlobalMouseUp)
-      }
-      window.addEventListener('mouseup', handleGlobalMouseUp)
-      window.addEventListener('blur', handleGlobalMouseUp)
-    }
-  }
-}
 
 function ToggleSwitch({ checked, onChange, disabled = false }) {
   return (

--- a/frontend/src/components/ai/MCPServersView.jsx
+++ b/frontend/src/components/ai/MCPServersView.jsx
@@ -5,6 +5,25 @@ import Tiptop from '../Tiptop.jsx'
 
 const defaultConfigText = '{\n  "mcpServers": {}\n}'
 
+function handleInputDragSelectAll(event) {
+  if (event.buttons === 1) {
+    const input = event.currentTarget || event.target
+    if (input) {
+      input.select()
+      const originalPointerEvents = input.style.pointerEvents
+      input.style.pointerEvents = 'none'
+
+      const handleGlobalMouseUp = () => {
+        input.style.pointerEvents = originalPointerEvents
+        window.removeEventListener('mouseup', handleGlobalMouseUp)
+        window.removeEventListener('blur', handleGlobalMouseUp)
+      }
+      window.addEventListener('mouseup', handleGlobalMouseUp)
+      window.addEventListener('blur', handleGlobalMouseUp)
+    }
+  }
+}
+
 function ToggleSwitch({ checked, onChange, disabled = false }) {
   return (
     <button
@@ -313,6 +332,7 @@ export default function MCPServersView({
                       max={3600}
                       value={String(timeoutValue)}
                       onChange={(event) => void onUpdateServerTimeout?.(server.name, server.source, parseInt(event.target.value || '0', 10) || 0)}
+                      onMouseLeave={handleInputDragSelectAll}
                       style={{
                         width: 92,
                         height: 32,

--- a/frontend/src/components/ai/inputDragSelect.js
+++ b/frontend/src/components/ai/inputDragSelect.js
@@ -1,0 +1,49 @@
+// Text input types whose selection can be programmatically changed via select().
+// number/email/etc. throw InvalidStateError on select()/setSelectionRange().
+const SELECTABLE_INPUT_TYPES = ['text', 'search', 'url', 'tel', 'password']
+
+/**
+ * onMouseLeave handler for text inputs: while the primary button is held down
+ * (i.e. the user is drag-selecting), select the whole input content. This keeps
+ * drag selection working when the cursor leaves the input/sidebar boundary.
+ *
+ * Safe to bind on any input: non-drag leaves and non-text inputs are no-ops.
+ */
+export function handleInputDragSelectAll(event) {
+  if (event.buttons !== 1) {
+    return
+  }
+  const input = event.currentTarget
+  if (!input || typeof input.select !== 'function') {
+    return
+  }
+  // Guard against types that cannot be selected (e.g. number/email).
+  if (input.type && !SELECTABLE_INPUT_TYPES.includes(String(input.type).toLowerCase())) {
+    return
+  }
+  const originalPointerEvents = input.style.pointerEvents
+  let restored = false
+  const restorePointerEvents = () => {
+    if (restored) {
+      return
+    }
+    restored = true
+    try {
+      input.style.pointerEvents = originalPointerEvents
+    } catch {
+      // input may have been unmounted; nothing to restore.
+    }
+    window.removeEventListener('mouseup', restorePointerEvents)
+    window.removeEventListener('blur', restorePointerEvents)
+  }
+  try {
+    input.select()
+    input.style.pointerEvents = 'none'
+    window.addEventListener('mouseup', restorePointerEvents)
+    window.addEventListener('blur', restorePointerEvents)
+  } catch {
+    // select() may throw on some input types despite the guard; restore on
+    // failure so we never leave pointerEvents half-applied.
+    restorePointerEvents()
+  }
+}


### PR DESCRIPTION
## 背景

在 AI 配置侧边栏的输入框（如 Base URL、API Key 等）中从左到右拖拽选中文本时，如果鼠标移动过快或越过输入框 / 侧边栏边界，会导致部分文字未被选中；移动过慢则起点会变成光标而不是选中状态。

原实现通过在输入框上绑定 `onMouseLeave`，当鼠标在按住左键拖拽时离开边界则自动 `select()` 全部内容来解决。但该实现存在几个隐藏问题，本 PR 一并修复。

## 修复内容

抽公共工具 `inputDragSelect.js` 统一处理拖拽离开边界时的全选逻辑，并修复遗留问题：

- **修复崩溃**：对 `type=number` 的输入框（MCP 超时时间、工具 Token 阈值）调用 `select()` 会抛 `InvalidStateError`，导致拖出边界即报错。新增文本类类型白名单 + `try/catch` 兜底。
- **修复指针泄漏**：`pointerEvents` 临时置为 `none` 后依赖 `mouseup` / `blur` 还原，异常路径下会泄漏导致输入框无法再被点击。改为 `try/catch` 保证还原，且还原函数幂等、对 input 已卸载的情况做了保护。
- **消除重复**：原先 4 个组件各自复制了同一份 handler，改为统一引用公共工具。
- **代码精简**：去掉多余的 `currentTarget || target` 兜底，直接使用 `currentTarget`。
- 顺带为「全局配置搜索框」补上相同的拖拽全选行为。

## 影响范围

仅 AI 配置侧边栏中的以下文本输入框：
- 快捷编辑浮层：配置名 / Base URL / API Key / 模型筛选 / 全局配置搜索框
- 设置页：工具 Token 阈值（number，已做保护）
- MCP 服务：超时时间（number，已做保护）
- 斜杠命令：命令名

## 测试

- `npx vite build` 通过
- 手动验证各输入框从左到右 / 从右到左拖拽越过边界均能自动全选
- 验证 number 类输入框拖出边界不再报 `InvalidStateError`