### PR TITLE
fix(pc): 稳定 SSH 长连接与重连

### DIFF
--- a/connection_proxy.go
+++ b/connection_proxy.go
@@ -191,8 +191,11 @@ func connectionUsesProxy(conn Connection) bool {
 
 func dialConnectionTargetContext(ctx context.Context, conn Connection, target string, timeout time.Duration) (net.Conn, error) {
 	if !connectionUsesProxy(conn) {
-		var d net.Dialer
-		d.Timeout = timeout
+		// 显式 TCP KeepAlive，减轻空闲被 NAT/中间设备静默丢连接。
+		d := net.Dialer{
+			Timeout:   timeout,
+			KeepAlive: 30 * time.Second,
+		}
 		return d.DialContext(ctx, "tcp", target)
 	}
 
@@ -205,8 +208,10 @@ func dialConnectionTargetContext(ctx context.Context, conn Connection, target st
 }
 
 func dialHTTPProxyContext(ctx context.Context, conn Connection, target string, timeout time.Duration) (net.Conn, error) {
-	var d net.Dialer
-	d.Timeout = timeout
+	d := net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}
 	proxyTarget := dialAddr(conn.ProxyHost, normalizeConnectionProxyPort(conn.ProxyPort))
 	netConn, err := d.DialContext(ctx, "tcp", proxyTarget)
 	if err != nil {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2734,6 +2734,13 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
       setConnectingServers((prev) => [...prev, { server: serverObj, sessionId: session.id, startTime: Date.now() }]);
     }
     try {
+      // 先拆旧 SSH（保留前端 terminals 列表用于恢复），避免脏 connTerminals / 重复登记
+      const priorTerminals = session.terminals?.length
+        ? session.terminals
+        : [{ id: session.id }];
+      const disconnectIds = new Set([session.id, ...priorTerminals.map((term) => term.id).filter(Boolean)]);
+      await Promise.all([...disconnectIds].map((id) => AppGo.DisconnectSSH(id).catch(() => {})));
+
       await AppGo.ConnectSSH(session.id, session.serverId);
 
       const savedTerminals = session.terminals?.length > 0 ? session.terminals : [{ id: session.id, label: `${t('终端')}1` }];
@@ -2984,30 +2991,59 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     });
   }, [rememberWorkspace, rememberWorkspaceLoaded, reconnectSession, resolveSessionRootTerminalId, serversLoaded, t]);
 
