### PR TITLE
fix: 修复 Ubuntu GNOME X11 单实例唤起主窗口失败 & CI rpm 打包

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# 强制 Linux 打包相关脚本使用 LF 换行：
+# CRLF 会让 shell 把 \r 当成命令的一部分，导致 postinst/spec/desktop 在 Linux 上执行失败。
+build/linux/postinst text eol=lf
+build/linux/postrm   text eol=lf
+build/linux/lumin.spec text eol=lf
+build/linux/lumin.desktop text eol=lf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,29 @@ jobs:
           sudo chown root:root build/deb/usr/bin/lumin
           cp build/appicon.png build/deb/usr/share/icons/hicolor/256x256/apps/lumin.png
           cp build/linux/lumin.desktop build/deb/usr/share/applications/lumin.desktop
+          # postinst/postrm：安装后刷新桌面数据库与图标缓存，避免 GNOME 菜单项/图标不生效
+          cat > build/deb/DEBIAN/postinst <<'POSTINST'
+          #!/bin/sh
+          set -e
+          if command -v update-desktop-database >/dev/null 2>&1; then
+            update-desktop-database -q /usr/share/applications || true
+          fi
+          if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+            gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+          fi
+          POSTINST
+          cat > build/deb/DEBIAN/postrm <<'POSTRM'
+          #!/bin/sh
+          set -e
+          if command -v update-desktop-database >/dev/null 2>&1; then
+            update-desktop-database -q /usr/share/applications || true
+          fi
+          if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+            gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+          fi
+          POSTRM
+          sudo chmod 755 build/deb/DEBIAN/postinst build/deb/DEBIAN/postrm
+          sudo chown root:root build/deb/DEBIAN/postinst build/deb/DEBIAN/postrm
           sudo dpkg-deb --root-owner-group --build build/deb "build/Lumin-V${VERSION}-amd64.deb"
           shasum -a 256 "build/Lumin-V${VERSION}-amd64.deb" | sed 's|build/||' > "build/Lumin-V${VERSION}-amd64.deb.sha256"
           echo "deb=${{ github.workspace }}/build/Lumin-V${VERSION}-amd64.deb" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           sudo apt-get install -y \
             libgtk-3-dev libwebkit2gtk-4.1-dev libglib2.0-dev \
             libc6-dev libayatana-appindicator3-dev \
-            rpm alien fakeroot upx-ucl
+            rpm upx-ucl
 
       - uses: actions/setup-go@v7
         with:
@@ -148,6 +148,7 @@ jobs:
         env:
           VERSION: ${{ needs.create-draft.outputs.version }}
         run: |
+          # ===== .deb =====
           mkdir -p build/deb/DEBIAN
           mkdir -p build/deb/usr/bin
           mkdir -p build/deb/usr/share/applications
@@ -168,47 +169,44 @@ jobs:
           sudo chown root:root build/deb/usr/bin/lumin
           cp build/appicon.png build/deb/usr/share/icons/hicolor/256x256/apps/lumin.png
           cp build/linux/lumin.desktop build/deb/usr/share/applications/lumin.desktop
-          # postinst/postrm：安装后刷新桌面数据库与图标缓存，避免 GNOME 菜单项/图标不生效
-          cat > build/deb/DEBIAN/postinst <<'POSTINST'
-          #!/bin/sh
-          set -e
-          if command -v update-desktop-database >/dev/null 2>&1; then
-            update-desktop-database -q /usr/share/applications || true
-          fi
-          if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-            gtk-update-icon-cache -q /usr/share/icons/hicolor || true
-          fi
-          POSTINST
-          cat > build/deb/DEBIAN/postrm <<'POSTRM'
-          #!/bin/sh
-          set -e
-          if command -v update-desktop-database >/dev/null 2>&1; then
-            update-desktop-database -q /usr/share/applications || true
-          fi
-          if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-            gtk-update-icon-cache -q /usr/share/icons/hicolor || true
-          fi
-          POSTRM
+          # postinst/postrm 用独立脚本文件安装（不用 heredoc）：
+          # heredoc 顶格会破坏 YAML 结构，带缩进又会破坏 shebang，两者无法兼得。
+          cp build/linux/postinst build/deb/DEBIAN/postinst
+          cp build/linux/postrm build/deb/DEBIAN/postrm
           sudo chmod 755 build/deb/DEBIAN/postinst build/deb/DEBIAN/postrm
           sudo chown root:root build/deb/DEBIAN/postinst build/deb/DEBIAN/postrm
           sudo dpkg-deb --root-owner-group --build build/deb "build/Lumin-V${VERSION}-amd64.deb"
           shasum -a 256 "build/Lumin-V${VERSION}-amd64.deb" | sed 's|build/||' > "build/Lumin-V${VERSION}-amd64.deb.sha256"
           echo "deb=${{ github.workspace }}/build/Lumin-V${VERSION}-amd64.deb" >> $GITHUB_ENV
           echo "deb_sha=${{ github.workspace }}/build/Lumin-V${VERSION}-amd64.deb.sha256" >> $GITHUB_ENV
