### PR TITLE
添加自动安装unzip支持 && 移除端口映射自动监听

### DIFF
--- a/app.go
+++ b/app.go
@@ -1010,6 +1010,11 @@ func (a *App) UncompressItem(sessionId string, remotePath string) error {
 	return a.sshManager.UncompressItemWithStrategy(sessionId, remotePath, strategy)
 }
 
+// InstallUnzip installs the unzip utility on the remote server.
+func (a *App) InstallUnzip(sessionId string) error {
+	return a.sshManager.InstallUnzip(sessionId)
+}
+
 // UploadLocalFile uploads a local file to a remote directory (no dialog)
 func (a *App) UploadLocalFile(sessionId string, localFile string, remoteDir string) error {
 	return a.sshManager.UploadFile(sessionId, localFile, remoteDir)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -562,13 +562,17 @@ export default function App() {
   const [showPortForwardDialog, setShowPortForwardDialog] = useState(false);
   const [portForwardDialogSessionId, setPortForwardDialogSessionId] = useState(null);
   const [portForwardInitialMapping, setPortForwardInitialMapping] = useState(null);
-  const [portListeningEnabled, setPortListeningEnabled] = useState(
-    () => localStorage.getItem('portForwardRealtimeListening') === 'true'
-  );
+  // 自动监听尚不稳定，暂时强制关闭，避免已保存的设置重新启用它。
+  const [portListeningEnabled, setPortListeningEnabled] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('portForwardRealtimeListening', 'false');
+  }, []);
 
   const handlePortListeningEnabledChange = useCallback((enabled) => {
-    setPortListeningEnabled(enabled);
-    localStorage.setItem('portForwardRealtimeListening', enabled ? 'true' : 'false');
+    // 保留接口，待自动监听稳定后再开放；当前不允许重新开启。
+    setPortListeningEnabled(false);
+    localStorage.setItem('portForwardRealtimeListening', 'false');
   }, []);
 
   const openPortForwardDialog = useCallback((sessionId, port = null) => {

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -78,6 +78,12 @@ function fmtDate(ts) {
   });
 }
 
+function isMissingUnzipError(error) {
+  const message = String(error || '').toLowerCase();
+  return /(?:bash|sh):\s*unzip:\s*command not found/.test(message)
+    || (message.includes('unzip') && message.includes('status 127'));
+}
+
 // 文件图标（颜色统一走 CSS 变量，浅/深色主题一致切换）
 const ICON_SIZE = 16;
 function fileIcon(name, isDir, isSymlink = false) {
@@ -5297,6 +5303,7 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
   const handleUncompress = async (item, options = {}) => {
     const basePath = typeof options === 'string' ? options : (options.basePath || currentPath);
     const remotePath = joinPath(basePath, item.name);
+    const isZip = String(item.name || '').toLowerCase().endsWith('.zip');
     try {
       const previewSmartUncompressItem = window?.go?.main?.App?.PreviewSmartUncompressItem;
       const uncompressItemWithStrategy = window?.go?.main?.App?.UncompressItemWithStrategy;
@@ -5333,7 +5340,28 @@ export default function FileManager({ sessionId, sessionGroupId = sessionId, add
         await loadDir(currentPathRef.current, { preserveView: true, showLoading: false });
       }
     } catch (err) {
-      addToast(`${t('解压失败')}: ${err}`, 'error');
+      if (!isZip || !isMissingUnzipError(err)) {
+        addToast(`${t('解压失败')}: ${err}`, 'error');
+        return;
+      }
+      const confirmed = await window.luminDialog?.confirm?.(
+        t('服务器未安装 unzip，无法解压 ZIP 文件。是否自动安装 unzip？'),
+        t('缺少 unzip')
+      );
+      if (!confirmed) return;
+      try {
+        addToast(t('正在自动安装 unzip...'), 'info');
+        await AppGo.InstallUnzip(sessionId);
+        addToast(t('unzip 安装成功，正在重新解压...'), 'info');
+        await handleUncompress(item, options);
+      } catch (installErr) {
+        const message = t('自动安装 unzip 失败，请手动解压');
+        if (typeof window.luminDialog?.alert === 'function') {
+          await window.luminDialog.alert(message, t('解压失败'));
+        } else {
+          addToast(message, 'error');
+        }
+      }
     }
   };
 

--- a/frontend/src/components/PortForwardDialog.jsx
+++ b/frontend/src/components/PortForwardDialog.jsx
@@ -135,13 +135,14 @@ export default function PortForwardDialog({
                         <div style={{ color: 'var(--text-secondary)', fontSize: '0.92rem' }}>
                             {t('本地端口映射到远程；远程端口映射到本地。')}
                         </div>
-                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, color: 'var(--text-secondary)', fontSize: 13, cursor: 'pointer' }}>
+                        <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, color: 'var(--text-tertiary)', fontSize: 13, cursor: 'not-allowed' }}>
                             <input
                                 type="checkbox"
                                 checked={portListeningEnabled}
                                 onChange={(event) => onPortListeningEnabledChange?.(event.target.checked)}
