### PR TITLE
fix(pc): 修复控制台 React 警告并统一 favicon

### DIFF
--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -382,52 +382,6 @@ function readBlobAsBase64(blob) {
   });
 }
 
-function debugUploadFileInfo(file) {
-  if (!file) return null;
-  return {
-    name: file.name,
-    size: file.size,
-    type: file.type,
-    lastModified: file.lastModified,
-    webkitRelativePath: file.webkitRelativePath,
-    fullPath: file._fullPath,
-    path: file.path,
-    constructorName: file.constructor?.name,
-    keys: Object.keys(file),
-  };
-}
-
-function debugUploadItemInfo(item) {
-  if (!item) return null;
-  let entry = null;
-  let file = null;
-  try {
-    const rawEntry = item.webkitGetAsEntry?.();
-    if (rawEntry) {
-      entry = {
-        name: rawEntry.name,
-        fullPath: rawEntry.fullPath,
-        isFile: rawEntry.isFile,
-        isDirectory: rawEntry.isDirectory,
-        filesystemName: rawEntry.filesystem?.name,
-      };
-    }
-  } catch (err) {
-    entry = { error: String(err) };
-  }
-  try {
-    file = item.kind === 'file' ? debugUploadFileInfo(item.getAsFile?.()) : null;
-  } catch (err) {
-    file = { error: String(err) };
-  }
-  return {
-    kind: item.kind,
-    type: item.type,
-    entry,
-    file,
-  };
-}
-
 function isCompressedTransferEnabled() {
   return localStorage.getItem('fileManagerCompressedTransfer') !== 'false';
 }