-          sudo alien -r "build/Lumin-V${VERSION}-amd64.deb" --scripts || echo "alien_rpm_failed=true" >> $GITHUB_ENV
-          RPM_FILE=$(find . -name "*.rpm" 2>/dev/null | head -1)
-          if [ -n "$RPM_FILE" ]; then
-            mv "$RPM_FILE" build/
-            RPM_BASENAME=$(basename "$RPM_FILE")
-            RPM_BASENAME_CLEAN=$(echo "$RPM_BASENAME" | sed "s/lumin-[0-9.]\+-\([0-9]\+\)\.x86_64\.rpm/Lumin-V${VERSION}-amd64.rpm/")
-            if [ "$RPM_BASENAME" != "$RPM_BASENAME_CLEAN" ] && [ -f "build/$RPM_BASENAME" ]; then
-              mv "build/$RPM_BASENAME" "build/$RPM_BASENAME_CLEAN"
-              RPM_BASENAME="$RPM_BASENAME_CLEAN"
-            fi
-            shasum -a 256 "build/$RPM_BASENAME" | sed 's|build/||' > "build/$RPM_BASENAME.sha256"
-            echo "rpm=${{ github.workspace }}/build/$RPM_BASENAME" >> $GITHUB_ENV
-            echo "rpm_sha=${{ github.workspace }}/build/$RPM_BASENAME.sha256" >> $GITHUB_ENV
+
+          # ===== .rpm（rpmbuild 原生构建，不再依赖 alien 转换）=====
+          RPM_TOPDIR="$HOME/rpmbuild"
+          mkdir -p "${RPM_TOPDIR}/SOURCES" "${RPM_TOPDIR}/SPECS" "${RPM_TOPDIR}/BUILD" "${RPM_TOPDIR}/RPMS" "${RPM_TOPDIR}/SRPMS"
+          cp build/bin/Lumin "${RPM_TOPDIR}/SOURCES/Lumin"
+          cp build/appicon.png "${RPM_TOPDIR}/SOURCES/appicon.png"
+          cp build/linux/lumin.desktop "${RPM_TOPDIR}/SOURCES/lumin.desktop"
+          cp build/linux/lumin.spec "${RPM_TOPDIR}/SPECS/lumin.spec"
+          # rpm Version 字段不允许 '-'（它是 Version/Release 的分隔符）：
+          # 把 1.2.6-test-ipc 拆成 Version=1.2.6, Release=1.test_ipc
+          VER_RAW="${VERSION#V}"
+          RPM_VER="${VER_RAW%%-*}"
+          RPM_REL_SUFFIX="${VER_RAW#*-}"
+          if [ "${RPM_REL_SUFFIX}" = "${VER_RAW}" ]; then
+            RPM_RELEASE="1"
+          else
+            RPM_RELEASE="1.$(echo "${RPM_REL_SUFFIX}" | sed 's/[^a-zA-Z0-9.]/_/g')"
           fi
