### PR TITLE
fix(pc): 修复托盘久置后点击无法唤起主窗口

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,11 +20,16 @@ var assets embed.FS
 //go:embed all:module
 var embeddedModuleFS embed.FS
 
-// forceShowWindow 唤醒隐藏到托盘的窗口，带 recover 防止 panic 导致托盘 goroutine 挂死
+// forceShowWindow 唤醒隐藏到托盘的窗口。
+// 不先 Hide 再 Show：久置后 Show 失败会把窗口永久卡在隐藏态。
+// 先走 Wails 恢复，再用平台原生激活抢前台（Windows 久置后 SetForeground 常被拒）。
 func forceShowWindow(ctx context.Context) {
 	defer func() { recover() }()
-	runtime.WindowHide(ctx)
-	runtime.WindowShow(ctx)
+	if ctx != nil {
+		runtime.WindowUnminimise(ctx)
+		runtime.WindowShow(ctx)
+	}
+	platformForceShowWindow()
 }
 
 var systrayOnce sync.Once
@@ -38,11 +43,13 @@ func setupSystray(app *App) {
 		mShow := systray.AddMenuItem("显示主窗口", "Show Main Window")
 		mQuit := systray.AddMenuItem("完全退出", "Quit Lumin")
 
+		showMain := func() {
+			forceShowWindow(app.ctx)
+		}
+
 		// 左键点击托盘图标：显示窗口
 		systray.SetOnClick(func(menu systray.IMenu) {
-			if app.ctx != nil {
-				forceShowWindow(app.ctx)
-			}
+			showMain()
 		})
 
 		// 右键点击托盘图标：显示菜单
@@ -51,9 +58,7 @@ func setupSystray(app *App) {
 		})
 
 		mShow.Click(func() {
-			if app.ctx != nil {
-				forceShowWindow(app.ctx)
-			}
+			showMain()
 		})
 
 		mQuit.Click(func() {

--- a/platform_darwin.go
+++ b/platform_darwin.go
@@ -22,6 +22,9 @@ var singletonLock *os.File
 // findAndShowWindow 在 macOS 上为空实现
 func findAndShowWindow() {}
 
+// platformForceShowWindow macOS 暂无原生兜底，依赖 Wails WindowShow
+func platformForceShowWindow() {}
+
 // ensureSingleInstance 使用 flock 检查是否已有实例运行（macOS 支持 flock）
 func ensureSingleInstance() {
 	lockFile := filepath.Join(os.TempDir(), "lumin-ssh.lock")

--- a/platform_unix.go
+++ b/platform_unix.go
@@ -21,6 +21,9 @@ var singletonLock *os.File
 // findAndShowWindow 在 Linux 上为空实现
 func findAndShowWindow() {}
 
+// platformForceShowWindow Linux 暂无原生兜底，依赖 Wails WindowShow
+func platformForceShowWindow() {}
+
 // ensureSingleInstance 使用 flock 检查是否已有实例运行
 func ensureSingleInstance() {
 	lockFile := filepath.Join(os.TempDir(), "lumin-ssh.lock")

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -15,35 +15,174 @@ import (
 //go:embed build/windows/icon.ico
 var icon []byte
 
-// findAndShowWindow 用 EnumWindows 枚举所有窗口，找到标题为 "Lumin" 的窗口并唤醒
-func findAndShowWindow() {
-	user32 := syscall.NewLazyDLL("user32.dll")
-	procEnumWindows := user32.NewProc("EnumWindows")
-	procGetWindowText := user32.NewProc("GetWindowTextW")
-	procGetWindowTextLength := user32.NewProc("GetWindowTextLengthW")
-	procShowWindow := user32.NewProc("ShowWindow")
-	procSetForegroundWindow := user32.NewProc("SetForegroundWindow")
+var (
+	user32                       = syscall.NewLazyDLL("user32.dll")
+	kernel32                     = syscall.NewLazyDLL("kernel32.dll")
+	procEnumWindows              = user32.NewProc("EnumWindows")
+	procGetWindowTextW           = user32.NewProc("GetWindowTextW")
+	procGetWindowTextLengthW     = user32.NewProc("GetWindowTextLengthW")
+	procGetClassNameW            = user32.NewProc("GetClassNameW")
+	procGetWindowThreadProcessId = user32.NewProc("GetWindowThreadProcessId")
+	procGetWindow                = user32.NewProc("GetWindow")
+	procIsIconic                 = user32.NewProc("IsIconic")
+	procShowWindow               = user32.NewProc("ShowWindow")
+	procSetForegroundWindow      = user32.NewProc("SetForegroundWindow")
+	procBringWindowToTop         = user32.NewProc("BringWindowToTop")
+	procSetFocus                 = user32.NewProc("SetFocus")
+	procSetWindowPos             = user32.NewProc("SetWindowPos")
+	procGetForegroundWindow      = user32.NewProc("GetForegroundWindow")
+	procAttachThreadInput        = user32.NewProc("AttachThreadInput")
+	procGetCurrentThreadId       = kernel32.NewProc("GetCurrentThreadId")
+	procGetCurrentProcessId      = kernel32.NewProc("GetCurrentProcessId")
+)
 
-	var targetHwnd syscall.Handle
+const (
+	swShow          = 5
+	swRestore       = 9
+	gwOwner         = 4
+	hwndTopmost     = ^uintptr(0) // -1
+	hwndNotopmost   = ^uintptr(1) // -2
+	swpNosize       = 0x0001
+	swpNomove       = 0x0002
+	swpShowWindow   = 0x0040
+	mainWindowTitle = "Lumin"
+	wailsFormClass  = "winc_Form"
+	systrayClass    = "SystrayClass"
+)
+
+func windowText(hwnd syscall.Handle) string {
+	textLen, _, _ := procGetWindowTextLengthW.Call(uintptr(hwnd))
+	if textLen == 0 {
+		return ""
+	}
+	buf := make([]uint16, textLen+1)
+	procGetWindowTextW.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&buf[0])), uintptr(textLen+1))
+	return syscall.UTF16ToString(buf)
+}
+
+func windowClass(hwnd syscall.Handle) string {
+	buf := make([]uint16, 256)
+	n, _, _ := procGetClassNameW.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&buf[0])), uintptr(len(buf)))
+	if n == 0 {
+		return ""
+	}
+	return syscall.UTF16ToString(buf[:n])
+}
+
+func isTopLevelWindow(hwnd syscall.Handle) bool {
+	owner, _, _ := procGetWindow.Call(uintptr(hwnd), uintptr(gwOwner))
+	return owner == 0
+}
+
+// activateHWND 用 SW_RESTORE + 短暂 TOPMOST + AttachThreadInput 抢前台。
+// 纯 SetForegroundWindow 在托盘久置后常被 Windows 前台限制静默拒绝。
+func activateHWND(hwnd syscall.Handle) {
+	if hwnd == 0 {
+		return
+	}
+	iconic, _, _ := procIsIconic.Call(uintptr(hwnd))
+	if iconic != 0 {
+		procShowWindow.Call(uintptr(hwnd), uintptr(swRestore))
+	} else {
+		// 隐藏到托盘时窗口是 SW_HIDE，不是最小化；RESTORE/SHOW 都能拉回
+		procShowWindow.Call(uintptr(hwnd), uintptr(swRestore))
+		procShowWindow.Call(uintptr(hwnd), uintptr(swShow))
+	}
+
+	flags := uintptr(swpNomove | swpNosize | swpShowWindow)
+	procSetWindowPos.Call(uintptr(hwnd), hwndTopmost, 0, 0, 0, 0, flags)
+	procSetWindowPos.Call(uintptr(hwnd), hwndNotopmost, 0, 0, 0, 0, flags)
+
+	fg, _, _ := procGetForegroundWindow.Call()
+	curThread, _, _ := procGetCurrentThreadId.Call()
+	var fgPid uint32
+	fgThread, _, _ := procGetWindowThreadProcessId.Call(fg, uintptr(unsafe.Pointer(&fgPid)))
+	var targetPid uint32
+	targetThread, _, _ := procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&targetPid)))
+
+	attachedFG := false
+	attachedTarget := false
+	if fgThread != 0 && fgThread != curThread {
+		r, _, _ := procAttachThreadInput.Call(curThread, fgThread, 1)
+		attachedFG = r != 0
+	}
+	if targetThread != 0 && targetThread != curThread && targetThread != fgThread {
+		r, _, _ := procAttachThreadInput.Call(curThread, targetThread, 1)
+		attachedTarget = r != 0
+	}
+
+	procBringWindowToTop.Call(uintptr(hwnd))
+	procSetForegroundWindow.Call(uintptr(hwnd))
+	procSetFocus.Call(uintptr(hwnd))
+
+	if attachedTarget {
+		procAttachThreadInput.Call(curThread, targetThread, 0)
+	}
+	if attachedFG {
+		procAttachThreadInput.Call(curThread, fgThread, 0)
+	}
+}
+
+// findMainWindowHWND 枚举顶层窗找 Lumin 主窗。
+// matchPID!=0：限本进程，优先 winc_Form，再标题 "Lumin"。
+// matchPID==0：跨进程二次启动用，只认标题 "Lumin"（避免误激活其他 Wails 应用）。
+func findMainWindowHWND(matchPID uint32) syscall.Handle {
+	var (
+		byClass syscall.Handle
+		byTitle syscall.Handle
+	)
 	callback := syscall.NewCallback(func(hwnd syscall.Handle, lParam uintptr) uintptr {
-		textLen, _, _ := procGetWindowTextLength.Call(uintptr(hwnd))
-		if textLen == 0 {
+		if !isTopLevelWindow(hwnd) {
 			return 1
 		}
-		buf := make([]uint16, textLen+1)
-		procGetWindowText.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&buf[0])), uintptr(textLen+1))
-		if syscall.UTF16ToString(buf) == "Lumin" {
-			targetHwnd = hwnd
-			return 0
+		class := windowClass(hwnd)
+		if class == systrayClass {
+			return 1
+		}
+		if matchPID != 0 {
+			var pid uint32
+			procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&pid)))
+			if pid != matchPID {
+				return 1
+			}
+		}
+		title := windowText(hwnd)
+		if title == mainWindowTitle && byTitle == 0 {
+			byTitle = hwnd
+			// 跨进程场景只靠标题即可结束
+			if matchPID == 0 {
+				return 0
+			}
+		}
+		if matchPID != 0 && class == wailsFormClass && byClass == 0 {
+			byClass = hwnd
+			// 本进程找到主窗类即可
+			if byTitle != 0 {
+				return 0
+			}
 		}
 		return 1
 	})
-
 	procEnumWindows.Call(callback, 0)
-	if targetHwnd != 0 {
-		const SW_RESTORE = 9
-		procShowWindow.Call(uintptr(targetHwnd), SW_RESTORE)
-		procSetForegroundWindow.Call(uintptr(targetHwnd))
+	// 本进程优先类名（隐藏后标题偶发读不到时仍可命中）
+	if matchPID != 0 && byClass != 0 {
+		return byClass
+	}
+	return byTitle
+}
+
+// findAndShowWindow 二次启动时唤醒已有实例窗口（按标题，跨进程）
+func findAndShowWindow() {
+	if hwnd := findMainWindowHWND(0); hwnd != 0 {
+		activateHWND(hwnd)
+	}
+}
+
+// platformForceShowWindow 托盘点击/菜单唤醒：按本进程主窗激活
+func platformForceShowWindow() {
+	pid, _, _ := procGetCurrentProcessId.Call()
+	if hwnd := findMainWindowHWND(uint32(pid)); hwnd != 0 {
+		activateHWND(hwnd)
 	}
 }
 


### PR DESCRIPTION
去掉 Hide-before-Show 以免 Show 失败后永久隐藏，并在 Windows 用原生前台激活兜底。