### PR TITLE
fix(pc): 批量连接时主机密钥确认与密码输入改为跟随终端

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import { useTranslation } from './i18n.js';
 import { getTerminalTheme, hexToRgb } from './utils/theme.js';
 import { formatUpdateError, useUpdateChecker } from './hooks/useUpdateChecker.js';
 import ConnectingCard from './components/ConnectingCard.jsx';
+import SessionAuthCard from './components/SessionAuthCard.jsx';
 import UpdateModal from './components/UpdateModal.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import SerialConfigModal from './components/SerialConfigModal.jsx';
@@ -517,6 +518,20 @@ export default function App() {
   const [sshChannelUsage, setSshChannelUsage] = useState({}); // sessionId -> { terminals, sharedSftp, uploadPool, total, maxSessions }
   const connectingServersRef = useRef([]);
   useEffect(() => { connectingServersRef.current = connectingServers; }, [connectingServers]);
+  // 会话内待处理的交互：主机密钥确认 / 认证失败重输密码。
+  // 按 sessionId 分键，批量连接时每个会话各自渲染一张卡片，不再走全局单例弹窗。
+  const [sessionAuthPrompts, setSessionAuthPrompts] = useState({}); // sessionId -> { kind, title, message, ... }
+  // 同一会话可能连续多次要求输入（密码输错重试），token 递增作为 React key，
+  // 强制重建卡片，避免复用旧实例导致输入框残留旧值 / 提交守卫失效。
+  const authPromptTokenRef = useRef(0);
+  const clearSessionAuthPrompt = useCallback((sessionId) => {
+    setSessionAuthPrompts((prev) => {
+      if (!prev[sessionId]) return prev;
+      const next = { ...prev };
+      delete next[sessionId];
+      return next;
+    });
+  }, []);
   const [toasts, setToasts] = useState([]);
   const TOAST_EXIT_DURATION = 1080;
   const toastIdRef = useRef(0);
@@ -2708,7 +2723,8 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     setActiveSessionId(null);
     setActiveTerminalId(null);
     setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-  }, [disconnectSessionTerminals, registerServerDisconnect]);
+    clearSessionAuthPrompt(sessionId);
+  }, [clearSessionAuthPrompt, disconnectSessionTerminals, registerServerDisconnect]);
 
   // ── 切换到下一个可用 session ──────────────────────────────
   const resolveSessionContentTab = useCallback((sessionId) => {
@@ -3180,15 +3196,54 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     };
   }, [addToast, t]);
 
+  // ── 主机密钥确认：用户在会话卡片上做出选择后 ──────────────────
+  // chosen: 0=取消, 1=仅本次接受, 2=接受并保存
+  const resolveHostKeyChoice = useCallback(async (sessionId, chosen) => {
+    clearSessionAuthPrompt(sessionId);
+    try {
+      await AppGo.AcceptHostKeyChange(sessionId, chosen);
+      if (chosen >= 1) {
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === sessionId ? { ...s, status: 'connected' } : s
+          )
+        );
+        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+        addToast(
+          chosen === 2 ? t('主机密钥已保存，连接成功') : t('本次已接受，连接成功'),
+          'success'
+        );
+
+        const matched = sessionsRef.current.find((s) => s.id === sessionId);
+        await postConnectSetup(sessionId, matched?.serverId);
+      } else {
+        updateSessionStatus(sessionId, 'error');
+        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+        addToast(t('用户取消连接'), 'warning', 3000);
+      }
+    } catch (err) {
+      // 取消分支后端固定返回「用户取消了主机密钥验证」，属预期结果，不作失败提示
+      if (chosen >= 1) {
+        addToast(`${t('连接失败')}: ${err}`, 'error', 5000);
+      } else {
+        addToast(t('用户取消连接'), 'warning', 3000);
+      }
+      updateSessionStatus(sessionId, 'error');
+      setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+    }
+  }, [addToast, clearSessionAuthPrompt, postConnectSetup, t, updateSessionStatus]);
+
   // ── 监听主机密钥变更事件 ────────────────────────────────────