+          rpmbuild -bb "${RPM_TOPDIR}/SPECS/lumin.spec" \
+            --define "lum_version ${RPM_VER}" \
+            --define "lum_release ${RPM_RELEASE}" \
+            --define "_topdir ${RPM_TOPDIR}" \
+            --target x86_64
+          BUILT_RPM=$(find "${RPM_TOPDIR}/RPMS" -name "lumin-*.x86_64.rpm" | head -1)
+          cp "${BUILT_RPM}" "build/Lumin-V${VERSION}-amd64.rpm"
+          shasum -a 256 "build/Lumin-V${VERSION}-amd64.rpm" | sed 's|build/||' > "build/Lumin-V${VERSION}-amd64.rpm.sha256"
+          echo "rpm=${{ github.workspace }}/build/Lumin-V${VERSION}-amd64.rpm" >> $GITHUB_ENV
+          echo "rpm_sha=${{ github.workspace }}/build/Lumin-V${VERSION}-amd64.rpm.sha256" >> $GITHUB_ENV
 
       - name: Upload to Draft Release
         env:
@@ -216,14 +214,10 @@ jobs:
           TAG: ${{ needs.create-draft.outputs.tag }}
         run: |
           set -euo pipefail
-          files=("${binary}" "${binary_sha}" "${deb}" "${deb_sha}")
-          if [ -n "${rpm:-}" ] && [ -f "${rpm}" ]; then
-            files+=("${rpm}" "${rpm_sha}")
-          fi
           gh release upload "${TAG}" \
             --repo "${{ github.repository }}" \
             --clobber \
-            "${files[@]}"
+            "${binary}" "${binary_sha}" "${deb}" "${deb_sha}" "${rpm}" "${rpm_sha}"
 
   build-macos:
     needs: create-draft

--- a/build/linux/lumin.desktop
+++ b/build/linux/lumin.desktop
@@ -2,8 +2,10 @@
 Name=Lumin SSH Client
 Comment=Lightweight SSH Client
 Exec=lumin
+TryExec=/usr/bin/lumin
 Icon=lumin
 Terminal=false
 Type=Application
 Categories=Network;RemoteAccess;
+StartupNotify=true
 StartupWMClass=Lumin

--- a/build/linux/lumin.spec
+++ b/build/linux/lumin.spec
@@ -1,0 +1,45 @@
+# RPM 构建规格：Lumin SSH Client
+# 由 CI 用 rpmbuild 原生构建，不依赖 alien 转换。
+# CI 把 VERSION 按 rpm 规则拆成 lum_version / lum_release 注入。
+
+Name:           lumin
+Version:        %{lum_version}
+Release:        %{lum_release}%{?dist}
+Summary:        Lightweight SSH Client
+License:        proprietary
+URL:            https://github.com/wmwlwmwl/Lumin-SSH
+Packager:       Lumin <admin@662662.xyz>
+# rpm 依赖用较通用的包名（覆盖 Fedora/openSUSE 等）。
+Requires:       gtk3
+Requires:       webkit2gtk3
+Requires:       glib2
+Requires:       libayatana-appindicator
+BuildArch:      x86_64
+
+%description
+A modern, lightweight SSH client built with Wails.
+Quickly manage and connect to your SSH servers.
+
+%install
+install -D -m 0755 %{_sourcedir}/Lumin %{buildroot}%{_bindir}/lumin
+install -D -m 0644 %{_sourcedir}/appicon.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/lumin.png
+install -D -m 0644 %{_sourcedir}/lumin.desktop %{buildroot}%{_datadir}/applications/lumin.desktop
+
+%files
+%{_bindir}/lumin
+%{_datadir}/icons/hicolor/256x256/apps/lumin.png
+%{_datadir}/applications/lumin.desktop
+
+# 等价于 deb 的 postinst：安装后刷新桌面数据库与图标缓存
+%post
+update-desktop-database -q %{_datadir}/applications || :
+gtk-update-icon-cache -q %{_datadir}/icons/hicolor || :
+
+# 等价于 deb 的 postrm：卸载后刷新
+%postun
+update-desktop-database -q %{_datadir}/applications || :
+gtk-update-icon-cache -q %{_datadir}/icons/hicolor || :
+
+%changelog
+* Thu Aug 7 2026 Lumin <admin@662662.xyz> - 1.0.0-1
+- Initial RPM build via rpmbuild (replaces alien conversion).

--- a/build/linux/postinst
+++ b/build/linux/postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+fi

--- a/build/linux/postrm
+++ b/build/linux/postrm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -q /usr/share/icons/hicolor || true
+fi

