### PR TITLE
fix(pc): 修复浅色模式下 nano 快捷键栏/粘贴高亮黑字黑底不可见

### DIFF
--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -22,7 +22,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n.js';
 import defaultTermBg from '../assets/term_bg.webp';
 import { Z } from '../constants/zIndex';
-import { getTerminalTheme, getAppThemeMode, isDarkTerminalSurface } from '../utils/theme.js';
+import { getTerminalTheme, getAppThemeMode, isDarkTerminalSurface, getSolidTerminalBackground } from '../utils/theme.js';
 import { getResolvedProgramFontPreferences } from '../utils/programFonts.js';
 
 const textDecoder = new TextDecoder();
@@ -1170,8 +1170,9 @@ export default function Terminal({
     const fontSize = parseInt(localStorage.getItem('terminalFontSize') || '13', 10);
 
     const term = new XTerm({
-      // background 保持透明，让底层主题色 + 壁纸透出来
-      theme:            T.xterm,
+      // background 用不透明的容器底色：nano/vim 的反转显示（SGR 7）需要真实的背景色参与
+      // 互换，透明底会退化成黑字黑底；壁纸/色调层改为叠在内容上方保持观感
+      theme:            { ...T.xterm, background: getSolidTerminalBackground(T) },
       fontFamily:       getResolvedProgramFontPreferences().terminalFontFamily,
       fontSize:         fontSize,
       fontWeight:       500,
@@ -1184,7 +1185,6 @@ export default function Terminal({
       cursorStyle:      'bar',
       cursorWidth:      1,
       scrollback:       5000,
-      allowTransparency: true,
       // SearchAddon 高亮装饰依赖 proposed API
       allowProposedApi: true,
       fastScrollModifier: 'alt',
@@ -1890,8 +1890,9 @@ export default function Terminal({
   useEffect(() => {
     const term = termRef.current;
     if (term) {
-      // xterm 背景保持透明，底色由 wrapper(--term-container-bg) 提供，壁纸才能叠在上面
+      // xterm 背景用不透明容器底色（反转显示需要真实背景色），壁纸/色调层叠在内容上方
       const xtermTheme = { ...T.xterm };
+      xtermTheme.background = getSolidTerminalBackground(T);
       const darkTerm = isDarkTerminalSurface(T);
       // 搜索/选区当前匹配常走 selectionForeground：深色终端强制白字，浅色终端强制深字
       xtermTheme.selectionForeground = darkTerm ? '#ffffff' : '#0f172a';
@@ -3088,15 +3089,15 @@ export default function Terminal({
         overflow: 'hidden',
       }}
     >
-      {/* 主题色调层：深色下拉开 Lumin/Tokyo/Catppuccin/Dracula 差异 */}
+      {/* 主题色调层：xterm 背景已不透明，叠在内容上方才能生效（弹出层 fixed+zIndex 更高，不受影响） */}
       <div style={{
         position: 'absolute',
         inset: 0,
         background: 'var(--term-tint, transparent)',
         pointerEvents: 'none',
-        zIndex: Z.BG,
+        zIndex: Z.STACK,
       }} />
-      {/* 壁纸层：正常叠加，保留质感 */}
+      {/* 壁纸层：叠在内容上方，保留质感 */}
       <div style={{
         position: 'absolute',
         inset: 0,
@@ -3105,7 +3106,7 @@ export default function Terminal({
         backgroundPosition: 'center',
         opacity: Number.isFinite(bgInfo.opacity) ? bgInfo.opacity : 0.15,
         pointerEvents: 'none',
-        zIndex: Z.BG,
+        zIndex: Z.STACK,
       }} />
       
       {/* 内容层（置于背景之上) */}

--- a/frontend/src/utils/theme.js
+++ b/frontend/src/utils/theme.js
@@ -969,6 +969,25 @@ function relativeLuminanceFromThemeColor(value) {
   return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
 }
 
+// 颜色是否为「全透明」值（#00000000 / 任意 alpha=0 的 8 位 hex / rgba(...,0) / transparent）
+function isFullyTransparentColor(value) {
+  const raw = String(value || '').trim();
+  if (!raw || raw.toLowerCase() === 'transparent') return true;
+  if (/^#[\da-f]{8}$/i.test(raw)) return raw.slice(7).toLowerCase() === '00';
+  return /rgba\([^)]*,\s*0(?:\.0+)?\s*\)$/i.test(raw);
+}
+
+// xterm 的默认背景必须是不透明色：nano/vim 等 TUI 的反转显示（SGR 7，如 nano 底部
+// 快捷键栏、粘贴/选区高亮）会用主题 background 与前景互换；若 background 是透明值，
+// 互换结果退化成黑色，浅色模式下出现「黑字黑底」完全不可见
+export function getSolidTerminalBackground(terminalTheme) {
+  const xterm = terminalTheme?.xterm || {};
+  const container = terminalTheme?.container || {};
+  if (!isFullyTransparentColor(xterm.background)) return xterm.background;
+  if (!isFullyTransparentColor(container.containerBg)) return container.containerBg;
+  return isDarkTerminalSurface(terminalTheme) ? '#0e1218' : '#f3f4f6';
+}
+
 // 按终端输出区底色判断深浅（不要看 inputBar：浅色 UI 会改成浅色 chrome）
 export function isDarkTerminalSurface(terminalTheme) {
   const container = terminalTheme?.container || {};


### PR DESCRIPTION
## 问题

- 浅色模式下打开 nano，底部快捷键栏（`^G Help`、`^O Write Out` 等）整条黑字黑底，完全不可见
- 从剪切板粘贴大段文本进 nano 时，粘贴区域同样呈现黑字黑底（类似坏掉的选中状态）
- 深色模式下是同一个问题，只是黑底叠在深色底上不易察觉

## 根因

nano/vim 等 TUI 的快捷键栏、粘贴/选区高亮使用反转显示（SGR 7），终端需要用主题的默认背景色与前景色互换来渲染。本应用为了让壁纸透出，把 xterm 背景设为全透明（`#00000000`），互换时「背景色」退化成黑色，于是浅色模式下出现黑字黑底。

## 修复方案

- `frontend/src/utils/theme.js`：新增 `getSolidTerminalBackground()`，解析出一个不透明背景色（xterm.background → container.containerBg → 按终端深浅兜底）
- `frontend/src/components/Terminal.jsx`：创建 xterm 实例与主题热切换时均用该不透明底色作为主题背景，反转显示即可用真实背景色参与互换
- 壁纸层与色调层相应从内容下方移到内容上方，保持原有壁纸/色调观感（历史指令、命令补全、右键菜单等弹层均为 fixed 定位 + 更高 z-index，不受影响）
- 移除不再需要的 `allowTransparency`

## 验证

- 前端 vite 构建通过
- 建议复测：浅色主题下打开 nano 查看底部快捷键栏是否可读；粘贴大段文本确认内容可见

## 细微观感变化

壁纸层上移到内容上方后，终端状态栏/搜索栏/命令输入条也会叠上壁纸（默认 15% 不透明度），与原先「壁纸半透明叠在上面」的设计意图一致。
