### PR TITLE
fix: 修复 Messages (Anthropic) 协议模式下无法获取模型列表的问题

### DIFF
--- a/ai_wails_bindings.go
+++ b/ai_wails_bindings.go
@@ -252,6 +252,10 @@ func (b *AIBindings) RequestAIProviderModels(baseURL string, apiKey string) ([]s
 	return b.runtime().RequestAIProviderModels(baseURL, apiKey)
 }
 
+func (b *AIBindings) RequestAIProviderModelsWithProfile(jsonStr string) ([]string, error) {
+	return b.runtime().RequestAIProviderModelsWithProfile(jsonStr)
+}
+
 type aiSSHDelegate struct {
 	manager *SSHManager
 }

--- a/internal/ai/provider_compatible.go
+++ b/internal/ai/provider_compatible.go
@@ -110,6 +110,123 @@ func fetchCompatibleProviderModels(client *http.Client, baseURL string, apiKey s
 	return models, nil
 }
 
+func fetchMessagesProviderModels(client *http.Client, baseURL string, apiKey string) ([]string, error) {
+	trimmedBaseURL := aiprovider.NormalizeMessagesBaseURL(baseURL)
+	if trimmedBaseURL == "" {
+		return nil, fmt.Errorf("请先填写 Anthropic 基础 URL")
+	}
+
+	endpoint := trimmedBaseURL + "/v1/models"
+	request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("anthropic-version", "2023-06-01")
+	if key := strings.TrimSpace(apiKey); key != "" {
+		request.Header.Set("x-api-key", key)
+	}
+
+	if client == nil {
+		client = &http.Client{Timeout: 20 * time.Second}
+	}
+
+	response, fetchErr := client.Do(request)
+
+	is404Or405 := false
+	if fetchErr == nil && response != nil {
+		if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusMethodNotAllowed {
+			is404Or405 = true
+			response.Body.Close()
+		}
+	}
+
+	if (fetchErr != nil || is404Or405) && strings.Contains(trimmedBaseURL, "/anthropic") {
+		// Fallback for DeepSeek or similar providers that expose Anthropic-compatible /v1/messages
+		// but require OpenAI-compatible /v1/models on their main domain.
+		derivedBaseURL := strings.TrimSuffix(strings.TrimRight(trimmedBaseURL, "/"), "/anthropic")
+		var fallbackErr error
+		fallbackSucceeded := false
+		for _, path := range []string{"/v1/models", "/models"} {
+			fallbackEndpoint := derivedBaseURL + path
+			fallbackReq, err := http.NewRequest(http.MethodGet, fallbackEndpoint, nil)
+			if err != nil {
+				continue
+			}
+			fallbackReq.Header.Set("Accept", "application/json")
+			if key := strings.TrimSpace(apiKey); key != "" {
+				fallbackReq.Header.Set("Authorization", "Bearer "+key)
+			}
+			fallbackResp, err := client.Do(fallbackReq)
+			if err != nil {
+				fallbackErr = err
+				continue
+			}
+			if fallbackResp.StatusCode >= 200 && fallbackResp.StatusCode < 300 {
+				response = fallbackResp
+				fetchErr = nil
+				fallbackSucceeded = true
+				break
+			}
+			bodyBytes, _ := io.ReadAll(io.LimitReader(fallbackResp.Body, 1024))
+			fallbackResp.Body.Close()
+			fallbackErr = fmt.Errorf("fallback to %s failed (status %d): %s", path, fallbackResp.StatusCode, strings.TrimSpace(string(bodyBytes)))
+		}
+		if !fallbackSucceeded {
+			if fallbackErr != nil {
+				return nil, fmt.Errorf("获取 Anthropic 模型列表失败，且尝试备用 OpenAI 兼容接口失败: %v", fallbackErr)
+			}
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			return nil, fmt.Errorf("获取 Anthropic 模型列表失败 (404/405)")
+		}
+	} else if fetchErr != nil {
+		return nil, fetchErr
+	} else if is404Or405 {
+		return nil, fmt.Errorf("获取 Anthropic 模型列表失败 (404/405)")
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
+		errorText := strings.TrimSpace(string(bodyBytes))
+		if errorText == "" {
+			errorText = response.Status
+		}
+		return nil, fmt.Errorf("%s", errorText)
+	}
+
+	var payload aiProviderModelsResponse
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	modelSet := make(map[string]struct{}, len(payload.Data))
+	models := make([]string, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		modelID := strings.TrimSpace(item.ID)
+		if modelID == "" {
+			continue
+		}
+		if _, exists := modelSet[modelID]; exists {
+			continue
+		}
+		modelSet[modelID] = struct{}{}
+		models = append(models, modelID)
+	}
+
+	sort.Strings(models)
+
+	if len(models) == 0 {
+		return nil, fmt.Errorf("未获取到任何模型")
+	}
+
+	return models, nil
+}
+
 func (a *App) RequestAIProviderModels(baseURL string, apiKey string) ([]string, error) {
 	client, err := a.newAIHTTPClient(20 * time.Second)
 	if err != nil {
@@ -130,6 +247,9 @@ func (a *App) RequestAIProviderModelsWithProfile(jsonStr string) ([]string, erro
 	client, err := a.newAIHTTPClientForProfile(&profile, 20*time.Second)
 	if err != nil {
 		return nil, err
+	}
+	if profile.Provider == "Messages" {
+		return fetchMessagesProviderModels(client, profile.BaseURL, profile.APIKey)
 	}
 	return fetchCompatibleProviderModels(client, profile.BaseURL, profile.APIKey)
 }


### PR DESCRIPTION
### 问题背景与原因
在 `Messages (Anthropic)` 协议模式下添加供应商并获取模型列表时，请求会失败。主要原因有两点：
1. 后端 bindings 文件 `ai_wails_bindings.go` 未向 Wails 层暴露 `RequestAIProviderModelsWithProfile` 绑定方法，导致前端调用降级至 `RequestAIProviderModels(baseUrl, apiKey)`。
2. 降级的接口不带 Provider 信息，后端硬编码使用 OpenAI 格式（`Authorization: Bearer <key>`，路径 `/models`）去拉取数据。而 Anthropic 的模型拉取接口规范是 `/v1/models`，且需要额外的 `x-api-key` 和 `anthropic-version` 请求头。
3. 此外，DeepSeek 虽然提供了 `https://api.deepseek.com/anthropic` 以兼容 Anthropic 格式的 `/v1/messages` 发送消息，但并没有在其 `/anthropic` 子路径下支持 `/v1/models` 接口（模型接口依然在 OpenAI 主域名上且使用 Bearer 鉴权）。

### 解决方案与修改内容
1. **暴露接口绑定**：在 [ai_wails_bindings.go](file:///d:/AllCode/golang/Lumin-SSH/ai_wails_bindings.go) 中正式暴露 `RequestAIProviderModelsWithProfile` 方法，使得前端能将完整的供应商配置传回后端。
2. **支持 Messages 协议获取**：在 [internal/ai/provider_compatible.go](file:///d:/AllCode/golang/Lumin-SSH/internal/ai/provider_compatible.go) 中，对于 `profile.Provider == "Messages"` 的请求，转向调用新实现的 `fetchMessagesProviderModels` 方法，支持 `x-api-key`、`anthropic-version` 及 `/v1/models`。
3. **加入 DeepSeek /anthropic 兼容 Fallback**：在 `fetchMessagesProviderModels` 中，当 `/v1/models` 获取失败且 Base URL 包含 `/anthropic` 时，自动启动降级备用逻辑：
   - 自动剥离 URL 尾部的 `/anthropic`（例如还原为 `https://api.deepseek.com`）
   - 切换为 OpenAI 兼容的 `Authorization: Bearer <key>` 请求头
   - 重新请求备用路径 `/v1/models` 和 `/models`