--- a/main.go
+++ b/main.go
@@ -109,9 +109,14 @@ func main() {
 			// 先挂托盘：startup 里 MCP 等可能阻塞，托盘若排后面会出现「窗口已能关到托盘但图标很久才出」。
 			app.ctx = ctx
 			startSystray(app)
+			// 启动单实例 socket：二次启动会发 show 指令，经 forceShowWindow 走托盘同一路径唤起主窗口。
+			startSingletonServer(func() {
+				forceShowWindow(app.ctx)
+			})
 			app.startup(ctx)
 		},
 		OnShutdown: func(ctx context.Context) {
+			stopSingletonServer()
 			stopMCPServer(app)
 			cleanupTray()
 		},

--- a/platform_darwin.go
+++ b/platform_darwin.go
@@ -5,9 +5,11 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
@@ -19,10 +21,28 @@ var icon []byte
 // singletonLock holds the lock file descriptor to prevent GC from closing it
 var singletonLock *os.File
 
-// findAndShowWindow 在 macOS 上为空实现
-func findAndShowWindow() {}
+// singletonSocketPath 是单实例 IPC 用的 Unix Domain Socket 路径。
+const singletonSocketPath = "lumin-ssh.sock"
 
-// platformForceShowWindow macOS 暂无原生兜底，依赖 Wails WindowShow
+// singletonShowWindow 收到二次启动信号时被 main 注入：
+// 主进程通过 Wails runtime 唤起自己的主窗口（与托盘点击同路径）。
+var singletonShowWindow func()
+
+// singletonSocketListener 主实例持有的 socket 监听器，退出时关闭。
+var singletonSocketListener net.Listener
+
+// findAndShowWindow 二次启动时调用：通知已运行的主实例显示窗口。
+func findAndShowWindow() {
+	conn, err := net.DialTimeout("unix", singleInstanceSocketPath(), 2*time.Second)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_, _ = conn.Write([]byte("show\n"))
+}
+
+// platformForceShowWindow macOS 暂无原生兜底，依赖 Wails WindowShow（托盘路径已覆盖）
 func platformForceShowWindow() {}
 
 // removeTrayIconSync Windows 幽灵托盘修复专用；macOS 无此问题
@@ -31,9 +51,66 @@ func removeTrayIconSync() {}
 // platformPrepareTrayMenu Windows 托盘右键菜单前台解锁专用；macOS 无此问题
 func platformPrepareTrayMenu() {}
 