@@ -3088,20 +3042,12 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
   const handleSelectedFiles = useCallback(async (e) => {
     const rawSelectedFiles = Array.from(e.target.files || []);
-    console.log('[FileManager][click upload] input files', {
-      files: rawSelectedFiles.map(debugUploadFileInfo),
-      rawFiles: rawSelectedFiles,
-    });
     const selectedFiles = rawSelectedFiles
       .filter((file) => !isHiddenFile(file.name))
       .map((file) => ({
         file,
         relativePath: file.webkitRelativePath || file.name,
       }));
-    console.log('[FileManager][click upload] normalized entries', selectedFiles.map((entry) => ({
-      relativePath: entry.relativePath,
-      file: debugUploadFileInfo(entry.file),
-    })));
     e.target.value = '';
     if (selectedFiles.length === 0) {
       return;
@@ -3116,7 +3062,6 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     try {
       const paths = await AppGo.SelectUploadFiles();
-      console.log('[FileManager][native click upload] paths', paths);
       await uploadNativePaths(paths || []);
     } catch (err) {
       if (err) addToast(`${t('上传失败')}: ${err}`, 'error');
@@ -3130,7 +3075,6 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     }
     try {
       const dirPath = await AppGo.SelectUploadDirectory();
-      console.log('[FileManager][native click upload folder] path', dirPath);
       if (!dirPath) {
         return;
       }
@@ -4493,29 +4437,10 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
   useEffect(() => {
     if (!isActive) return undefined;
-    console.log('[FileManager][native drop upload] register', {
-      canResolveFilePaths: CanResolveFilePaths?.(),
-      flags: window.wails?.flags,
-    });
     OnFileDrop((x, y, paths) => {
       const rect = fileManagerRootRef.current?.getBoundingClientRect?.();
       const compressedEnabled = isCompressedTransferEnabled();
       const hit = !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
-      console.log('[FileManager][native drop upload] callback', {
-        x,
-        y,
-        paths,
-        compressedEnabled,
-        hit,
-        rect: rect ? {
-          left: rect.left,
-          top: rect.top,
-          right: rect.right,
-          bottom: rect.bottom,
-          width: rect.width,
-          height: rect.height,
-        } : null,
-      });
       if (!rect || !hit || !compressedEnabled) return;
       nativeDropHandledUntilRef.current = Date.now() + 5000;
       setIsDragOver(false);
@@ -4584,13 +4509,6 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
     const droppedItems = Array.from(e.dataTransfer.items || []);
     const droppedFiles = Array.from(e.dataTransfer.files || []);
-    console.log('[FileManager][drop upload] dataTransfer', {
-      types: Array.from(e.dataTransfer.types || []),
-      items: droppedItems.map(debugUploadItemInfo),
-      files: droppedFiles.map(debugUploadFileInfo),
-      rawItems: droppedItems,
-      rawFiles: droppedFiles,
-    });
     if (droppedItems.length === 0 && droppedFiles.length === 0) return;
 
     const entryMap = new Map();
@@ -4620,18 +4538,12 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
 
     droppedFiles.forEach((file) => addEntry(file, file.webkitRelativePath || file.name));
 
-    console.log('[FileManager][drop upload] normalized entries', Array.from(entryMap.values()).map((entry) => ({
-      relativePath: entry.relativePath,
-      file: debugUploadFileInfo(entry.file),
-    })));
     if (isCompressedTransferEnabled()) {
-      console.log('[FileManager][drop upload] compressed transfer enabled, waiting for native drop handoff');
+      // 等原生 OnFileDrop 抢先处理；超时再走浏览器 File/Blob 兜底
       await new Promise((resolve) => setTimeout(resolve, 3000));
       if (Date.now() < nativeDropHandledUntilRef.current) {
-        console.log('[FileManager][drop upload] native drop handled, skip browser File/Blob fallback');
         return;
       }
-      console.warn('[FileManager][drop upload] native drop did not handle in time, fallback to browser File/Blob upload');
     }
     await uploadEntries(Array.from(entryMap.values()));
   };

--- a/frontend/src/components/ProbePanel.jsx
+++ b/frontend/src/components/ProbePanel.jsx
@@ -471,6 +471,8 @@ export default function ProbePanel({ sessionId, host, addToast, enabled, active,
   const [info, setInfo] = useState(() => snapshot?.info || null);
   // ponytail: 合并 3 个历史数组为 1 个状态更新，减少 3 次渲染为 1 次
   const [hist, setHist] = useState(() => snapshot?.hist || createEmptyHist());
+  const histRef = useRef(hist);
+  histRef.current = hist;
   const [showConfirm, setShowConfirm] = useState(false);
   const [enabling, setEnabling] = useState(false);
   const [hideIP, setHideIP] = useState(() => localStorage.getItem('probeHideIP') === 'true');
@@ -660,9 +662,11 @@ export default function ProbePanel({ sessionId, host, addToast, enabled, active,
 
   // 切换服务器时立即清空旧数据和静态缓存
   useEffect(() => {
+    const nextHist = snapshot?.hist || createEmptyHist();
     setInfo(snapshot?.info || null);
     staticInfoRef.current = null;
-    setHist(snapshot?.hist || createEmptyHist());
+    histRef.current = nextHist;
+    setHist(nextHist);
     setCpuExpanded(false);
     setDiskExpanded(false);
     setProbeError(null);
@@ -747,16 +751,17 @@ export default function ProbePanel({ sessionId, host, addToast, enabled, active,
         networkInterfaces: data.network?.interfaces || [],
         processes: data.processes || [],
       };
+      // 用 histRef 算 nextHist，避免在 setState updater 里调父组件 onSnapshot（渲染期 setState 警告）
+      const prevHist = histRef.current || createEmptyHist();
+      const nextHist = {
+        cpu: [...prevHist.cpu, ni.cpuUsage].slice(-HISTORY_SIZE),
+        up: [...prevHist.up, ni.netUp].slice(-HISTORY_SIZE),
+        down: [...prevHist.down, ni.netDown].slice(-HISTORY_SIZE),
+      };
+      histRef.current = nextHist;
       setInfo(ni);
-      setHist(prev => {
-        const nextHist = {
-          cpu: [...prev.cpu, ni.cpuUsage].slice(-HISTORY_SIZE),
-          up: [...prev.up, ni.netUp].slice(-HISTORY_SIZE),
-          down: [...prev.down, ni.netDown].slice(-HISTORY_SIZE),
-        };
-        onSnapshotRef.current?.({ info: ni, hist: nextHist });
-        return nextHist;
-      });
+      setHist(nextHist);
+      onSnapshotRef.current?.({ info: ni, hist: nextHist });
       probeErrorCountRef.current = 0;
       setProbeError(false);
       setProbeErrorDetail('');

--- a/frontend/src/components/ServerList.jsx
+++ b/frontend/src/components/ServerList.jsx
@@ -509,10 +509,10 @@ export default function ServerList({
       tryConnect(server);
     };
 
+    // key 必须在 map 返回的最外层（Tiptop），挂在内层 div 时 React 仍会报 missing key
     return (
-      <Tiptop text={`${server.username}@${server.host}:${server.port || 22}`}>
+      <Tiptop key={`${server.id}-${rowToken || 'stable'}`} text={`${server.username}@${server.host}:${server.port || 22}`}>
         <div
-          key={`${server.id}-${rowToken || 'stable'}`}
           data-server-update-id={server.id}
           className={`server-card ${active ? 'active' : ''}${rowToken ? ' save-flow-hit' : ''}${selectionMode && isChecked ? 'selected' : ''}`}
           {...pointerSelectHandlers}

--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -1698,7 +1698,12 @@ export default function Terminal({
       termRef.current     = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;
-      try { term.dispose(); } catch (_) {}
+      // xterm Viewport 构造里 setTimeout(syncScrollArea) 无句柄；StrictMode 先 dispose 再触发会读空 renderer.dimensions
+      // 延后 dispose，让该 setTimeout 先跑完（同队列 FIFO）
+      const termToDispose = term;
+      setTimeout(() => {
+        try { termToDispose.dispose(); } catch (_) {}
+      }, 0);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);

--- a/frontend/src/components/ai/aiProviderPasteHandlers.js
+++ b/frontend/src/components/ai/aiProviderPasteHandlers.js
@@ -1,4 +1,3 @@
-console.log(1)
 function normalizeToken(value) {
   return typeof value === 'string' ? value.trim() : ''
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,19 @@ import { AlertTriangle } from 'lucide-react';
 import './index.css';
 import { applyProgramFontPreferences } from './utils/programFonts.js';
 import { applyStoredThemePackage, loadThemePackages } from './utils/theme.js';
+// favicon 与 UI logo 共用同一源，避免 public/favicon.png 再拷一份
+import logoFavicon from './assets/logo.png';
+
+(() => {
+  let link = document.querySelector("link[rel='icon']");
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    link.type = 'image/png';
+    document.head.appendChild(link);
+  }
+  link.href = logoFavicon;
+})();
 
 // 全局错误边界，防止渲染错误导致白屏
 class ErrorBoundary extends React.Component {


### PR DESCRIPTION
- ServerList 将 key 提到 Tiptop 最外层，消除 list key 警告
- Terminal 延后 dispose，避开 xterm Viewport setTimeout 读空 dimensions
- ProbePanel 用 histRef 在 updater 外调用 onSnapshot，避免渲染期更新 App
- 去掉 FileManager 上传调试日志与误留的 console.log(1)
- favicon 与 UI logo 共用 src/assets/logo.png，不再拷贝 public 副本