+  // 只写入该会话的待确认状态，由会话面板内的 SessionAuthCard 呈现，
+  // 批量连接时 N 台主机就有 N 张卡片，各自独立。
   useEffect(() => {
-    const unbind = EventsOn('ssh-host-key-changed', async (data) => {
+    const unbind = EventsOn('ssh-host-key-changed', (data) => {
       const {
-        sessionId, hostname, host, port, newFingerprint, oldFingerprints, isNew
+        sessionId, host, port, newFingerprint, oldFingerprints, isNew
       } = data;
 
       const oldFpList = (oldFingerprints || []).join('\n');
-      const msg = isNew
+      const message = isNew
         ? [
             t('首次连接到此主机，请确认密钥指纹：'),
             ``,
@@ -3213,107 +3268,89 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
             t('如果确认这是预期的变更（如服务器重装），点击"接受并保存"。'),
           ].join('\n');
 
-      const action = await window.luminDialog?.choice?.(
-        msg,
-        isNew ? t('主机密钥确认') : t('主机密钥已变更'),
-        [
-          { label: t('只接受本次'), value: 1, secondary: true },
-          { label: t('接受并保存'), value: 2, primary: true },
-          { label: t('取消'), value: 0, secondary: true },
-        ]
-      );
-
-      // action: 0/取消或null → 取消连接, 1 → 仅本次, 2 → 保存
-      const chosen = action ?? 0;
-
-      try {
-        await AppGo.AcceptHostKeyChange(sessionId, chosen);
-        if (chosen >= 1) {
-          setSessions((prev) =>
-            prev.map((s) =>
-              s.id === sessionId ? { ...s, status: 'connected' } : s
-            )
-          );
-          setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-          addToast(
-            chosen === 2 ? t('主机密钥已保存，连接成功') : t('本次已接受，连接成功'),
-            'success'
-          );
-
-          const matched = sessionsRef.current.find((s) => s.id === sessionId);
-          await postConnectSetup(sessionId, matched?.serverId);
-        } else {
-          updateSessionStatus(sessionId, 'error');
-          setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        }
-      } catch (err) {
-        updateSessionStatus(sessionId, 'error');
-        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        addToast(`${t('连接失败')}: ${err}`, 'error', 5000);
-      }
+      setSessionAuthPrompts((prev) => ({
+        ...prev,
+        [sessionId]: {
+          kind: 'hostkey',
+          token: ++authPromptTokenRef.current,
+          title: isNew ? t('主机密钥确认') : t('主机密钥已变更'),
+          message,
+          danger: !isNew, // 密钥变更（疑似中间人）默认焦点落在「取消」
+        },
+      }));
     });
     return () => {
       if (unbind) unbind();
     };
-  }, [addToast, postConnectSetup, t]);
+  }, [t]);
+
+  // ── 认证失败：用户在会话卡片上重输密码后 ──────────────────
+  // result: null=取消 | { value, persist }
+  const resolvePasswordPrompt = useCallback(async (sessionId, connId, result) => {
+    clearSessionAuthPrompt(sessionId);
+    if (result === null) {
+      // 用户取消
+      updateSessionStatus(sessionId, 'error');
+      setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      addToast(t('用户取消连接'), 'warning', 3000);
+      return;
+    }
+
+    const { value: newPassword, persist } = result;
+    if (!newPassword) {
+      updateSessionStatus(sessionId, 'error');
+      setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      return;
+    }
+
+    try {
+      await AppGo.ReconnectWithPassword(sessionId, connId, newPassword, persist);
+      setSessions((prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, status: 'connected' } : s))
+      );
+      setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      addToast(persist ? t('密码已保存，连接成功') : t('连接成功'), 'success', 3000);
+
+      await postConnectSetup(sessionId, connId, { password: newPassword });
+    } catch (retryErr) {
+      updateSessionStatus(sessionId, 'error');
+      setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
+      addToast(`${t('重新连接失败')}: ${String(retryErr)}`, 'error', 5000);
+    }
+  }, [addToast, clearSessionAuthPrompt, postConnectSetup, t, updateSessionStatus]);
 
   // ── 监听认证失败事件（密码错误等） ──────────────────────────
