### PR TITLE
fix(pc): 分栏拖条热区偏侧栏，避免终端划词误触

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5866,7 +5866,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
               {showAIPanel ? (
                 <Tiptop text={t('收起 AI 助手面板')} placement="bottom" style={{ display: 'flex' }}>
                   <div
-                    className={`split-resizer-v${collapseDragIntent === 'ai' ? ' armed' : ''}`}
+                    className={`split-resizer-v hotzone-left${collapseDragIntent === 'ai' ? ' armed' : ''}`}
                     onMouseDown={(e) => startDrag(e, 'ai')}
                     onClick={() => {
                       if (shouldIgnoreResizerClick()) return;
@@ -5928,7 +5928,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                 </div>
                 <Tiptop text={t('收起监控面板')} placement="bottom" style={{ display: 'flex' }}>
                   <div
-                    className={`split-resizer-v probe-resizer${collapseDragIntent === 'probe' ? ' armed' : ''}`}
+                    className={`split-resizer-v hotzone-left probe-resizer${collapseDragIntent === 'probe' ? ' armed' : ''}`}
                     onMouseDown={(e) => startDrag(e, 'probe')}
                     onClick={() => {
                       if (shouldIgnoreResizerClick()) return;
@@ -6248,7 +6248,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                           >
                             {/* 拖条放在面板顶部内部，不再与终端「历史/命令」按钮重叠 */}
                             <div
-                              className={`split-resizer-h${collapseDragIntent === 'bottom' ? ' armed' : ''}`}
+                              className={`split-resizer-h hotzone-bottom${collapseDragIntent === 'bottom' ? ' armed' : ''}`}
                               onMouseDown={(e) => {
                                 e.stopPropagation();
                                 startDrag(e, 'bottom');
@@ -6262,8 +6262,8 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                                 position: 'absolute',
                                 left: 0,
                                 right: 0,
-                                top: -2,
-                                height: 6,
+                                top: 0,
+                                height: 0,
                                 zIndex: 5,
                                 margin: 0,
                               }}
@@ -6284,7 +6284,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                         )}
                         {showLeftFileManager && (
                           <div
-                            className={`split-resizer-v${collapseDragIntent === 'left' ? ' armed' : ''}`}
+                            className={`split-resizer-v hotzone-left${collapseDragIntent === 'left' ? ' armed' : ''}`}
                             onMouseDown={(e) => startDrag(e, 'left')}
                             onClick={() => {
                               if (shouldIgnoreResizerClick()) return;
@@ -6305,7 +6305,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                         )}
                         {showRightFileManager && (
                           <div
-                            className={`split-resizer-v${collapseDragIntent === 'right' ? ' armed' : ''}`}
+                            className={`split-resizer-v hotzone-right${collapseDragIntent === 'right' ? ' armed' : ''}`}
                             onMouseDown={(e) => startDrag(e, 'right')}
                             onClick={() => {
                               if (shouldIgnoreResizerClick()) return;
@@ -6326,7 +6326,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                         {/* 仅文件管理器底部模式用外部分隔条；快捷命令用面板内拖条 */}
                         {showBottomFileManager && !showBottomQuickCommands && (
                           <div
-                            className={`split-resizer-h${collapseDragIntent === 'bottom' ? ' armed' : ''}`}
+                            className={`split-resizer-h hotzone-bottom${collapseDragIntent === 'bottom' ? ' armed' : ''}`}
                             onMouseDown={(e) => startDrag(e, 'bottom')}
                             onClick={(e) => {
                               e.stopPropagation();
@@ -6595,7 +6595,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
               ))}
               {/* 文件编辑器分栏 host（由 FileEditor 通过 Portal 渲染） */}
               <div
-                className="split-resizer-v"
+                className="split-resizer-v hotzone-right"
                 style={{ display: 'none', order: 1 }}
                 id="editor-split-resizer"
                 onMouseDown={(e) => {
@@ -6710,7 +6710,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
               <>
                 <Tiptop text={t('收起监控面板')} placement="bottom" style={{ display: 'flex' }}>
                   <div
-                    className={`split-resizer-v probe-resizer${collapseDragIntent === 'probe' ? ' armed' : ''}`}
+                    className={`split-resizer-v hotzone-right probe-resizer${collapseDragIntent === 'probe' ? ' armed' : ''}`}
                     onMouseDown={(e) => startDrag(e, 'probe')}
                     onClick={() => {
                       if (shouldIgnoreResizerClick()) return;
@@ -6748,7 +6748,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
               {showAIPanel ? (
                 <Tiptop text={t('收起 AI 助手面板')} placement="bottom" style={{ display: 'flex' }}>
                   <div
-                    className={`split-resizer-v${collapseDragIntent === 'ai' ? ' armed' : ''}`}
+                    className={`split-resizer-v hotzone-right${collapseDragIntent === 'ai' ? ' armed' : ''}`}
                     onMouseDown={(e) => startDrag(e, 'ai')}
                     onClick={() => {
                       if (shouldIgnoreResizerClick()) return;

--- a/frontend/src/components/FileEditor.jsx
+++ b/frontend/src/components/FileEditor.jsx
@@ -490,6 +490,9 @@ export default function FileEditor({
     const mainContent = document.getElementById('editor-main-content');
     if (resizer) {
       resizer.style.display = '';
+      // 热区偏编辑器侧，减少终端划词误触
+      resizer.classList.remove('hotzone-left', 'hotzone-right');
+      resizer.classList.add(splitPosition === 'left' ? 'hotzone-left' : 'hotzone-right');
     }
     if (splitPosition === 'left') {
       host.style.order = '0';

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -2181,6 +2181,9 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
     if (resizer) {
       resizer.style.display = '';
       resizer.style.order = '1';
+      // 上传面板在右侧：热区偏右，避免终端划词误触
+      resizer.classList.remove('hotzone-left', 'hotzone-right');
+      resizer.classList.add('hotzone-right');
     }
     container.style.flexDirection = 'row';
     host.style.width = '42%';

--- a/frontend/src/components/NetworkPage.jsx
+++ b/frontend/src/components/NetworkPage.jsx
@@ -341,7 +341,7 @@ export default function NetworkPage({ sessionId, active }) {
 
       {detailConnections.length > 0 ? (
         <>
-          <div className="split-resizer-h" onMouseDown={startDetailDrag} style={{ flexShrink: 0, zIndex: 10 }} />
+          <div className="split-resizer-h hotzone-bottom" onMouseDown={startDetailDrag} style={{ flexShrink: 0, zIndex: 10 }} />
           <div style={{ height: detailHeight, flexShrink: 0, borderTop: '1px solid var(--border)', display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--surface-sunken)' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 8px', borderBottom: '1px solid var(--border-light)', background: 'var(--surface-raised)', gap: 4 }}>
             <div style={{ display: 'flex', gap: 3, overflow: 'hidden', flex: 1 }}>

--- a/frontend/src/components/ProcessPage.jsx
+++ b/frontend/src/components/ProcessPage.jsx
@@ -619,7 +619,7 @@ export default function ProcessPage({ sessionId, addToast, active }) {
       {detailState.processes.length > 0 && (
         <>
           <div
-            className="split-resizer-h"
+            className="split-resizer-h hotzone-bottom"
             onMouseDown={startDetailDrag}
             style={{ flexShrink: 0, zIndex: 10 }}
           />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4538,21 +4538,39 @@ body.theme-light .dashboard-server-editor {
   background: transparent;
   flex-shrink: 0;
 }
-/* 视觉 0，热区 ~8px；悬停/拖拽时画 1px 强调线 */
+/*
+ * 视觉 0。热区偏侧栏，终端侧仅 1px，避免划词误触拖宽。
+ * hotzone-left：左侧侧栏右缘（热区主要在左）
+ * hotzone-right：右侧侧栏左缘（热区主要在右）
+ */
 .split-resizer-v::after {
   content: '';
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -4px;
-  width: 8px;
+  left: -5px;
+  width: 6px;
   background: transparent;
   transition: background-color 0.15s;
+}
+.split-resizer-v.hotzone-left::after {
+  left: -5px;
+  width: 6px;
+}
+.split-resizer-v.hotzone-right::after {
+  left: -1px;
+  width: 6px;
 }
 .split-resizer-v:hover::after,
 .split-resizer-v.dragging::after,
 .split-resizer-v.armed::after {
-  background: linear-gradient(90deg, transparent 3.5px, var(--accent) 3.5px, var(--accent) 4.5px, transparent 4.5px);
+  /* 默认/偏左：强调线贴分隔缝（热区右缘内侧） */
+  background: linear-gradient(90deg, transparent 4.5px, var(--accent) 4.5px, var(--accent) 5.5px, transparent 5.5px);
+}
+.split-resizer-v.hotzone-right:hover::after,
+.split-resizer-v.hotzone-right.dragging::after,
+.split-resizer-v.hotzone-right.armed::after {
+  background: linear-gradient(90deg, transparent 0.5px, var(--accent) 0.5px, var(--accent) 1.5px, transparent 1.5px);
 }
 
 .split-resizer-h {
@@ -4563,20 +4581,34 @@ body.theme-light .dashboard-server-editor {
   background: transparent;
   flex-shrink: 0;
 }
+/* 默认偏下（底部面板上缘），终端侧仅 1px */
 .split-resizer-h::after {
   content: '';
   position: absolute;
   left: 0;
   right: 0;
-  top: -4px;
-  height: 8px;
+  top: -1px;
+  height: 6px;
   background: transparent;
   transition: background-color 0.15s;
+}
+.split-resizer-h.hotzone-top::after {
+  top: -5px;
+  height: 6px;
+}
+.split-resizer-h.hotzone-bottom::after {
+  top: -1px;
+  height: 6px;
 }
 .split-resizer-h:hover::after,
 .split-resizer-h.dragging::after,
 .split-resizer-h.armed::after {
-  background: linear-gradient(180deg, transparent 3.5px, var(--accent) 3.5px, var(--accent) 4.5px, transparent 4.5px);
+  background: linear-gradient(180deg, transparent 0.5px, var(--accent) 0.5px, var(--accent) 1.5px, transparent 1.5px);
+}
+.split-resizer-h.hotzone-top:hover::after,
+.split-resizer-h.hotzone-top.dragging::after,
+.split-resizer-h.hotzone-top.armed::after {
+  background: linear-gradient(180deg, transparent 4.5px, var(--accent) 4.5px, var(--accent) 5.5px, transparent 5.5px);
 }
 
 /* ── 终端主题选择卡片 ────────────────────────────────────────── */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4539,38 +4539,38 @@ body.theme-light .dashboard-server-editor {
   flex-shrink: 0;
 }
 /*
- * 视觉 0。热区偏侧栏，终端侧仅 1px，避免划词误触拖宽。
- * hotzone-left：左侧侧栏右缘（热区主要在左）
- * hotzone-right：右侧侧栏左缘（热区主要在右）
+ * 视觉 0。热区完全落在侧栏侧，终端侧 0px，避免划词误触拖宽。
+ * hotzone-left：左侧侧栏右缘
+ * hotzone-right：右侧侧栏左缘
  */
 .split-resizer-v::after {
   content: '';
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -5px;
+  left: -6px;
   width: 6px;
   background: transparent;
   transition: background-color 0.15s;
 }
 .split-resizer-v.hotzone-left::after {
-  left: -5px;
+  left: -6px;
   width: 6px;
 }
 .split-resizer-v.hotzone-right::after {
-  left: -1px;
+  left: 0;
   width: 6px;
 }
 .split-resizer-v:hover::after,
 .split-resizer-v.dragging::after,
 .split-resizer-v.armed::after {
-  /* 默认/偏左：强调线贴分隔缝（热区右缘内侧） */
-  background: linear-gradient(90deg, transparent 4.5px, var(--accent) 4.5px, var(--accent) 5.5px, transparent 5.5px);
+  /* 默认/偏左：强调线贴分隔缝（热区右缘） */
+  background: linear-gradient(90deg, transparent 5px, var(--accent) 5px, var(--accent) 6px, transparent 6px);
 }
 .split-resizer-v.hotzone-right:hover::after,
 .split-resizer-v.hotzone-right.dragging::after,
 .split-resizer-v.hotzone-right.armed::after {
-  background: linear-gradient(90deg, transparent 0.5px, var(--accent) 0.5px, var(--accent) 1.5px, transparent 1.5px);
+  background: linear-gradient(90deg, var(--accent) 0, var(--accent) 1px, transparent 1px);
 }
 
 .split-resizer-h {
@@ -4581,34 +4581,34 @@ body.theme-light .dashboard-server-editor {
   background: transparent;
   flex-shrink: 0;
 }
-/* 默认偏下（底部面板上缘），终端侧仅 1px */
+/* 默认偏下（底部面板上缘），终端侧 0 */
 .split-resizer-h::after {
   content: '';
   position: absolute;
   left: 0;
   right: 0;
-  top: -1px;
+  top: 0;
   height: 6px;
   background: transparent;
   transition: background-color 0.15s;
 }
 .split-resizer-h.hotzone-top::after {
-  top: -5px;
+  top: -6px;
   height: 6px;
 }
 .split-resizer-h.hotzone-bottom::after {
-  top: -1px;
+  top: 0;
   height: 6px;
 }
 .split-resizer-h:hover::after,
 .split-resizer-h.dragging::after,
 .split-resizer-h.armed::after {
-  background: linear-gradient(180deg, transparent 0.5px, var(--accent) 0.5px, var(--accent) 1.5px, transparent 1.5px);
+  background: linear-gradient(180deg, var(--accent) 0, var(--accent) 1px, transparent 1px);
 }
 .split-resizer-h.hotzone-top:hover::after,
 .split-resizer-h.hotzone-top.dragging::after,
 .split-resizer-h.hotzone-top.armed::after {
-  background: linear-gradient(180deg, transparent 4.5px, var(--accent) 4.5px, var(--accent) 5.5px, transparent 5.5px);
+  background: linear-gradient(180deg, transparent 5px, var(--accent) 5px, var(--accent) 6px, transparent 6px);
 }
 
 /* ── 终端主题选择卡片 ────────────────────────────────────────── */


### PR DESCRIPTION
分隔条视觉宽为 0 时，对称 8px 热区会盖住终端边缘；改为按侧栏方向偏置，终端侧仅保留约 0px。