-  // ── 监听 SSH 意外断开事件 ────────────────────────────────────
+  // ── 监听 SSH 断开事件（整机意外断 vs 单终端结束）────────────────
   useEffect(() => {
-    const unbind = EventsOn('ssh-disconnected', (sessionId) => {
+    const unbind = EventsOn('ssh-disconnected', (payload) => {
+      // 兼容旧版纯 string sessionId
+      const data = (payload && typeof payload === 'object')
+        ? payload
+        : { sessionId: payload, parentSessionId: payload, connectionClosed: true, reason: 'transport' };
+      const sessionId = data.sessionId;
+      const parentSessionId = data.parentSessionId || sessionId;
+      const connectionClosed = data.connectionClosed !== false && data.connectionClosed !== 'false';
+      const reason = data.reason || '';
+      const endedTerminalIds = Array.isArray(data.terminalIds) && data.terminalIds.length
+        ? data.terminalIds
+        : (sessionId ? [sessionId] : []);
+
       const sessionList = sessionsRef.current;
-      const matchedSession = sessionList.find((item) => item.id === sessionId)
-        || sessionList.find((item) => item.terminals?.some((terminal) => terminal.id === sessionId))
+      const matchedSession = sessionList.find((item) => item.id === parentSessionId || item.id === sessionId)
+        || sessionList.find((item) => item.terminals?.some((terminal) => terminal.id === sessionId || terminal.id === parentSessionId || endedTerminalIds.includes(terminal.id)))
         || null;
-      setSessions((prev) => {
-        const serverSession = prev.find(s => s.id === sessionId);
-        if (serverSession) {
-          return prev.map((s) => (s.id === sessionId ? { ...s, status: 'closed' } : s));
+      if (!matchedSession) {
+        return;
+      }
+      const parentId = matchedSession.id;
+
+      const transportDead = reason === 'transport' || reason === 'keepalive';
+      if (connectionClosed || transportDead) {
+        setSessions((prev) => prev.map((s) => (s.id === parentId ? { ...s, status: 'closed' } : s)));
+        // 仅传输/保活导致的整机断开视为「意外」；最后一终端正常 exit 只标 closed，不误报
+        if (transportDead) {
+          addToast(t('SSH 连接已意外断开'), 'error', 4000);
         }
-        const parent = prev.find(s => s.terminals?.some(t => t.id === sessionId));
-        if (parent) {
-          return prev.map((s) => (s.id === parent.id ? { ...s, status: 'closed' } : s));
+        return;
+      }
+
+      // 单终端 channel 结束：只移除该终端；若已无终端再标 closed
+      setSessions((prev) => prev.map((s) => {
+        if (s.id !== parentId) return s;
+        const nextTerminals = (s.terminals || []).filter((term) => !endedTerminalIds.includes(term.id));
+        if (nextTerminals.length === 0) {
+          return { ...s, status: 'closed', terminals: [{ id: s.id, label: `${t('终端')}1` }] };
         }
-        return prev;
-      });
-      addToast(t('SSH 连接已意外断开'), 'error', 4000);
+        // 根终端 id 常等于 session.id；若根 shell 结束但子终端还在，保留子终端
+        const stillHasRoot = nextTerminals.some((term) => term.id === s.id);
+        const terminals = stillHasRoot
+          ? nextTerminals
+          : [{ id: s.id, label: nextTerminals[0]?.label || `${t('终端')}1` }, ...nextTerminals.filter((term) => term.id !== s.id)];
+        return { ...s, status: 'connected', terminals };
+      }));
     });
     return () => {
       if (unbind) unbind();
     };
-  }, [addToast]);
+  }, [addToast, t]);
 
   // ── 监听主机密钥变更事件 ────────────────────────────────────
   useEffect(() => {

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -3353,8 +3353,17 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   }, [sessionId, sessionGroupId, currentPath, getUploadSettings, addToast, t, markUploadAborted, openTransferQueueIfNeeded, normalizePath, refreshDirectoryAfterTransfer]);
 
   useEffect(() => {
-    const off = EventsOn('ssh-disconnected', (disconnectedSessionId) => {
-      abortActiveUploadsForSession(disconnectedSessionId, t('已终止'));
+    const off = EventsOn('ssh-disconnected', (payload) => {
+      const data = (payload && typeof payload === 'object')
+        ? payload
+        : { sessionId: payload, terminalIds: payload ? [payload] : [] };
+      const ids = new Set();
+      if (data.sessionId) ids.add(data.sessionId);
+      if (data.parentSessionId) ids.add(data.parentSessionId);
+      if (Array.isArray(data.terminalIds)) {
+        data.terminalIds.forEach((id) => id && ids.add(id));
+      }
+      ids.forEach((id) => abortActiveUploadsForSession(id, t('已终止')));
     });
     return () => {
       off?.();

--- a/ssh.go
+++ b/ssh.go
@@ -52,8 +52,10 @@ const (
 	postAuthSlowNoticeTimeout = 10 * time.Second
 	postAuthChannelTimeout    = 30 * time.Second
 	sftpInitWaitTimeout       = 5 * time.Second
-	sshKeepaliveInterval      = 5 * time.Second
-	sshKeepaliveTimeout       = 10 * time.Second
+	// 保活略松：单次超时不立刻拆线，连续失败达阈值才清理共享连接。
+	sshKeepaliveInterval = 15 * time.Second
+	sshKeepaliveTimeout  = 20 * time.Second
+	sshKeepaliveFailMax  = 3
 )
 
 // PendingHostKey 保存等待用户确认的主机密钥变更信息
@@ -439,7 +441,7 @@ func (m *SSHManager) Connect(sessionId string, conn Connection) error {
 			go m.watchClient(connKey, client)
 			go func() {
 				_ = client.Wait()
-				m.cleanupClientTransport(connKey, client)
+				m.cleanupClientTransport(connKey, client, "transport")
 			}()
 		}
 	}
@@ -602,7 +604,7 @@ func (m *SSHManager) setupSession(ctx context.Context, client *ssh.Client, connK
 	go m.pipeOutput(sessionId, stderr, nil)
 	go func() {
 		_ = session.Wait()
-		m.disconnectAndNotify(sessionId)
+		m.disconnectAndNotify(sessionId, "session_end")
 	}()
 
 	return nil
@@ -641,19 +643,44 @@ func (m *SSHManager) initSFTPClient(sessionId string, connKey string, conn Conne
 func (m *SSHManager) watchClient(connKey string, client *ssh.Client) {
 	ticker := time.NewTicker(sshKeepaliveInterval)
 	defer ticker.Stop()
+	fails := 0
 	for range ticker.C {
-		if !m.checkClientKeepalive(connKey, client, sshKeepaliveTimeout) {
+		tracked, probeOK := m.checkClientKeepalive(connKey, client, sshKeepaliveTimeout)
+		var stop bool
+		fails, stop = m.handleKeepaliveProbeResult(connKey, client, fails, tracked, probeOK)
+		if stop {
 			return
 		}
 	}
 }
 
-func (m *SSHManager) checkClientKeepalive(connKey string, client *ssh.Client, timeout time.Duration) bool {
+// handleKeepaliveProbeResult 根据单次探活结果更新连续失败计数。
+// 返回 (新失败次数, 是否结束 watch)。达 sshKeepaliveFailMax 才拆共享连接。
+func (m *SSHManager) handleKeepaliveProbeResult(connKey string, client *ssh.Client, fails int, tracked, probeOK bool) (int, bool) {
+	if !tracked {
+		return fails, true
+	}
+	if probeOK {
+		return 0, false
+	}
+	fails++
+	if fails >= sshKeepaliveFailMax {
+		m.cleanupClientTransport(connKey, client, "keepalive")
+		return fails, true
+	}
+	return fails, false
+}
+
+// checkClientKeepalive 发起一次 SSH 层探活。
+// tracked=false：该 client 已不在 map（停止 watch，勿重复 cleanup）。
+// tracked=true 且 probeOK=true：通路正常（含服务端拒绝未知 keepalive 名但仍有响应）。
+// tracked=true 且 probeOK=false：超时或传输错误——不在此处拆线，由 watch 累计失败。
+func (m *SSHManager) checkClientKeepalive(connKey string, client *ssh.Client, timeout time.Duration) (tracked bool, probeOK bool) {
 	m.mu.RLock()
 	entry, ok := m.clients[connKey]
 	if !ok || entry.Client != client || entry.NetConn == nil {
 		m.mu.RUnlock()
-		return false
+		return false, false
 	}
 	m.mu.RUnlock()
 
@@ -672,15 +699,49 @@ func (m *SSHManager) checkClientKeepalive(connKey string, client *ssh.Client, ti
 			current, currentOK := m.clients[connKey]
 			alive := currentOK && current.Client == client
 			m.mu.RUnlock()
-			return alive
+			if !alive {
+				return false, false
+			}
+			return true, true
 		}
+		// 有响应但 request 失败（如未知类型被拒）：golang.org/x/crypto/ssh 对 want-reply
+		// 被拒通常仍 err==nil 且 reply=false；若将来变成 err，仍视为通路可达。
+		m.mu.RLock()
+		current, currentOK := m.clients[connKey]
+		alive := currentOK && current.Client == client
+		m.mu.RUnlock()
+		if !alive {
+			return false, false
+		}
+		// 传输层错误（连接已断）→ 计失败；纯协议拒绝在 SendRequest 成功路径已覆盖。
+		if isSSHKeepaliveTransportError(err) {
+			return true, false
+		}
+		return true, true
 	case <-timer.C:
+		m.mu.RLock()
+		current, currentOK := m.clients[connKey]
+		alive := currentOK && current.Client == client
+		m.mu.RUnlock()
+		if !alive {
+			return false, false
+		}
+		return true, false
 	}
-	m.cleanupClientTransport(connKey, client)
-	return false
 }
 
-func (m *SSHManager) cleanupClientTransport(connKey string, client *ssh.Client) {
+func isSSHKeepaliveTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// 连接已死、reset、EOF 等：算探活失败。其它错误偏协议层，保守当通路仍在。
+	return isTransientNetError(err) ||
+		errors.Is(err, io.EOF) ||
+		strings.Contains(err.Error(), "connection lost") ||
+		strings.Contains(err.Error(), "use of closed network connection")
+}
+
+func (m *SSHManager) cleanupClientTransport(connKey string, client *ssh.Client, reason string) {
 	m.mu.Lock()
 	entry, ok := m.clients[connKey]
 	if !ok || entry.Client != client {
@@ -699,22 +760,94 @@ func (m *SSHManager) cleanupClientTransport(connKey string, client *ssh.Client) 
 	delete(m.probeFailed, connKey)
 	m.mu.Unlock()
 
+	if reason == "" {
+		reason = "transport"
+	}
 	if netConn != nil {
 		_ = netConn.Close()
 	}
+	// 静默拆各终端 session，再发一次「整机连接断开」事件，避免 N 次误报
+	parentSessionId := ""
 	for _, terminalId := range terminalIds {
-		m.disconnectAndNotify(terminalId)
+		if parentSessionId == "" {
+			parentSessionId = m.sessionParentID(terminalId)
+		}
+		_ = m.Disconnect(terminalId)
 	}
 	if sftpClient != nil {
 		closeWithTimeout(sftpClient, 3*time.Second)
 	}
 	closeWithTimeout(client, 3*time.Second)
+
+	if m.ctx != nil && len(terminalIds) > 0 {
+		if parentSessionId == "" {
+			parentSessionId = terminalIds[0]
+		}
+		runtime.EventsEmit(m.ctx, "ssh-disconnected", map[string]interface{}{
+			"sessionId":         terminalIds[0],
+			"parentSessionId":   parentSessionId,
+			"terminalIds":       terminalIds,
+			"reason":            reason,
+			"connectionClosed":  true,
+		})
+	}
 }
 
-func (m *SSHManager) disconnectAndNotify(sessionId string) {
-	if m.Disconnect(sessionId) && m.ctx != nil {
-		runtime.EventsEmit(m.ctx, "ssh-disconnected", sessionId)
+// sessionParentID 返回前端 tab 用的父会话 id（子终端用 GroupSessionId）。
+func (m *SSHManager) sessionParentID(sessionId string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if s, ok := m.sessions[sessionId]; ok {
+		if s.GroupSessionId != "" {
+			return s.GroupSessionId
+		}
+		return sessionId
 	}
+	return sessionId
+}
+
+// disconnectAndNotify 结束单个 terminal 并通知前端。
+// reason=session_end：shell 正常/异常退出；connectionClosed 表示是否同时拆掉了共享 TCP。
+func (m *SSHManager) disconnectAndNotify(sessionId string, reason string) {
+	if reason == "" {
+		reason = "session_end"
+	}
+	parentSessionId := m.sessionParentID(sessionId)
+
+	m.mu.RLock()
+	s, ok := m.sessions[sessionId]
+	connKey := ""
+	terminalsBefore := 0
+	if ok {
+		connKey = s.ConnKey
+		terminalsBefore = len(m.connTerminals[connKey])
+	}
+	m.mu.RUnlock()
+
+	if !m.Disconnect(sessionId) {
+		return
+	}
+	if m.ctx == nil {
+		return
+	}
+
+	connectionClosed := false
+	if ok && connKey != "" {
+		m.mu.RLock()
+		_, clientAlive := m.clients[connKey]
+		terminalsAfter := len(m.connTerminals[connKey])
+		m.mu.RUnlock()
+		// 断开前是该连接上最后一个终端，或 client 已不在
+		connectionClosed = !clientAlive || (terminalsBefore > 0 && terminalsAfter == 0)
+	}
+
+	runtime.EventsEmit(m.ctx, "ssh-disconnected", map[string]interface{}{
+		"sessionId":        sessionId,
+		"parentSessionId":  parentSessionId,
+		"terminalIds":      []string{sessionId},
+		"reason":           reason,
+		"connectionClosed": connectionClosed,
+	})
 }
 
 func (m *SSHManager) pipeOutput(sessionId string, r io.Reader, historyStream *commandHistoryStream) {

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -114,7 +114,7 @@ func newTestSSHClient(t *testing.T, reply *bool) (*ssh.Client, net.Conn) {
 	return client, clientConn
 }
 
-func TestClientKeepaliveTimeoutCleansSharedConnection(t *testing.T) {
+func TestClientKeepaliveTimeoutDoesNotCleanOnSingleFailure(t *testing.T) {
 	client, netConn := newTestSSHClient(t, nil)
 	manager := NewSSHManager()
 	manager.clients["server"] = &sshClientEntry{Client: client, NetConn: netConn}
@@ -123,15 +123,64 @@ func TestClientKeepaliveTimeoutCleansSharedConnection(t *testing.T) {
 	manager.sessions["terminal-2"] = &SessionData{ConnKey: "server"}
 
 	started := time.Now()
-	if manager.checkClientKeepalive("server", client, 50*time.Millisecond) {
-		t.Fatal("无响应的保活不应被判定为存活")
-	}
+	tracked, probeOK := manager.checkClientKeepalive("server", client, 50*time.Millisecond)
 	if time.Since(started) > time.Second {
 		t.Fatal("保活超时未在限定时间内结束")
+	}
+	if !tracked || probeOK {
+		t.Fatalf("无响应超时应 tracked=true probeOK=false，实际 tracked=%v probeOK=%v", tracked, probeOK)
+	}
+	fails, stop := manager.handleKeepaliveProbeResult("server", client, 0, tracked, probeOK)
+	if stop || fails != 1 {
+		t.Fatalf("单次失败不应拆线: fails=%d stop=%v", fails, stop)
+	}
+	if len(manager.clients) != 1 || len(manager.sessions) != 2 {
+		t.Fatalf("单次超时不应清理连接: clients=%d sessions=%d", len(manager.clients), len(manager.sessions))
+	}
+}
+
+func TestClientKeepaliveConsecutiveFailuresCleanSharedConnection(t *testing.T) {
+	client, netConn := newTestSSHClient(t, nil)
+	manager := NewSSHManager()
+	manager.clients["server"] = &sshClientEntry{Client: client, NetConn: netConn}
+	manager.connTerminals["server"] = []string{"terminal-1", "terminal-2"}
+	manager.sessions["terminal-1"] = &SessionData{ConnKey: "server"}
+	manager.sessions["terminal-2"] = &SessionData{ConnKey: "server"}
+
+	fails := 0
+	for i := 0; i < sshKeepaliveFailMax; i++ {
+		tracked, probeOK := manager.checkClientKeepalive("server", client, 50*time.Millisecond)
+		if !tracked || probeOK {
+			t.Fatalf("第 %d 次超时期望 tracked=true probeOK=false", i+1)
+		}
+		var stop bool
+		fails, stop = manager.handleKeepaliveProbeResult("server", client, fails, tracked, probeOK)
+		if i < sshKeepaliveFailMax-1 {
+			if stop {
+				t.Fatalf("第 %d 次失败不应结束 watch", i+1)
+			}
+			continue
+		}
+		if !stop || fails < sshKeepaliveFailMax {
+			t.Fatalf("达到失败阈值应拆线: fails=%d stop=%v", fails, stop)
+		}
 	}
 	if len(manager.clients) != 0 || len(manager.connTerminals) != 0 || len(manager.sessions) != 0 {
 		t.Fatalf("连接清理不完整: clients=%d terminals=%d sessions=%d", len(manager.clients), len(manager.connTerminals), len(manager.sessions))
 	}
+}
+
+func TestHandleKeepaliveProbeResultResetsOnSuccess(t *testing.T) {
+	manager := NewSSHManager()
+	fails, stop := manager.handleKeepaliveProbeResult("server", nil, 2, true, true)
+	if stop || fails != 0 {
+		t.Fatalf("探活成功应清零失败计数: fails=%d stop=%v", fails, stop)
+	}
+	fails, stop = manager.handleKeepaliveProbeResult("server", nil, 1, false, false)
+	if !stop {
+		t.Fatal("未跟踪的 client 应结束 watch")
+	}
+	_ = fails
 }
 
 func TestClientKeepaliveRejectionKeepsConnection(t *testing.T) {
@@ -142,8 +191,13 @@ func TestClientKeepaliveRejectionKeepsConnection(t *testing.T) {
 	manager.connTerminals["server"] = []string{"terminal"}
 	manager.sessions["terminal"] = &SessionData{ConnKey: "server"}
 
-	if !manager.checkClientKeepalive("server", client, time.Second) {
-		t.Fatal("服务端拒绝未知保活请求仍应证明 SSH 传输存活")
+	tracked, probeOK := manager.checkClientKeepalive("server", client, time.Second)
+	if !tracked || !probeOK {
+		t.Fatalf("服务端拒绝未知保活请求仍应证明 SSH 传输存活: tracked=%v probeOK=%v", tracked, probeOK)
+	}
+	fails, stop := manager.handleKeepaliveProbeResult("server", client, 2, tracked, probeOK)
+	if stop || fails != 0 {
+		t.Fatalf("成功探活后不应拆线: fails=%d stop=%v", fails, stop)
 	}
 	if manager.clients["server"].Client != client || manager.sessions["terminal"] == nil {
 		t.Fatal("成功收到保活响应后不应清理连接")
@@ -183,7 +237,7 @@ func TestStaleClientCleanupKeepsReplacement(t *testing.T) {
 	manager.connTerminals["server"] = []string{"terminal"}
 	manager.sessions["terminal"] = &SessionData{ConnKey: "server"}
 
-	manager.cleanupClientTransport("server", oldClient)
+	manager.cleanupClientTransport("server", oldClient, "transport")
 	if manager.clients["server"].Client != newClient || manager.sessions["terminal"] == nil {
 		t.Fatal("旧连接的迟到清理不应删除快速重连后的新连接")
 	}


### PR DESCRIPTION
放宽应用层保活并连续失败才拆线；重连前先清理旧会话；
断开事件区分整机意外与单终端结束；直连/HTTP 拨号启用 TCP KeepAlive。