+                                disabled
                             />
-                            {t('命令后实时检测新增监听端口')}
+                            {t('命令后实时检测新增监听端口（暂已关闭）')}
                         </label>
                     </div>
                     <button className="btn btn-ghost btn-sm" type="button" onClick={onClose} aria-label={t('关闭')}>

--- a/ssh.go
+++ b/ssh.go
@@ -4311,6 +4311,37 @@ func (m *SSHManager) UncompressItem(sessionId string, remotePath string) error {
 	return m.UncompressItemWithStrategy(sessionId, remotePath, smartUncompressConflictStrategyAutoRename)
 }
 
+// InstallUnzip installs unzip using the package manager available on the remote host.
+// Non-root users must have passwordless sudo because this temporary SSH session cannot
+// provide an interactive password prompt.
+func (m *SSHManager) InstallUnzip(sessionId string) error {
+	client, _, err := m.getClientEntry(sessionId)
+	if err != nil {
+		return err
+	}
+	cmd := `if [ "$(id -u)" -eq 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -n"; else echo "root privileges or passwordless sudo are required" >&2; exit 1; fi
+if command -v apt-get >/dev/null 2>&1; then $SUDO apt-get update && $SUDO apt-get install -y unzip
+elif command -v dnf >/dev/null 2>&1; then $SUDO dnf install -y unzip
+elif command -v yum >/dev/null 2>&1; then $SUDO yum install -y unzip
+elif command -v apk >/dev/null 2>&1; then $SUDO apk add unzip
+elif command -v zypper >/dev/null 2>&1; then $SUDO zypper --non-interactive install unzip
+elif command -v pacman >/dev/null 2>&1; then $SUDO pacman --noconfirm -S unzip
+else echo "no supported package manager found" >&2; exit 1
+fi
+command -v unzip >/dev/null 2>&1`
+	// Package-index refreshes can take longer than regular file-manager commands.
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+	out, err := runCommandWithSessionContext(context.Background(), session, cmd, 5*time.Minute)
+	if err != nil {
+		return fmt.Errorf("install unzip failed: %w, output: %s", err, out)
+	}
+	return nil
+}
+
 func (m *SSHManager) UncompressUploadedArchive(sessionId string, remotePath string) error {
 	client, _, err := m.getClientEntry(sessionId)
 	if err != nil {


### PR DESCRIPTION
端口映射自动监听当前方案可能导致显示一整页 暂时移除

使用过程中发现unzip未安装时会报错 添加了自动安装逻辑
<img width="1440" height="900" alt="f21bf07c143c04db99c457105cfaa065" src="https://github.com/user-attachments/assets/f16be02d-2aac-4400-8e33-9f35d9b28ff8" />
