### PR TITLE
feat(ai): 调整MCP文件访问为shell优先并扩展callmy域名白名单

### DIFF
--- a/frontend/src/components/AIPanel.jsx
+++ b/frontend/src/components/AIPanel.jsx
@@ -18,6 +18,7 @@ import { processRemoteFileMentions } from './ai/aiMentions.js'
 import { expandFirstSlashCommandForPrompt } from './ai/aiSlashCommands.js'
 import AIChatConversation from './ai/chat/AIChatConversation.jsx'
 import { getConversationBranchAnchor } from './ai/chat/aiChatMessageTopology.js'
+import { isCallMyVipProviderHost } from './ai/providerSpecialHosts.js'
 import assistantThinkingActiveImg from '../assets/assistant-thinking-active.png'
 
 function formatMessageTime() {
@@ -1007,20 +1008,7 @@ export default function AIPanel({ width, side, terminalId = 'global', sessionId 
     () => (Array.isArray(aiProviderState?.providers) ? aiProviderState.providers : []),
     [aiProviderState],
   )
-  const canToggleAIMode = useMemo(() => {
-    const rawBaseURL = typeof selectedAIProvider?.baseUrl === 'string' ? selectedAIProvider.baseUrl.trim() : ''
-    if (!rawBaseURL) {
-      return false
-    }
-    const candidates = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(rawBaseURL) ? [rawBaseURL] : [rawBaseURL, `https://${rawBaseURL}`]
-    return candidates.some((item) => {
-      try {
-        return new URL(item).hostname.toLowerCase() === 'newapi.callmy.vip'
-      } catch {
-        return false
-      }
-    })
-  }, [selectedAIProvider])
+  const canToggleAIMode = useMemo(() => isCallMyVipProviderHost(selectedAIProvider?.baseUrl), [selectedAIProvider])
   useEffect(() => {
     if (!canToggleAIMode) {
       setIsDevilMode(false)

--- a/frontend/src/components/ai/AIProviderSelector.jsx
+++ b/frontend/src/components/ai/AIProviderSelector.jsx
@@ -6,6 +6,7 @@ import AIProviderQuickEditOverlay from './AIProviderQuickEditOverlay.jsx'
 import Tiptop from '../Tiptop.jsx'
 import { getAIProviderState, isBuiltinAIProvider, normalizeAIProviderState, saveAIProviderState } from './aiProviderBridge.js'
 import { getAIProviderDefinition } from './providers/index.js'
+import { isCallMyVipProviderHost } from './providerSpecialHosts.js'
 
 const defaultProviders = []
 const summaryTooltipDelay = 300
@@ -417,15 +418,7 @@ function resolveAIProviderBaseOrigin(value) {
 }
 
 function isAIProviderBalanceLabelEnabled(provider) {
-  const origin = resolveAIProviderBaseOrigin(provider?.baseUrl)
-  if (!origin) {
-    return false
-  }
-  try {
-    return new URL(origin).hostname.toLowerCase() === 'newapi.callmy.vip'
-  } catch {
-    return false
-  }
+  return isCallMyVipProviderHost(provider?.baseUrl)
 }
 
 function normalizeAIProviderBalanceValue(value) {

--- a/frontend/src/components/ai/providerSpecialHosts.js
+++ b/frontend/src/components/ai/providerSpecialHosts.js
@@ -1,0 +1,19 @@
+export const CALLMY_VIP_PROVIDER_HOSTS = [
+  'newapi.callmy.vip',
+  'newapi2.callmy.vip',
+]
+
+export function isCallMyVipProviderHost(value) {
+  const rawBaseURL = typeof value === 'string' ? value.trim() : ''
+  if (!rawBaseURL) {
+    return false
+  }
+  const candidates = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(rawBaseURL) ? [rawBaseURL] : [rawBaseURL, `https://${rawBaseURL}`]
+  return candidates.some((candidate) => {
+    try {
+      return CALLMY_VIP_PROVIDER_HOSTS.includes(new URL(candidate).hostname.toLowerCase())
+    } catch {
+      return false
+    }
+  })
+}

--- a/mcp_bridge.go
+++ b/mcp_bridge.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	ai "luminssh-go/internal/ai"
 	mcp "luminssh-go/internal/mcp"
 	"luminssh-go/internal/mcpserver"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func loadMCPServiceSettings(app *App) mcp.ServiceSettings {
@@ -304,12 +308,18 @@ func (h mcpHost) ListDirectoryContext(ctx context.Context, sessionID string, rem
 	if h.app == nil || h.app.sshManager == nil {
 		return nil, fmt.Errorf("ssh manager unavailable")
 	}
+	if client, _, err := h.app.sshManager.getClientEntry(sessionID); err == nil && client != nil {
+		return h.shellListDirectory(ctx, client, remotePath)
+	}
 	return h.app.sshManager.ListDirContext(ctx, sessionID, remotePath)
 }
 
 func (h mcpHost) ReadTextFileContext(ctx context.Context, sessionID string, remotePath string) (string, error) {
 	if h.app == nil || h.app.sshManager == nil {
 		return "", fmt.Errorf("ssh manager unavailable")
+	}
+	if client, _, err := h.app.sshManager.getClientEntry(sessionID); err == nil && client != nil {
+		return h.runShellCommandLong(ctx, client, "cat -- "+shellQuotePath(remotePath))
 	}
 	return h.app.sshManager.ReadFileContext(ctx, sessionID, remotePath)
 }
@@ -439,4 +449,110 @@ func containsMCPSessionTag(tags []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func (h mcpHost) runShellCommandLong(ctx context.Context, client *ssh.Client, command string) (string, error) {
+	session, err := client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+	return runCommandWithSessionContext(ctx, session, command, remoteCmdLongTimeout)
+}
+
+func (h mcpHost) shellListDirectory(ctx context.Context, client *ssh.Client, remotePath string) ([]map[string]interface{}, error) {
+	command := "cd " + shellQuotePath(remotePath) + " && stat -c '%f\t%s\t%u\t%g\t%Y\t%n' -- .* * 2>/dev/null"
+	output, err := h.runShellCommandLong(ctx, client, command)
+	if err != nil {
+		return nil, err
+	}
+	results := parseShellDirEntries(output)
+	sort.Slice(results, func(i, j int) bool {
+		iDir := results[i]["isDirectory"].(bool)
+		jDir := results[j]["isDirectory"].(bool)
+		if iDir != jDir {
+			return iDir
+		}
+		return results[i]["name"].(string) < results[j]["name"].(string)
+	})
+	return results, nil
+}
+
+func parseShellDirEntries(output string) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0)
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 6)
+		if len(fields) < 6 {
+			continue
+		}
+		name := fields[5]
+		if name == "." || name == ".." || name == "" {
+			continue
+		}
+		rawMode, parseErr := strconv.ParseUint(strings.TrimSpace(fields[0]), 16, 32)
+		if parseErr != nil {
+			continue
+		}
+		fileMode := unixRawModeToFileMode(uint32(rawMode))
+		size, _ := strconv.ParseInt(strings.TrimSpace(fields[1]), 10, 64)
+		modifyTime := ""
+		if epoch, timeErr := strconv.ParseInt(strings.TrimSpace(fields[4]), 10, 64); timeErr == nil {
+			modifyTime = time.Unix(epoch, 0).Format(time.RFC3339)
+		}
+		results = append(results, map[string]interface{}{
+			"name":        name,
+			"isDirectory": fileMode.IsDir(),
+			"size":        size,
+			"modifyTime":  modifyTime,
+			"permission":  fileMode.String(),
+			"mode":        fmt.Sprintf("%o", fileMode.Perm()),
+			"uid":         strings.TrimSpace(fields[2]),
+			"gid":         strings.TrimSpace(fields[3]),
+		})
+	}
+	return results
+}
+
+func unixRawModeToFileMode(raw uint32) os.FileMode {
+	const (
+		cIFMT   = 0xf000
+		cIFSOCK = 0xc000
+		cIFLNK  = 0xa000
+		cIFREG  = 0x8000
+		cIFBLK  = 0x6000
+		cIFDIR  = 0x4000
+		cIFCHR  = 0x2000
+		cIFIFO  = 0x1000
+		cISUID  = 0x800
+		cISGID  = 0x400
+		cISVTX  = 0x200
+	)
+	mode := os.FileMode(raw & 0777)
+	switch raw & cIFMT {
+	case cIFBLK:
+		mode |= os.ModeDevice
+	case cIFCHR:
+		mode |= os.ModeDevice | os.ModeCharDevice
+	case cIFDIR:
+		mode |= os.ModeDir
+	case cIFIFO:
+		mode |= os.ModeNamedPipe
+	case cIFLNK:
+		mode |= os.ModeSymlink
+	case cIFSOCK:
+		mode |= os.ModeSocket
+	}
+	if raw&cISUID != 0 {
+		mode |= os.ModeSetuid
+	}
+	if raw&cISGID != 0 {
+		mode |= os.ModeSetgid
+	}
+	if raw&cISVTX != 0 {
+		mode |= os.ModeSticky
+	}
+	return mode
 }


### PR DESCRIPTION
- AI助手侧的read_file和list_files改为优先走无感shell,仅在无可用shell时回退SFTP
- 保持文件管理器现有SFTP行为不变
- 抽取callmy域名白名单公共数组
- 新增对 newapi2.callmy.vip 的支持,复用恶魔模式和余额展示判断