+// singleInstanceSocketPath 返回 socket 文件路径（与 lock 文件同目录，区分用户避免多用户冲突）。
+func singleInstanceSocketPath() string {
+	if runDir := os.Getenv("XDG_RUNTIME_DIR"); runDir != "" {
+		return filepath.Join(runDir, singletonSocketPath)
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("lumin-ssh-%d.sock", os.Getuid()))
+}
+
+// startSingletonServer 在主实例上启动 Unix Socket 监听，
+// 二次启动的实例会连接并发送 "show" 指令，此处回调 showFn 显示主窗口。
+// showFn 通常包装 runtime.WindowShow（与托盘点击同路径）。
+func startSingletonServer(showFn func()) {
+	socketPath := singleInstanceSocketPath()
+	_ = os.Remove(socketPath) // 清理上次崩溃残留
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return
+	}
+	singletonSocketListener = l
+	singletonShowWindow = showFn
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // listener 已关闭
+			}
+			go handleSingletonConn(conn)
+		}
+	}()
+}
+
+// handleSingletonConn 读取一帧指令并执行，处理完即关闭连接。
+func handleSingletonConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	buf := make([]byte, 16)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _ := conn.Read(buf)
+	cmd := string(buf[:n])
+	switch cmd {
+	case "show\n", "show":
+		if singletonShowWindow != nil {
+			singletonShowWindow()
+		}
+	}
+}
+
+// stopSingletonServer 关闭并清理 socket（主实例退出时调用）。
+func stopSingletonServer() {
+	if singletonSocketListener != nil {
+		_ = singletonSocketListener.Close()
+		singletonSocketListener = nil
+	}
+	_ = os.Remove(singleInstanceSocketPath())
+}
+
 // ensureSingleInstance 使用 flock 检查是否已有实例运行（macOS 支持 flock）
 func ensureSingleInstance() {
-	lockFile := filepath.Join(os.TempDir(), "lumin-ssh.lock")
+	lockFile := filepath.Join(os.TempDir(), fmt.Sprintf("lumin-ssh-%d.lock", os.Getuid()))
 	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return

--- a/platform_unix.go
+++ b/platform_unix.go
@@ -5,9 +5,11 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
@@ -18,10 +20,31 @@ var icon []byte
 // singletonLock holds the lock file descriptor to prevent GC from closing it
 var singletonLock *os.File
 
-// findAndShowWindow 在 Linux 上为空实现
-func findAndShowWindow() {}
+// singletonSocketPath 是单实例 IPC 用的 Unix Domain Socket 路径。
+// 与 flock 锁放在同一目录，目录受 $TMPDIR / 系统管理，权限 0700 足够。
+const singletonSocketPath = "lumin-ssh.sock"
 
-// platformForceShowWindow Linux 暂无原生兜底，依赖 Wails WindowShow
+// singletonShowWindow 收到二次启动信号时被 main 注入：
+// 主进程通过 Wails runtime 唤起自己的主窗口（与托盘点击同路径）。
+var singletonShowWindow func()
+
+// singletonSocketListener 主实例持有的 socket 监听器，退出时关闭。
+var singletonSocketListener net.Listener
+
+// findAndShowWindow 二次启动时调用：通知已运行的主实例显示窗口。
+// 主实例在 ensureSingleInstance 拿到锁后会启动 socket server，
+// 二实例连进来发 "show\n"，主实例回调 singletonShowWindow。
+func findAndShowWindow() {
+	conn, err := net.DialTimeout("unix", singleInstanceSocketPath(), 2*time.Second)
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_, _ = conn.Write([]byte("show\n"))
+}
+
+// platformForceShowWindow Linux 暂无原生兜底，依赖 Wails WindowShow（托盘路径已覆盖）
 func platformForceShowWindow() {}
 
 // removeTrayIconSync Windows 幽灵托盘修复专用；Linux 无此问题
@@ -30,9 +53,18 @@ func removeTrayIconSync() {}
 // platformPrepareTrayMenu Windows 托盘右键菜单前台解锁专用；Linux 无此问题
 func platformPrepareTrayMenu() {}
 
-// ensureSingleInstance 使用 flock 检查是否已有实例运行
+// singleInstanceSocketPath 返回 socket 文件路径（与 lock 文件同目录，区分用户避免多用户冲突）。
+func singleInstanceSocketPath() string {
+	if runDir := os.Getenv("XDG_RUNTIME_DIR"); runDir != "" {
+		return filepath.Join(runDir, singletonSocketPath)
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("lumin-ssh-%d.sock", os.Getuid()))
+}
+
+// ensureSingleInstance 使用 flock 检查是否已有实例运行。
+// 拿到锁的主实例随后应调用 startSingletonServer 注册窗口唤起回调。
 func ensureSingleInstance() {
-	lockFile := filepath.Join(os.TempDir(), "lumin-ssh.lock")
+	lockFile := filepath.Join(os.TempDir(), fmt.Sprintf("lumin-ssh-%d.lock", os.Getuid()))
 	f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return
@@ -44,6 +76,55 @@ func ensureSingleInstance() {
 		os.Exit(0)
 	}
 	singletonLock = f
+}
+
+// startSingletonServer 在主实例上启动 Unix Socket 监听，
+// 二次启动的实例会连接并发送 "show" 指令，此处回调 showFn 显示主窗口。
+// showFn 通常包装 runtime.WindowShow（与托盘点击同路径）。
+func startSingletonServer(showFn func()) {
+	socketPath := singleInstanceSocketPath()
+	_ = os.Remove(socketPath) // 清理上次崩溃残留
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return
+	}
+	singletonSocketListener = l
+	singletonShowWindow = showFn
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // listener 已关闭
+			}
+			go handleSingletonConn(conn)
+		}
+	}()
+}
+
+// handleSingletonConn 读取一帧指令并执行，处理完即关闭连接。
+func handleSingletonConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	buf := make([]byte, 16)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _ := conn.Read(buf)
+	cmd := string(buf[:n])
+	switch cmd {
+	case "show\n", "show":
+		if singletonShowWindow != nil {
+			singletonShowWindow()
+		}
+	}
+}
+
+// stopSingletonServer 关闭并清理 socket（主实例退出时调用）。
+func stopSingletonServer() {
+	if singletonSocketListener != nil {
+		_ = singletonSocketListener.Close()
+		singletonSocketListener = nil
+	}
+	_ = os.Remove(singleInstanceSocketPath())
 }
 
 func acquireMainLivenessLock(path string) (func(), error) {

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -372,6 +372,13 @@ func ensureSingleInstance() {
 	}
 }
 