+  // 只写入该会话的待确认状态，由会话面板内的 SessionAuthCard 呈现
   useEffect(() => {
-    const unbind = EventsOn('ssh-auth-failed', async (data) => {
+    const unbind = EventsOn('ssh-auth-failed', (data) => {
       const { sessionId, connId, host, port, username, error } = data;
       const usesCredential = serversRef.current.some(s => s.id === connId && s.credentialId);
 
-      const password = await window.luminDialog?.prompt?.(
-        [
-          t('认证失败，请输入正确的密码重试：'),
-          ``,
-          `${t('主机:')} ${host}:${port}`,
-          `${t('用户')}: ${username}`,
-          ``,
-          `${t('错误')}: ${error}`,
-        ].join('\n'),
-        '',
-        t('认证失败'),
-        usesCredential ? t('更新凭据密码') : t('记住密码')
-      );
+      const message = [
+        t('认证失败，请输入正确的密码重试：'),
+        ``,
+        `${t('主机:')} ${host}:${port}`,
+        `${t('用户')}: ${username}`,
+        ``,
+        `${t('错误')}: ${error}`,
+      ].join('\n');
 
-      if (password === null) {
-        // 用户取消
-        updateSessionStatus(sessionId, 'error');
-        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        addToast(t('用户取消连接'), 'warning', 3000);
-        return;
-      }
-
-      const newPassword = typeof password === 'object' ? password.value : password;
-      const persist = typeof password === 'object' ? password.checked : false;
-
-      if (!newPassword) {
-        updateSessionStatus(sessionId, 'error');
-        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        return;
-      }
-
-      try {
-        await AppGo.ReconnectWithPassword(sessionId, connId, newPassword, persist);
-        setSessions((prev) =>
-          prev.map((s) => (s.id === sessionId ? { ...s, status: 'connected' } : s))
-        );
-        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        addToast(persist ? t('密码已保存，连接成功') : t('连接成功'), 'success', 3000);
-
-        await postConnectSetup(sessionId, connId, { password: newPassword });
-
-        } catch (retryErr) {
-        updateSessionStatus(sessionId, 'error');
-        setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
-        addToast(`${t('重新连接失败')}: ${String(retryErr)}`, 'error', 5000);
-      }
+      setSessionAuthPrompts((prev) => ({
+        ...prev,
+        [sessionId]: {
+          kind: 'password',
+          token: ++authPromptTokenRef.current,
+          title: t('认证失败'),
+          message,
+          connId,
+          checkboxLabel: usesCredential ? t('更新凭据密码') : t('记住密码'),
+        },
+      }));
     });
     return () => {
       if (unbind) unbind();
     };
-  }, [addToast]);
+  }, [t]);
 
   // ── 关闭窗口通用处理 ──────────────────────────────────────────
   const handleCloseWindow = useCallback(async () => {
@@ -3747,7 +3784,8 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     if (connectingServersRef.current.some((s) => s.sessionId === sessionId)) {
       setConnectingServers((prev) => prev.filter((s) => s.sessionId !== sessionId));
     }
-  }, [disconnectSessionTerminals, persistServerWorkspaceSessionSnapshot, registerServerDisconnect, switchToNextSession]);
+    clearSessionAuthPrompt(sessionId);
+  }, [clearSessionAuthPrompt, disconnectSessionTerminals, persistServerWorkspaceSessionSnapshot, registerServerDisconnect, switchToNextSession]);
 
   const closeSession = useCallback(async (sessionId, e) => {
     e?.stopPropagation();
@@ -3794,6 +3832,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
     setActiveSessionId(null);
     setActiveTerminalId(null);
     setConnectingServers([]);
+    setSessionAuthPrompts({});
   }, [disconnectSessionTerminals, persistServerWorkspaceSessionSnapshot, registerServerDisconnect, t]);
 
   // ── 在当前服务器上新建终端标签 ──────────────────────────────
@@ -5847,7 +5886,12 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                         });
                       }}
                     >