+// startSingletonServer Windows 上为空操作：Windows 用命名 mutex + HWND 直接激活，
+// 不需要 socket IPC（findAndShowWindow 已在二进程内完成跨进程窗口唤起）。
+func startSingletonServer(_ func()) {}
+
+// stopSingletonServer Windows 上无 socket 资源需要清理。
+func stopSingletonServer() {}
+
 func acquireMainLivenessLock(path string) (func(), error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {


### PR DESCRIPTION
## 背景

用户反馈：**Ubuntu GNOME X11 环境下安装后从启动器点击打不开主窗口，但从托盘可以打开**。KDE Wayland 下正常。

同时 CI 的 `publish-release` 一直失败，提示缺少 rpm 资产。

本 PR 分两个提交分别修复这两个问题。

---

## 提交 1：fix: Linux/macOS 单实例二次启动唤起主窗口

### 问题
应用最小化到托盘后，从桌面启动器再次点击无法打开主窗口（托盘点击正常）。

### 根因
`platform_unix.go` / `platform_darwin.go` 的 `findAndShowWindow()` 为空实现。二次进程经 flock 检测到已有实例后直接 `os.Exit(0)`，无法跨进程通知主实例显示窗口。Windows 有完整的 HWND 枚举 + `SetForegroundWindow` 实现，Linux/macOS 缺失对应机制。

### 修复
用 Unix Domain Socket IPC 实现跨进程唤起：
- 主实例 `OnStartup` 时启动 socket server，注入 `forceShowWindow` 回调
- 二次进程检测到单实例后连接 socket 发送 `show` 指令再退出
- 主实例收到指令后调用 `runtime.WindowShow`（与托盘点击同一路径）
- 新增 `startSingletonServer` / `stopSingletonServer`，`OnShutdown` 时清理
- Windows 走原有 mutex + HWND 方案，新增空实现保持接口统一

---

## 提交 2：fix(ci): rpm 改用 rpmbuild 原生构建，修复 postinst 导致 alien 转换失败

### 问题
CI 的 `publish-release` 因缺少 rpm 资产而 `exit 1`，导致所有平台产物无法发布。

### 根因
`release.yml` 用 heredoc 内联生成 deb 的 `postinst`/`postrm` 脚本，内容带了 YAML 缩进的前导空格，导致 `#!/bin/sh` shebang 失效；`alien --scripts` 转换 deb→rpm 时对脚本格式敏感而失败，rpm 未生成。

### 修复
- `postinst`/`postrm` 抽成独立脚本文件（`build/linux/`），用 `cp` 安装而非 heredoc，回避 YAML 缩进与 shell shebang 顶格的冲突
- rpm 改用 `rpmbuild` 原生构建（新增 `build/linux/lumin.spec`），不再依赖 alien
- 版本号按 rpm 规则拆分：`1.2.6-test-ipc` → `Version=1.2.6` / `Release=1.test_ipc`（rpm Version 字段不允许 `-`）
- 依赖列表移除不再需要的 `alien` / `fakeroot`
- 新增 `.gitattributes` 强制 Linux 脚本 LF 换行，防止 CRLF 在 Linux 上执行失败

---

## 测试

已通过完整 CI 打包验证（`v1.2.6-test-rpm`，全平台 14 个资产齐全，`publish-release` 成功）：
- ✅ build-linux（含 rpm 原生构建）
- ✅ build-windows / build-macos
- ✅ publish-release（资产齐套，成功发布）

并在 Ubuntu GNOME X11 实测：从启动器二次点击成功唤起已最小化到托盘的主窗口。