-                      <span className={`status-dot ${s.status === 'connecting' ? 'connecting' : s.status === 'connected' ? 'online' : 'offline'}`} />
+                      <span
+                        className={`status-dot ${sessionAuthPrompts[s.id] ? 'attention' : s.status === 'connecting' ? 'connecting' : s.status === 'connected' ? 'online' : 'offline'}`}
+                        role={sessionAuthPrompts[s.id] ? 'img' : undefined}
+                        aria-label={sessionAuthPrompts[s.id] ? sessionAuthPrompts[s.id].title : undefined}
+                        title={sessionAuthPrompts[s.id] ? sessionAuthPrompts[s.id].title : undefined}
+                      />
                       {(() => {
                         const usage = sshChannelUsage[s.id];
                         if (!usage || usage.total <= 0 || s.status !== 'connected') return null;
@@ -6432,6 +6476,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                       && fileManagerPosition === 'tab'
                       && contentTab === 'files';
                     const sessionConnectingServer = connectingServers.find((item) => item.sessionId === s.id) || null;
+                    const sessionAuthPrompt = sessionAuthPrompts[s.id] || null;
                     const showLeftFileManager = showSplitFileManager && fileManagerPosition === 'left' && !fileManagerCollapsed;
                     const showRightFileManager = showSplitFileManager && fileManagerPosition === 'right' && !fileManagerCollapsed;
                     const showSideFileManager = showLeftFileManager || showRightFileManager;
@@ -6873,11 +6918,27 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                               />
                             </div>
                           )}
-                          {sessionConnectingServer && s.status === 'connecting' && (
+                          {/* 有待确认交互时让位给 SessionAuthCard，二者 z-index 相同不可重叠 */}
+                          {sessionConnectingServer && s.status === 'connecting' && !sessionAuthPrompt && (
                             <ConnectingCard
                               connectingServer={sessionConnectingServer}
                               t={t}
                               onCancel={() => handleCancelConnection(s.id)}
+                            />
+                          )}
+                          {sessionAuthPrompt && (
+                            <SessionAuthCard
+                              key={sessionAuthPrompt.token}
+                              prompt={sessionAuthPrompt}
+                              isActive={activeSessionId === s.id}
+                              t={t}
+                              onResolve={(result) => {
+                                if (sessionAuthPrompt.kind === 'password') {
+                                  void resolvePasswordPrompt(s.id, sessionAuthPrompt.connId, result);
+                                } else {
+                                  void resolveHostKeyChoice(s.id, result);
+                                }
+                              }}
                             />
                           )}
                         </div>
@@ -7511,7 +7572,7 @@ const getFileManagerDockConfirmRect = useCallback((target) => {
                   onClick={() => { handleTabClick(s.id); setShowSessionList(false); }}
                   style={{ fontWeight: activeSessionId === s.id ? 700 : 400, color: activeSessionId === s.id ? 'var(--accent)' : 'var(--text-secondary)' }}
                 >
-                  <span className={`status-dot ${s.status === 'connecting' ? 'connecting' : s.status === 'connected' ? 'online' : 'offline'}`} />
+                  <span className={`status-dot ${sessionAuthPrompts[s.id] ? 'attention' : s.status === 'connecting' ? 'connecting' : s.status === 'connected' ? 'online' : 'offline'}`} />
                   <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.serverName}</span>
                   <Tiptop text={t('关闭')} placement="bottom">
                     <span

--- a/frontend/src/components/GlobalDialog.jsx
+++ b/frontend/src/components/GlobalDialog.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Eye, EyeOff, Clipboard } from 'lucide-react';
 import { useTranslation, t } from '../i18n.js';
 import Tiptop from './Tiptop.jsx';
@@ -6,6 +6,22 @@ import { Z } from '../constants/zIndex';
 
 export default function GlobalDialog() {
   const [dialogs, setDialogs] = useState([]);
+  // ponytail: 队列同时存一份 ref。去重判定必须同步进行——同一 tick 内连续调用时
+  // state 尚未更新，只比对 state 会漏判；ref 与 state 始终同步写入，二者不会漂移。
+  const dialogsRef = useRef([]);
+
+  // 入队；命中去重返回 false。调用方据此立即 resolve，避免 Promise 永久挂起。
+  const pushDialog = useCallback((dialog, isDuplicate) => {
+    if (dialogsRef.current.some(isDuplicate)) return false;
+    dialogsRef.current = [...dialogsRef.current, dialog];
+    setDialogs(dialogsRef.current);
+    return true;
+  }, []);
+
+  const shiftDialog = useCallback(() => {
+    dialogsRef.current = dialogsRef.current.slice(1);
+    setDialogs(dialogsRef.current);
+  }, []);
 
   useEffect(() => {
     // 注册全局 API
@@ -13,79 +29,70 @@ export default function GlobalDialog() {
       alert: (message, title = t('提示'), options = {}) => {
         const normalizedMessage = typeof message === 'string' ? message : String(message ?? '');
         return new Promise((resolve) => {
-          setDialogs(prev => {
-            if (prev.some(d => d.type === 'alert' && d.message === normalizedMessage && d.title === title)) return prev;
-            return [...prev, {
-              id: Date.now() + Math.random(),
-              type: 'alert',
-              title,
-              message: normalizedMessage,
-              copyable: options?.copyable !== false,
-              onClose: () => resolve()
-            }];
-          });
+          const queued = pushDialog({
+            id: Date.now() + Math.random(),
+            type: 'alert',
+            title,
+            message: normalizedMessage,
+            copyable: options?.copyable !== false,
+            onClose: () => resolve()
+          }, d => d.type === 'alert' && d.message === normalizedMessage && d.title === title);
+          if (!queued) resolve();
         });
       },
       confirm: (message, title = t('操作确认'), checkboxLabel = '') => {
         return new Promise((resolve) => {
-          setDialogs(prev => {
-            // 防止重复弹窗
-            if (prev.some(d => d.type === 'confirm' && d.message === message)) return prev;
-            return [...prev, {
-              id: Date.now() + Math.random(),
-              type: 'confirm',
-              title,
-              message,
-              checkboxLabel,
-              onConfirm: (_, checked) => resolve(checkboxLabel ? { confirmed: true, checked } : true),
-              onCancel: () => resolve(checkboxLabel ? { confirmed: false, checked: false } : false)
-            }];
-          });
+          const queued = pushDialog({
+            id: Date.now() + Math.random(),
+            type: 'confirm',
+            title,
+            message,
+            checkboxLabel,
+            onConfirm: (_, checked) => resolve(checkboxLabel ? { confirmed: true, checked } : true),
+            onCancel: () => resolve(checkboxLabel ? { confirmed: false, checked: false } : false)
+          }, d => d.type === 'confirm' && d.message === message);
+          // 去重丢弃按「取消」处理：不确认即不执行破坏性操作
+          if (!queued) resolve(checkboxLabel ? { confirmed: false, checked: false } : false);
         });
       },
       prompt: (message, defaultValue = '', title = t('输入信息'), checkboxLabel = '', options = {}) => {
         return new Promise((resolve) => {
-          setDialogs(prev => {
-            if (prev.some(d => d.type === 'prompt' && d.message === message)) return prev;
-            return [...prev, {
-              id: Date.now() + Math.random(),
-              type: 'prompt',
-              title,
-              message,
-              defaultValue,
-              checkboxLabel,
-              inputType: options?.inputType === 'password' ? 'password' : 'text',
-              // validate(value) => null/undefined 通过；返回字符串则保留弹窗并展示错误
-              validate: typeof options?.validate === 'function' ? options.validate : null,
-              onConfirm: (val, checked) => resolve(checkboxLabel ? { value: val, checked } : val),
-              onCancel: () => resolve(null)
-            }];
-          });
+          const queued = pushDialog({
+            id: Date.now() + Math.random(),
+            type: 'prompt',
+            title,
+            message,
+            defaultValue,
+            checkboxLabel,
+            inputType: options?.inputType === 'password' ? 'password' : 'text',
+            // validate(value) => null/undefined 通过；返回字符串则保留弹窗并展示错误
+            validate: typeof options?.validate === 'function' ? options.validate : null,
+            onConfirm: (val, checked) => resolve(checkboxLabel ? { value: val, checked } : val),
+            onCancel: () => resolve(null)
+          }, d => d.type === 'prompt' && d.message === message);
+          if (!queued) resolve(null);
         });
       },
       choice: (message, title, buttons, checkboxLabel = '') => {
         return new Promise((resolve) => {
-          setDialogs(prev => {
-            // 防止重复弹窗
-            if (prev.some(d => d.type === 'choice' && d.title === title)) return prev;
-            return [...prev, {
-              id: Date.now() + Math.random(),
-              type: 'choice',
-              title,
-              message,
-              buttons,
-              checkboxLabel,
-              onChoice: (val, checked) => resolve(checkboxLabel ? { value: val, checked } : val),
-              onClose: () => resolve(null)
-            }];
-          });
+          const queued = pushDialog({
+            id: Date.now() + Math.random(),
+            type: 'choice',
+            title,
+            message,
+            buttons,
+            checkboxLabel,
+            onChoice: (val, checked) => resolve(checkboxLabel ? { value: val, checked } : val),
+            onClose: () => resolve(null)
+          }, d => d.type === 'choice' && d.title === title);
+          if (!queued) resolve(null);
         });
       }
     };
     return () => {
       delete window.luminDialog;
     };
-  }, []);
+  }, [pushDialog]);
 
   if (dialogs.length === 0) return null;
 
@@ -94,17 +101,17 @@ export default function GlobalDialog() {
   const handleClose = () => {
     if (current.onClose) current.onClose();
     if (current.onCancel && current.type !== 'alert') current.onCancel();
-    setDialogs(prev => prev.slice(1));
+    shiftDialog();
   };
 
   const handleConfirm = (val, checked) => {
     if (current.onConfirm) current.onConfirm(val, checked);
-    setDialogs(prev => prev.slice(1));
+    shiftDialog();
   };
 
   const handleChoice = (val, checked) => {
     if (current.onChoice) current.onChoice(val, checked);
-    setDialogs(prev => prev.slice(1));
+    shiftDialog();
   };
 
   return (

--- a/frontend/src/components/SessionAuthCard.jsx
+++ b/frontend/src/components/SessionAuthCard.jsx
@@ -1,0 +1,242 @@
+import { useEffect, useRef, useState } from 'react';
+import { ShieldAlert, ShieldQuestion, KeyRound, Eye, EyeOff, Clipboard } from 'lucide-react';
+import { Z } from '../constants/zIndex';
+import { getThemeComponentTheme } from '../utils/theme.js';
+
+// 会话内的交互卡片：主机密钥确认 / 认证失败重输密码。
+// 与 ConnectingCard 同一挂载点、同一配色，每个会话各自渲染一张，
+// 因此批量连接时 N 个会话会得到 N 张卡片，互不干扰。
+export default function SessionAuthCard({ prompt, isActive, t, onResolve }) {
+  const C = getThemeComponentTheme('connectingCard');
+  const isPassword = prompt.kind === 'password';
+  const [value, setValue] = useState('');
+  const [checked, setChecked] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [focusIdx, setFocusIdx] = useState(0);
+  const inputRef = useRef(null);
+  // 卡片卸载前可能连收两次回车/双击，onResolve 会调后端，必须只生效一次
+  const resolvedRef = useRef(false);
+
+  const buttons = isPassword
+    ? [
+        { label: t('确定'), value: 'ok', primary: true },
+        { label: t('取消'), value: 'cancel' },
+      ]
+    : [
+        { label: t('只接受本次'), value: 1 },
+        { label: t('接受并保存'), value: 2, primary: true },
+        { label: t('取消'), value: 0 },
+      ];
+
+  // 密钥已变更（可能中间人）时默认落在「取消」，避免回车误接受；首次连接落在主按钮
+  useEffect(() => {
+    if (isPassword) {
+      setFocusIdx(0);
+      return;
+    }
+    if (prompt.danger) {
+      setFocusIdx(2);
+      return;
+    }
+    setFocusIdx(1);
+  }, [isPassword, prompt.danger]);
+
+  useEffect(() => {
+    if (!isPassword || !isActive) return undefined;
+    // 非活动会话的祖先为 display:none，autoFocus 无效，切回时再聚焦
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [isPassword, isActive]);
+
+  const canSubmit = !isPassword || value.length > 0;
+
+  const submit = (btnValue) => {
+    if (resolvedRef.current) return;
+    if (!isPassword) {
+      resolvedRef.current = true;
+      onResolve(btnValue);
+      return;
+    }
+    if (btnValue === 'cancel') {
+      resolvedRef.current = true;
+      onResolve(null);
+      return;
+    }
+    if (!value) return;
+    resolvedRef.current = true;
+    onResolve({ value, persist: checked });
+  };
+
+  useEffect(() => {
+    if (!isActive) return undefined;
+    const handleKeyDown = (e) => {
+      // ponytail: 全局弹窗（GlobalDialog / 各类 Modal）打开时让位，避免 Esc/Enter 被双重处理
+      if (document.querySelector('.modal-overlay')) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        submit(isPassword ? 'cancel' : 0);
+        return;
+      }
+      if (!isPassword && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+        e.preventDefault();
+        setFocusIdx((prev) => {
+          const n = buttons.length;
+          return e.key === 'ArrowLeft' ? (prev - 1 + n) % n : (prev + 1) % n;
+        });
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        if (isPassword) {
+          submit('ok');
+          return;
+        }
+        const btn = buttons[focusIdx] || buttons[0];
+        submit(btn.value);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+  }, [isActive, isPassword, focusIdx, value, checked]);
+
+  const pasteFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        setValue(text);
+        return;
+      }
+    } catch {}
+    try {
+      const { ClipboardGetText } = await import('../../wailsjs/runtime/runtime.js');
+      const text = await ClipboardGetText();
+      if (text) setValue(text);
+    } catch {}
+  };
+
+  const Icon = isPassword ? KeyRound : prompt.danger ? ShieldAlert : ShieldQuestion;
+  const iconBg = isPassword || !prompt.danger
+    ? 'rgba(var(--warning-rgb), 0.85)'
+    : 'rgba(var(--danger-rgb), 0.85)';
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, zIndex: Z.FULLSCREEN_OVERLAY,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: C.overlayBg,
+    }}>
+      <div style={{
+        width: 440, maxWidth: 'calc(100% - 32px)', borderRadius: 16, overflow: 'hidden',
+        background: C.popupBg,
+        border: '1px solid ' + C.btnBorder,
+        boxShadow: C.contextShadow,
+        padding: '20px 24px 22px',
+      }}>
+        {/* 标题行 */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 16 }}>
+          <div style={{
+            width: 42, height: 42, borderRadius: 10, flexShrink: 0,
+            background: iconBg,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}><Icon size={22} style={{ color: '#fff' }} /></div>
+          <div style={{ fontSize: 15, fontWeight: 700, color: C.inputColor, minWidth: 0 }}>
+            {prompt.title}
+          </div>
+        </div>
+
+        {/* 正文（含指纹 / 错误详情） */}
+        <div style={{
+          fontSize: 12.5,
+          color: C.statusBarColor,
+          lineHeight: 1.65,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          overflowWrap: 'anywhere',
+          userSelect: 'text',
+          maxHeight: '38vh',
+          overflowY: 'auto',
+          marginBottom: 18,
+        }}>
+          {prompt.message}
+        </div>
+
+        {isPassword && (
+          <>
+            <div style={{ position: 'relative', marginBottom: prompt.checkboxLabel ? 12 : 18 }}>
+              <input
+                ref={inputRef}
+                className="input"
+                type={showPassword ? 'text' : 'password'}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder={t('请输入密码')}
+                style={{ width: '100%', fontSize: 14, padding: '10px 68px 10px 14px' }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? t('隐藏密码') : t('显示密码')}
+                title={showPassword ? t('隐藏密码') : t('显示密码')}
+                style={{
+                  position: 'absolute', right: 38, top: '50%', transform: 'translateY(-50%)',
+                  background: 'none', border: 'none', color: C.mutedColor, cursor: 'pointer',
+                  padding: 4, display: 'flex', alignItems: 'center', borderRadius: 4,
+                }}
+              >{showPassword ? <EyeOff size={16} /> : <Eye size={16} />}</button>
+              <button
+                type="button"
+                onClick={pasteFromClipboard}
+                aria-label={t('粘贴')}
+                title={t('粘贴')}
+                style={{
+                  position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)',
+                  background: 'none', border: 'none', color: C.mutedColor, cursor: 'pointer',
+                  padding: 4, display: 'flex', alignItems: 'center', borderRadius: 4,
+                }}
+              ><Clipboard size={16} /></button>
+            </div>
+            {prompt.checkboxLabel && (
+              <label style={{
+                display: 'flex', alignItems: 'center', gap: 8, marginBottom: 18,
+                fontSize: 12.5, color: C.statusBarColor, cursor: 'pointer',
+              }}>
+                <input type="checkbox" checked={checked} onChange={(e) => setChecked(e.target.checked)} />
+                {prompt.checkboxLabel}
+              </label>
+            )}
+          </>
+        )}
+
+        {/* 操作按钮 */}
+        <div style={{ display: 'flex', gap: 8 }}>
+          {buttons.map((btn, i) => {
+            const disabled = btn.value === 'ok' && !canSubmit;
+            return (
+              <button
+                key={i}
+                type="button"
+                disabled={disabled}
+                onClick={() => submit(btn.value)}
+                onMouseEnter={() => setFocusIdx(i)}
+                style={{
+                  flex: 1, padding: '9px 0', fontSize: 12.5, borderRadius: 8,
+                  cursor: disabled ? 'not-allowed' : 'pointer',
+                  opacity: disabled ? 0.5 : 1,
+                  background: btn.primary ? 'var(--accent)' : C.buttonBg,
+                  border: '1px solid ' + (btn.primary ? 'var(--accent)' : C.btnBorder),
+                  color: btn.primary ? '#fff' : C.buttonTextColor,
+                  outline: focusIdx === i ? '2px solid var(--accent)' : 'none',
+                  outlineOffset: 2,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {btn.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -778,10 +778,22 @@ input::-ms-clear {
   animation: pulse-warning 1s infinite;
 }
 .status-dot.just-connected { background: var(--success); }
+/* 等待用户确认（主机密钥 / 重输密码）：非活动标签页也能看出哪个会话在等输入。
+   连接中已是「警告色 + 透明度脉冲」，这里用不透明实心点 + 扩散光环区分开。 */
+.status-dot.attention {
+  background: var(--warning);
+  animation: pulse-attention 1.4s ease-out infinite;
+}
 
 @keyframes pulse-warning {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
+}
+
+@keyframes pulse-attention {
+  0%   { box-shadow: 0 0 0 0 rgba(var(--warning-rgb), 0.55); }
+  70%  { box-shadow: 0 0 0 5px rgba(var(--warning-rgb), 0); }
+  100% { box-shadow: 0 0 0 0 rgba(var(--warning-rgb), 0); }
 }
 
 /* ── 模态框 ─────────────────────────────────────────────────── */
@@ -5034,12 +5046,17 @@ body.theme-light .dashboard-server-editor {
   .status-dot.just-connected,
   .status-dot.online,
   .status-dot.connecting,
+  .status-dot.attention,
   .modal,
   .modal-overlay,
   .tab-context-menu,
   .update-bubble,
   .update-bubble-pulse {
     animation: none;
+  }
+  /* 动画关闭后 .attention 会与 .connecting 长得一样，用静态光环保留区分 */
+  .status-dot.attention {
+    box-shadow: 0 0 0 3px rgba(var(--warning-rgb), 0.35);
   }
   .file-list-body-live.switch-waiting {
     opacity: 0;


### PR DESCRIPTION
批量连接多台服务器时只弹出一个主机密钥确认框，其余会话永久卡在
「连接中」；密码重试框同样如此。

根因在 GlobalDialog 的去重：choice 只比对 title，批量连接时 N 台
主机的 title 全相同，第 1 个入队、其余被 return prev 丢弃，且
Promise 从未 resolve。于是 await 永久挂起，AcceptHostKeyChange 永不调用，后端 pendingHostKeys 条目也一直不清。prompt 按 message
去重，同服务器重复连接时同样中招。后端本就按 sessionId 分键，无需
改动。

- 新增 SessionAuthCard，按 ConnectingCard 的范式渲染在各自会话 面板内，状态按 sessionId 分键，从结构上消除去重与丢弃
- 两个事件监听改为只写 state，选择后的逻辑抽为 resolveHostKeyChoice / resolvePasswordPrompt
- 标签页新增 attention 提醒点。connecting 已是「警告色+透明度脉冲」， 故用扩散光环区分；reduced-motion 下动画被禁用，补静态光环保留区分
- GlobalDialog 去重命中时改为立即 resolve，把永久挂起变为确定结果； 去重判定改用 ref 同步进行，避免同一 tick 内连发漏判
- 密钥已变更（疑似中间人）时默认焦点落在「取消」，避免回车误接受
- prompt 带递增 token 作 React key，避免密码输错重试时复用旧卡片 实例导致提交守卫失效