### PR TITLE
fix: 修复 Linux 本地终端命令历史重启丢失 & 首屏空白需回车

### DIFF
--- a/app.go
+++ b/app.go
@@ -40,7 +40,8 @@ type App struct {
 	wsPort                    int
 	wsToken                   string
 	wsMu                      sync.Mutex
-	wsConns                   map[string]*wsEntry // sessionId -> active WebSocket
+	wsConns                   map[string]*wsEntry    // sessionId -> active WebSocket
+	wsPending                 map[string]*wsPendingBuf // WS 注册前到达的输出缓冲（本地终端 PTY 首帧）
 	wsServer                  *http.Server        // WebSocket HTTP 服务器，用于优雅关闭
 	wsListener                net.Listener        // WebSocket 监听器，用于关闭时释放端口
 	mainLivenessLockPath      string
@@ -74,6 +75,18 @@ type wsEntry struct {
 	conn    *websocket.Conn
 	writeMu sync.Mutex
 }
+
+// wsPendingBuf 缓冲 WS 注册前到达的输出（本地终端启动极快，PTY 首帧提示符
+// 往往早于前端 WS 注册到达；直接丢弃会表现为「首屏空白，回车才出提示符」）。
+// firstAt 用于过期：前端始终不连接时过期作废，避免陈旧数据在之后误 flush。
+type wsPendingBuf struct {
+	data    []byte
+	firstAt time.Time
+}
+
+// 每 session 首帧缓冲上限与过期时间
+const wsPendingMaxBytes = 256 * 1024
+const wsPendingMaxAge = 30 * time.Second
 
 type BuiltinProviderRuntimeStatus struct {
 	ProviderID string `json:"providerId"`
@@ -116,6 +129,7 @@ func NewApp() *App {
 		sshManager:                NewSSHManager(),
 		configManager:             NewConfigManager(),
 		wsConns:                   make(map[string]*wsEntry),
+		wsPending:                 make(map[string]*wsPendingBuf),
 		builtinProcesses:          make(map[string]*exec.Cmd),
 		builtinBundleReady:        make(map[string]bool),
 		builtinInitCommands:       make(map[string]*exec.Cmd),
@@ -200,6 +214,8 @@ func (a *App) startup(ctx context.Context) {
 		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
 			log.Printf("[DBG-LocalTerm %s] ws conn REGISTERED", sessionId)
 		}
+		// 注册完成后立即 flush 注册前缓冲的首帧，保证本地终端首屏提示符立即可见
+		a.flushPendingWsOutput(sessionId)
 		defer func() {
 			a.wsMu.Lock()
 			// 仅删除自己的 entry：若已被新连接覆盖，cur != entry，不能误删新连接
@@ -300,19 +316,82 @@ func (a *App) GetWsToken() string {
 
 // WriteWsToSession 将 WebSocket 输出写入给指定 session 的 WS 连接
 func (a *App) WriteWsOutput(sessionId string, data []byte) {
-	// 仅在 wsMu 下取出 entry，写消息时用每连接独立锁，避免慢客户端阻塞其他 session
+	// 仅在 wsMu 下取出 entry，并原子取走可能存在的注册前缓冲；
+	// 写消息时用每连接独立锁，避免慢客户端阻塞其他 session
 	a.wsMu.Lock()
 	entry, ok := a.wsConns[sessionId]
+	var pending []byte
+	if ok && entry != nil {
+		if p := a.wsPending[sessionId]; p != nil {
+			pending = p.data
+			delete(a.wsPending, sessionId)
+		}
+	}
 	a.wsMu.Unlock()
+
 	if !ok || entry == nil {
-		// 调试：本地终端首屏竞态排查。若 PTY 首帧在 WS 注册前到达，数据会被丢弃，
-		// 表现为"打开终端空白，按回车才出提示符"。设 LUMIN_DBG_LOCAL_TERM=1 可观察。
+		// WS 尚未注册（本地终端 PTY 首帧竞态）：缓冲而非丢弃，注册时 flush。
+		if len(data) > 0 {
+			a.bufferPendingWsOutput(sessionId, data)
+		}
 		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
-			log.Printf("[DBG-LocalTerm %s] WriteWsOutput DROP %d bytes (ws conn not registered yet)", sessionId, len(data))
+			log.Printf("[DBG-LocalTerm %s] WriteWsOutput BUFFER %d bytes (ws conn not registered yet)", sessionId, len(data))
 		}
 		return
 	}
 
+	// 先写缓冲首帧再写当前数据，保证前端帧顺序
+	if len(pending) > 0 {
+		a.writeWsFrame(sessionId, entry, pending)
+	}
+	if len(data) > 0 {
+		a.writeWsFrame(sessionId, entry, data)
+	}
+}
+
+// bufferPendingWsOutput 在 wsMu 下累积注册前输出，带上限与过期保护。
+func (a *App) bufferPendingWsOutput(sessionId string, data []byte) {
+	a.wsMu.Lock()
+	defer a.wsMu.Unlock()
+	p := a.wsPending[sessionId]
+	if p == nil || time.Since(p.firstAt) > wsPendingMaxAge {
+		p = &wsPendingBuf{firstAt: time.Now()}
+		a.wsPending[sessionId] = p
+	}
+	if len(p.data) >= wsPendingMaxBytes {
+		return // 已达上限：只保留头部首帧数据
+	}
+	if remain := wsPendingMaxBytes - len(p.data); len(data) > remain {
+		data = data[:remain]
+	}
+	p.data = append(p.data, data...)
+}
+
+// flushPendingWsOutput 在 WS 注册时把注册前缓冲 flush 给新连接。
+// 与 WriteWsOutput 的取缓冲操作同在 wsMu 下原子完成，二者只会有一方取到，
+// 因此「flush 路径」与「注册后首条实时数据路径」不会重复或乱序。
+func (a *App) flushPendingWsOutput(sessionId string) {
+	a.wsMu.Lock()
+	entry, ok := a.wsConns[sessionId]
+	var pending []byte
+	if ok && entry != nil {
+		if p := a.wsPending[sessionId]; p != nil {
+			pending = p.data
+			delete(a.wsPending, sessionId)
+		}
+	}
+	a.wsMu.Unlock()
+	if !ok || entry == nil || len(pending) == 0 {
+		return
+	}
+	if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
+		log.Printf("[DBG-LocalTerm %s] flush pending %d bytes to newly registered ws conn", sessionId, len(pending))
+	}
+	a.writeWsFrame(sessionId, entry, pending)
+}
+
+// writeWsFrame 在连接独立写锁下写一帧二进制消息；写失败时移除并关闭连接。
+func (a *App) writeWsFrame(sessionId string, entry *wsEntry, data []byte) {
 	entry.writeMu.Lock()
 	defer entry.writeMu.Unlock()
 	// 设置写超时，防止前端停止读取后 goroutine 永久阻塞

--- a/app.go
+++ b/app.go
@@ -211,9 +211,6 @@ func (a *App) startup(ctx context.Context) {
 		}
 		a.wsConns[sessionId] = entry
 		a.wsMu.Unlock()
-		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
-			log.Printf("[DBG-LocalTerm %s] ws conn REGISTERED", sessionId)
-		}
 		// 注册完成后立即 flush 注册前缓冲的首帧，保证本地终端首屏提示符立即可见
 		a.flushPendingWsOutput(sessionId)
 		defer func() {
@@ -334,9 +331,6 @@ func (a *App) WriteWsOutput(sessionId string, data []byte) {
 		if len(data) > 0 {
 			a.bufferPendingWsOutput(sessionId, data)
 		}
-		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
-			log.Printf("[DBG-LocalTerm %s] WriteWsOutput BUFFER %d bytes (ws conn not registered yet)", sessionId, len(data))
-		}
 		return
 	}
 
@@ -384,10 +378,16 @@ func (a *App) flushPendingWsOutput(sessionId string) {
 	if !ok || entry == nil || len(pending) == 0 {
 		return
 	}
-	if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
-		log.Printf("[DBG-LocalTerm %s] flush pending %d bytes to newly registered ws conn", sessionId, len(pending))
-	}
 	a.writeWsFrame(sessionId, entry, pending)
+}
+
+// cleanupWsPending 在会话彻底销毁时清理其注册前缓冲，避免 wsPending map 残留。
+// 注意：不能在单条 WS 重连时调用——重连期间 PTY 可能仍在向 pending 缓冲首帧，
+// 那些数据需要留给新连接 flush。仅在 session 从 m.sessions 删除（彻底断开）时调用。
+func (a *App) cleanupWsPending(sessionId string) {
+	a.wsMu.Lock()
+	delete(a.wsPending, sessionId)
+	a.wsMu.Unlock()
 }
 
 // writeWsFrame 在连接独立写锁下写一帧二进制消息；写失败时移除并关闭连接。

--- a/app.go
+++ b/app.go
@@ -197,6 +197,9 @@ func (a *App) startup(ctx context.Context) {
 		}
 		a.wsConns[sessionId] = entry
 		a.wsMu.Unlock()
+		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
+			log.Printf("[DBG-LocalTerm %s] ws conn REGISTERED", sessionId)
+		}
 		defer func() {
 			a.wsMu.Lock()
 			// 仅删除自己的 entry：若已被新连接覆盖，cur != entry，不能误删新连接
@@ -302,6 +305,11 @@ func (a *App) WriteWsOutput(sessionId string, data []byte) {
 	entry, ok := a.wsConns[sessionId]
 	a.wsMu.Unlock()
 	if !ok || entry == nil {
+		// 调试：本地终端首屏竞态排查。若 PTY 首帧在 WS 注册前到达，数据会被丢弃，
+		// 表现为"打开终端空白，按回车才出提示符"。设 LUMIN_DBG_LOCAL_TERM=1 可观察。
+		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
+			log.Printf("[DBG-LocalTerm %s] WriteWsOutput DROP %d bytes (ws conn not registered yet)", sessionId, len(data))
+		}
 		return
 	}
 

--- a/config.go
+++ b/config.go
@@ -2396,10 +2396,31 @@ func (c *ConfigManager) ClearWorkspaceState() error {
 
 // ─── 命令历史 ──────────────────────────────────────
 
+// historyFileName 把会话 id 规整为历史文件名（不含扩展名），同时防止路径穿越。
+//
+// 不能用 filepath.Base：它在 Linux 上会把 "local_/bin/bash" 裁成 "bash"，
+// 丢掉 local_/serial_ 前缀，导致 CleanupOrphanedHistory 把它当孤儿删掉
+// （本地/串口终端的历史在每次启动后被清空，重启即丢失）。Windows 的 shell
+// 名（pwsh.exe / wsl://Ubuntu）不含路径分隔符，filepath.Base 不会改它们，
+// 这正是 PowerShell/WSL 正常、Linux bash 丢失的根因。
+//
+// 这里直接把所有平台上的路径分隔符与路径相关字符（/ \ :）统一替换为下划线：
+// 替换后不再含任何分隔符，天然杜绝路径穿越（"../../etc/passwd" 也会被改成
+// 形如 "______etc_passwd" 的扁平名字），同时完整保留 local_/serial_ 前缀契约，
+// 使清理孤儿逻辑能正确豁免本地/串口终端历史。
+// 对既有 id（SSH 连接的 hex ID、Windows shell 名等不含分隔符的 id）结果不变，
+// 向后兼容。
+func historyFileName(id string) string {
+	if id == "" {
+		return ""
+	}
+	return strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(id)
+}
+
 // GetCommandHistory 读取指定会话的命令历史
 func (c *ConfigManager) GetCommandHistory(sessionId string) string {
-	// 防止路径穿越
-	sessionId = filepath.Base(sessionId)
+	// 防止路径穿越：保留 local_/serial_ 前缀（见 historyFileName）
+	sessionId = historyFileName(sessionId)
 	path := filepath.Join(c.historyDir, sessionId+".json")
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -2412,8 +2433,8 @@ func (c *ConfigManager) GetCommandHistory(sessionId string) string {
 
 // SaveCommandHistory 保存指定会话的命令历史
 func (c *ConfigManager) SaveCommandHistory(sessionId, jsonStr string) error {
-	// 防止路径穿越
-	sessionId = filepath.Base(sessionId)
+	// 防止路径穿越：保留 local_/serial_ 前缀（见 historyFileName）
+	sessionId = historyFileName(sessionId)
 	path := filepath.Join(c.historyDir, sessionId+".json")
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -1592,9 +1592,31 @@ export default function Terminal({
       ws.binaryType = 'arraybuffer';
       wsRef.current = ws;
 
+      // ── 调试：本地终端首屏空白排查（按需开启）─────────────────────
+      // 复现「打开本地 bash 终端完全空白，按一次回车才出提示符」时，开启诊断：
+      //   localStorage.setItem('dbgLocalTerm','1')（前端 console）
+      //   后端设 LUMIN_DBG_LOCAL_TERM=1 后从终端启动应用，看 stderr 的 [DBG-LocalTerm] 日志。
+      // 用于定位是 WS 没连上 / 首帧没到 / 走了过滤分支被吞 / term.write 没渲染 / 后端 DROP。
+      const DBG = localStorage.getItem('dbgLocalTerm') === '1';
+      const dbgTag = `[DBG-LocalTerm ${sessionId.slice(-8)}]`;
+      let dbgMsgCount = 0;
+      const dbgOut = (msg) => { if (DBG) console.log(dbgTag, msg); };
+      const dbgBytes = (d) => {
+        if (typeof d === 'string') return `len=${d.length} text=${JSON.stringify(d.slice(0, 80))}`;
+        const u = new Uint8Array(d);
+        const hex = Array.from(u.slice(0, 40)).map(b => b.toString(16).padStart(2, '0')).join(' ');
+        return `len=${u.length} hex=${hex}`;
+      };
+      dbgOut('WebSocket creating');
+      ws.onopen = () => { dbgOut('ws.onopen'); };
+      ws.onclose = (ev) => { dbgOut(`ws.onclose code=${ev.code}`); };
+
       ws.onmessage = (ev) => {
         if (!termRef.current) return;
-
+        if (DBG && dbgMsgCount < 8) {
+          dbgMsgCount += 1;
+          dbgOut(`ws.onmessage #${dbgMsgCount} ${dbgBytes(ev.data)} localEcho=${localEchoRef.current} carry=${predictiveTextCarry.length}`);
+        }
         // 在原始数据上检测清屏序列（不依赖后续文本处理路径）
         const rawBytes = typeof ev.data === 'string' ? null : new Uint8Array(ev.data);
         // 统一解码：高亮开启时整个连接只用一个流式解码器（hlDecoderRef），
@@ -1628,6 +1650,7 @@ export default function Terminal({
         }
 
         const shouldFilterIncomingText = (localEchoRef.current && pendingEchoes.length > 0) || predictiveTextCarry.length > 0
+        if (DBG && dbgMsgCount <= 8) dbgOut(`  branch: ${shouldFilterIncomingText ? 'filter' : 'direct-smartWrite'}`);
 
         if (!shouldFilterIncomingText) {
           predictiveDecoder = new TextDecoder()
@@ -1645,7 +1668,9 @@ export default function Terminal({
         const splitText = splitTrailingIncompleteEscapeSequence(text);
         predictiveTextCarry = splitText.carry;
         text = splitText.complete;
+        if (DBG && dbgMsgCount <= 8) dbgOut(`  split carry=${splitText.carry.length} complete=${splitText.complete.length}`);
         if (!text) {
+          if (DBG) dbgOut('  !! text empty after split -> NOT written (held in carry)');
           return;
         }
 
@@ -1722,6 +1747,7 @@ export default function Terminal({
     let localInputLength = 0; // 用于保护提示符，防止退格越界
 
     term.onData((data) => {
+      if (localStorage.getItem('dbgLocalTerm') === '1') console.log(`[DBG-LocalTerm ${sessionId.slice(-8)}] term.onData user-input`, JSON.stringify(data.slice(0, 20)), 'wsState=', wsRef.current?.readyState);
       if ((statusRef.current === 'closed' || statusRef.current === 'error') && (data.includes('\r') || data.includes('\n'))) {
         window.dispatchEvent(new CustomEvent('ssh-reconnect-trigger', { detail: sessionId }));
         return;

--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -1592,24 +1592,7 @@ export default function Terminal({
       ws.binaryType = 'arraybuffer';
       wsRef.current = ws;
 
-      // ── 调试：本地终端首屏空白排查（按需开启）─────────────────────
-      // 复现「打开本地 bash 终端完全空白，按一次回车才出提示符」时，开启诊断：
-      //   localStorage.setItem('dbgLocalTerm','1')（前端 console）
-      //   后端设 LUMIN_DBG_LOCAL_TERM=1 后从终端启动应用，看 stderr 的 [DBG-LocalTerm] 日志。
-      // 用于定位是 WS 没连上 / 首帧没到 / 走了过滤分支被吞 / term.write 没渲染 / 后端 DROP。
-      const DBG = localStorage.getItem('dbgLocalTerm') === '1';
-      const dbgTag = `[DBG-LocalTerm ${sessionId.slice(-8)}]`;
-      let dbgMsgCount = 0;
-      const dbgOut = (msg) => { if (DBG) console.log(dbgTag, msg); };
-      const dbgBytes = (d) => {
-        if (typeof d === 'string') return `len=${d.length} text=${JSON.stringify(d.slice(0, 80))}`;
-        const u = new Uint8Array(d);
-        const hex = Array.from(u.slice(0, 40)).map(b => b.toString(16).padStart(2, '0')).join(' ');
-        return `len=${u.length} hex=${hex}`;
-      };
-      dbgOut('WebSocket creating');
       ws.onopen = () => {
-        dbgOut('ws.onopen');
         // 补发一次初始尺寸：终端首次 fit 发生在 onResize 订阅之前，那次
         // 尺寸变化事件被错过，本地 PTY 可能长期停留在出生尺寸；这里主动
         // 同步一次，同时给 SIGWINCH 会重绘提示符的 shell（bash/zsh）兜底自愈机会。
@@ -1617,14 +1600,9 @@ export default function Terminal({
           AppGo.ResizeTerminal(sessionId, termRef.current.cols, termRef.current.rows);
         }
       };
-      ws.onclose = (ev) => { dbgOut(`ws.onclose code=${ev.code}`); };
 
       ws.onmessage = (ev) => {
         if (!termRef.current) return;
-        if (DBG && dbgMsgCount < 8) {
-          dbgMsgCount += 1;
-          dbgOut(`ws.onmessage #${dbgMsgCount} ${dbgBytes(ev.data)} localEcho=${localEchoRef.current} carry=${predictiveTextCarry.length}`);
-        }
         // 在原始数据上检测清屏序列（不依赖后续文本处理路径）
         const rawBytes = typeof ev.data === 'string' ? null : new Uint8Array(ev.data);
         // 统一解码：高亮开启时整个连接只用一个流式解码器（hlDecoderRef），
@@ -1658,7 +1636,6 @@ export default function Terminal({
         }
 
         const shouldFilterIncomingText = (localEchoRef.current && pendingEchoes.length > 0) || predictiveTextCarry.length > 0
-        if (DBG && dbgMsgCount <= 8) dbgOut(`  branch: ${shouldFilterIncomingText ? 'filter' : 'direct-smartWrite'}`);
 
         if (!shouldFilterIncomingText) {
           predictiveDecoder = new TextDecoder()
@@ -1676,9 +1653,7 @@ export default function Terminal({
         const splitText = splitTrailingIncompleteEscapeSequence(text);
         predictiveTextCarry = splitText.carry;
         text = splitText.complete;
-        if (DBG && dbgMsgCount <= 8) dbgOut(`  split carry=${splitText.carry.length} complete=${splitText.complete.length}`);
         if (!text) {
-          if (DBG) dbgOut('  !! text empty after split -> NOT written (held in carry)');
           return;
         }
 
@@ -1755,7 +1730,6 @@ export default function Terminal({
     let localInputLength = 0; // 用于保护提示符，防止退格越界
 
     term.onData((data) => {
-      if (localStorage.getItem('dbgLocalTerm') === '1') console.log(`[DBG-LocalTerm ${sessionId.slice(-8)}] term.onData user-input`, JSON.stringify(data.slice(0, 20)), 'wsState=', wsRef.current?.readyState);
       if ((statusRef.current === 'closed' || statusRef.current === 'error') && (data.includes('\r') || data.includes('\n'))) {
         window.dispatchEvent(new CustomEvent('ssh-reconnect-trigger', { detail: sessionId }));
         return;

--- a/frontend/src/components/Terminal.jsx
+++ b/frontend/src/components/Terminal.jsx
@@ -1608,7 +1608,15 @@ export default function Terminal({
         return `len=${u.length} hex=${hex}`;
       };
       dbgOut('WebSocket creating');
-      ws.onopen = () => { dbgOut('ws.onopen'); };
+      ws.onopen = () => {
+        dbgOut('ws.onopen');
+        // 补发一次初始尺寸：终端首次 fit 发生在 onResize 订阅之前，那次
+        // 尺寸变化事件被错过，本地 PTY 可能长期停留在出生尺寸；这里主动
+        // 同步一次，同时给 SIGWINCH 会重绘提示符的 shell（bash/zsh）兜底自愈机会。
+        if (termRef.current) {
+          AppGo.ResizeTerminal(sessionId, termRef.current.cols, termRef.current.rows);
+        }
+      };
       ws.onclose = (ev) => { dbgOut(`ws.onclose code=${ev.code}`); };
 
       ws.onmessage = (ev) => {

--- a/local_conn_unix.go
+++ b/local_conn_unix.go
@@ -41,6 +41,13 @@ func (a *App) getLocalShells() ([]string, error) {
 
 // connectLocal spawns a local process using creack/pty.
 func (a *App) connectLocal(sessionId string, name string, shellPath string, cwd string) error {
+	dbg := os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1"
+	dbgLog := func(format string, args ...any) {
+		if dbg {
+			log.Printf("[DBG-LocalTerm %s] "+format, append([]any{sessionId}, args...)...)
+		}
+	}
+
 	workDir := cwd
 	if workDir == "" {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -52,9 +59,15 @@ func (a *App) connectLocal(sessionId string, name string, shellPath string, cwd 
 	cmd.Dir = workDir
 	cmd.Env = os.Environ()
 
+	dbgLog("shellPath=%s workDir=%s pty.Start (no initial Winsize, will be 0x0 until first Resize)", shellPath, workDir)
 	ptyFile, err := pty.Start(cmd)
 	if err != nil {
 		return fmt.Errorf("pty start error: %w", err)
+	}
+	if dbg {
+		if ws, e := pty.Getsize(ptyFile); e == nil {
+			dbgLog("after pty.Start: pty size = %dx%d", ws.Rows, ws.Cols)
+		}
 	}
 
 	sd := &SessionData{
@@ -112,6 +125,9 @@ func (m *SSHManager) ResizeLocal(s *SessionData, cols, rows int) {
 	ptyFile := s.LocalPTYUnix
 	m.mu.RUnlock()
 	if ptyFile != nil {
+		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
+			log.Printf("[DBG-LocalTerm] ResizeLocal cols=%d rows=%d", cols, rows)
+		}
 		_ = pty.Setsize(ptyFile, &pty.Winsize{
 			Cols: uint16(cols),
 			Rows: uint16(rows),

--- a/local_conn_unix.go
+++ b/local_conn_unix.go
@@ -41,13 +41,6 @@ func (a *App) getLocalShells() ([]string, error) {
 
 // connectLocal spawns a local process using creack/pty.
 func (a *App) connectLocal(sessionId string, name string, shellPath string, cwd string) error {
-	dbg := os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1"
-	dbgLog := func(format string, args ...any) {
-		if dbg {
-			log.Printf("[DBG-LocalTerm %s] "+format, append([]any{sessionId}, args...)...)
-		}
-	}
-
 	workDir := cwd
 	if workDir == "" {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -63,15 +56,9 @@ func (a *App) connectLocal(sessionId string, name string, shellPath string, cwd 
 	// 不绘制提示符/回显，且首屏尺寸与前端不同步。前端会在 WS onopen 后
 	// 主动发一次实际 fit 尺寸，这里只需一个合理的出生尺寸。
 	initialSize := &pty.Winsize{Rows: 24, Cols: 80}
-	dbgLog("shellPath=%s workDir=%s pty.StartWithSize initial=%dx%d", shellPath, workDir, initialSize.Rows, initialSize.Cols)
 	ptyFile, err := pty.StartWithSize(cmd, initialSize)
 	if err != nil {
 		return fmt.Errorf("pty start error: %w", err)
-	}
-	if dbg {
-		if rows, cols, e := pty.Getsize(ptyFile); e == nil {
-			dbgLog("after pty.Start: pty size = %dx%d", rows, cols)
-		}
 	}
 
 	sd := &SessionData{
@@ -129,9 +116,6 @@ func (m *SSHManager) ResizeLocal(s *SessionData, cols, rows int) {
 	ptyFile := s.LocalPTYUnix
 	m.mu.RUnlock()
 	if ptyFile != nil {
-		if os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1" {
-			log.Printf("[DBG-LocalTerm] ResizeLocal cols=%d rows=%d", cols, rows)
-		}
 		_ = pty.Setsize(ptyFile, &pty.Winsize{
 			Cols: uint16(cols),
 			Rows: uint16(rows),

--- a/local_conn_unix.go
+++ b/local_conn_unix.go
@@ -59,14 +59,18 @@ func (a *App) connectLocal(sessionId string, name string, shellPath string, cwd 
 	cmd.Dir = workDir
 	cmd.Env = os.Environ()
 
-	dbgLog("shellPath=%s workDir=%s pty.Start (no initial Winsize, will be 0x0 until first Resize)", shellPath, workDir)
-	ptyFile, err := pty.Start(cmd)
+	// 传初始 Winsize，避免 PTY 以 0x0 出生：部分 shell 在 0 列下 readline
+	// 不绘制提示符/回显，且首屏尺寸与前端不同步。前端会在 WS onopen 后
+	// 主动发一次实际 fit 尺寸，这里只需一个合理的出生尺寸。
+	initialSize := &pty.Winsize{Rows: 24, Cols: 80}
+	dbgLog("shellPath=%s workDir=%s pty.StartWithSize initial=%dx%d", shellPath, workDir, initialSize.Rows, initialSize.Cols)
+	ptyFile, err := pty.StartWithSize(cmd, initialSize)
 	if err != nil {
 		return fmt.Errorf("pty start error: %w", err)
 	}
 	if dbg {
-		if ws, e := pty.Getsize(ptyFile); e == nil {
-			dbgLog("after pty.Start: pty size = %dx%d", ws.Rows, ws.Cols)
+		if rows, cols, e := pty.Getsize(ptyFile); e == nil {
+			dbgLog("after pty.Start: pty size = %dx%d", rows, cols)
 		}
 	}
 

--- a/ssh.go
+++ b/ssh.go
@@ -1084,9 +1084,6 @@ func (m *SSHManager) pipeLocalOutput(sessionId string, cptyHandle any, stdoutPip
 		defer m.bufPool.Put(bufPtr)
 		buf := *bufPtr
 
-		dbg := os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1"
-		dbgFrames := 0
-
 		for {
 			var n int
 			var err error
@@ -1097,14 +1094,6 @@ func (m *SSHManager) pipeLocalOutput(sessionId string, cptyHandle any, stdoutPip
 					return
 				}
 				n, err = stdoutPipe.Read(buf)
-			}
-			if dbg && n > 0 && dbgFrames < 8 {
-				dbgFrames++
-				hex := ""
-				for i := 0; i < n && i < 40; i++ {
-					hex += fmt.Sprintf("%02x ", buf[i])
-				}
-				log.Printf("[DBG-LocalTerm %s] pipeLocalOutput read #%d n=%d hex=%s", sessionId, dbgFrames, n, hex)
 			}
 			if n <= 0 {
 				if err != nil {
@@ -1323,6 +1312,11 @@ func (m *SSHManager) Disconnect(sessionId string) bool {
 	m.mu.Unlock() // 尽早释放锁，避免 Close 阻塞影响其他操作
 	if stopForwardsConnKey != "" {
 		m.stopPortForwardsForConnKey(stopForwardsConnKey)
+	}
+	// 会话彻底销毁：清理其 WS 注册前缓冲，避免 wsPending map 残留泄漏
+	// （PTY 在 WS 断开后可能缓冲过数据；此时 session 已删，再无 flush 机会）。
+	if m.app != nil {
+		m.app.cleanupWsPending(sessionId)
 	}
 
 	// 2. 在锁外关闭资源（服务器挂了时这些操作可能阻塞，但不会锁住其他 goroutine）

--- a/ssh.go
+++ b/ssh.go
@@ -1084,6 +1084,9 @@ func (m *SSHManager) pipeLocalOutput(sessionId string, cptyHandle any, stdoutPip
 		defer m.bufPool.Put(bufPtr)
 		buf := *bufPtr
 
+		dbg := os.Getenv("LUMIN_DBG_LOCAL_TERM") == "1"
+		dbgFrames := 0
+
 		for {
 			var n int
 			var err error
@@ -1094,6 +1097,14 @@ func (m *SSHManager) pipeLocalOutput(sessionId string, cptyHandle any, stdoutPip
 					return
 				}
 				n, err = stdoutPipe.Read(buf)
+			}
+			if dbg && n > 0 && dbgFrames < 8 {
+				dbgFrames++
+				hex := ""
+				for i := 0; i < n && i < 40; i++ {
+					hex += fmt.Sprintf("%02x ", buf[i])
+				}
+				log.Printf("[DBG-LocalTerm %s] pipeLocalOutput read #%d n=%d hex=%s", sessionId, dbgFrames, n, hex)
 			}
 			if n <= 0 {
 				if err != nil {
@@ -1111,6 +1122,7 @@ func (m *SSHManager) pipeLocalOutput(sessionId string, cptyHandle any, stdoutPip
 				return
 			}
 			oscParser := curSd.OSCCwdParser
+
 
 			var data []byte
 			if oscParser != nil {

--- a/ws_pending_test.go
+++ b/ws_pending_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newWsPair 建立一对真实 WebSocket 连接：服务端 conn 包装成 wsEntry 供被测代码写入，
+// 客户端 conn 用于接收断言。
+func newWsPair(t *testing.T) (*wsEntry, *websocket.Conn, func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	serverCh := make(chan *websocket.Conn, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		c, upErr := upgrader.Upgrade(w, r, nil)
+		if upErr != nil {
+			return
+		}
+		serverCh <- c
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+
+	client, _, err := websocket.DefaultDialer.Dial("ws://"+ln.Addr().String()+"/", nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	var server *websocket.Conn
+	select {
+	case server = <-serverCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server side upgrade timeout")
+	}
+	cleanup := func() {
+		_ = client.Close()
+		_ = server.Close()
+		_ = srv.Close()
+		_ = ln.Close()
+	}
+	return &wsEntry{conn: server}, client, cleanup
+}
+
+func newTestAppWithWs() *App {
+	return &App{
+		wsConns:   make(map[string]*wsEntry),
+		wsPending: make(map[string]*wsPendingBuf),
+	}
+}
+
+// 首帧在 WS 注册前到达时必须缓冲而不是丢弃（本地终端首屏空白根因）。
+func TestWriteWsOutputBuffersBeforeRegistration(t *testing.T) {
+	a := newTestAppWithWs()
+	a.WriteWsOutput("s1", []byte("prompt$ "))
+
+	a.wsMu.Lock()
+	p := a.wsPending["s1"]
+	a.wsMu.Unlock()
+	if p == nil || string(p.data) != "prompt$ " {
+		t.Fatalf("首帧未缓冲, got %+v", p)
+	}
+}
+
+// 注册后 flush：客户端必须先收到缓冲首帧、再收到实时数据，顺序不能乱。
+func TestWriteWsOutputFlushPendingOnRegistration(t *testing.T) {
+	a := newTestAppWithWs()
+	a.WriteWsOutput("s1", []byte("first-frame"))
+
+	entry, client, cleanup := newWsPair(t)
+	defer cleanup()
+
+	// 模拟 startup handler 的注册顺序：先写 map，再 flush
+	a.wsMu.Lock()
+	a.wsConns["s1"] = entry
+	a.wsMu.Unlock()
+	a.flushPendingWsOutput("s1")
+	a.WriteWsOutput("s1", []byte("live"))
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, m1, err := client.ReadMessage()
+	if err != nil || string(m1) != "first-frame" {
+		t.Fatalf("第 1 帧应为缓冲首帧, got %q err=%v", m1, err)
+	}
+	_, m2, err := client.ReadMessage()
+	if err != nil || string(m2) != "live" {
+		t.Fatalf("第 2 帧应为实时数据, got %q err=%v", m2, err)
+	}
+
+	// flush 后缓冲应被清空
+	a.wsMu.Lock()
+	_, still := a.wsPending["s1"]
+	a.wsMu.Unlock()
+	if still {
+		t.Fatal("flush 后 wsPending 未清理")
+	}
+}
+
+// 缓冲必须有上限，防止前端永不连接时无限增长。
+func TestBufferPendingWsOutputCap(t *testing.T) {
+	a := newTestAppWithWs()
+	big := make([]byte, wsPendingMaxBytes+1024)
+	a.bufferPendingWsOutput("s1", big)
+
+	a.wsMu.Lock()
+	n := len(a.wsPending["s1"].data)
+	a.wsMu.Unlock()
+	if n != wsPendingMaxBytes {
+		t.Fatalf("缓冲应截断到 %d, got %d", wsPendingMaxBytes, n)
+	}
+}

--- a/ws_pending_test.go
+++ b/ws_pending_test.go
@@ -116,3 +116,18 @@ func TestBufferPendingWsOutputCap(t *testing.T) {
 		t.Fatalf("缓冲应截断到 %d, got %d", wsPendingMaxBytes, n)
 	}
 }
+
+// 会话彻底销毁时必须清理其 pending 缓冲，避免 map 残留泄漏。
+func TestCleanupWsPendingRemovesEntry(t *testing.T) {
+	a := newTestAppWithWs()
+	a.WriteWsOutput("s1", []byte("orphaned-frame"))
+
+	a.cleanupWsPending("s1")
+
+	a.wsMu.Lock()
+	_, still := a.wsPending["s1"]
+	a.wsMu.Unlock()
+	if still {
+		t.Fatal("cleanupWsPending 后 wsPending 仍残留")
+	}
+}


### PR DESCRIPTION
## 背景

本 PR 修复两个 Linux 本地终端相关问题，Windows (PowerShell / WSL) 不受影响。

## 问题一：本地终端命令历史重启后丢失（Linux bash）

### 现象
PowerShell / WSL 的本地终端历史能正常保留，但 Linux 下 bash（以及 zsh / sh）的历史在软件重启后全部消失。

### 根因
本地终端的 `serverId` 为 \`local_/bin/bash\`（shell 绝对路径含 \`/\`）。而 \`GetCommandHistory\` / \`SaveCommandHistory\` 原先用 \`filepath.Base(sessionId)\` 防路径穿越：

- Linux 下 \`/\` 是路径分隔符，\`filepath.Base("local_/bin/bash")\` 把它裁成 \`"bash"\`，丢掉 \`local_\` 前缀 → 历史文件被写成 \`bash.json\`；
- 会话内 save / load 都用 \`bash.json\`，所以**会话内历史正常**（迷惑性强）；
- 但 \`CleanupOrphanedHistory\`（每次启动运行）发现 \`bash.json\` 不以 \`local_\` / \`serial_\` 开头 → 当成孤儿删掉 → **重启后丢失**；
- Windows 的 shell 名（\`pwsh.exe\` / \`wsl://Ubuntu\`）不含路径分隔符，\`filepath.Base\` 不改它们 → 前缀保留 → 不被清理 → **持久化正常**。

这正是「PowerShell/WSL 正常、Linux bash 丢失」的根因，是 \`filepath.Base\` 跨平台行为差异导致的。

### 修复（\`config.go\`）
新增 \`historyFileName()\`：把 \`/\` \`\\` \`:\` 统一替换为下划线。替换后不含任何分隔符，天然杜绝路径穿越（\`"../../etc/passwd"\` 也会变成扁平名字），同时完整保留 \`local_\` / \`serial_\` 前缀契约，清理孤儿逻辑能正确豁免。

对既有 id（SSH 连接的 hex ID、Windows shell 名等不含分隔符的 id）结果不变，**完全向后兼容**。

## 问题二：本地终端首屏空白，需按一次回车才显示提示符（Linux bash）

### 现象
在 Linux 上打开本地 bash 终端，屏幕完全空白，必须按一次回车后才出现 \`user@host:~\$\` 提示符。

### 根因（双重时序竞态）
1. **PTY 首帧在 WS 注册前到达被丢弃**：本地 PTY 启动极快，bash 的首屏提示符往往早于前端 WebSocket 连接注册到达后端。\`WriteWsOutput\` 原逻辑在 WS 未注册时直接丢弃数据 → 首屏丢失，前端按回车触发 shell 重绘才看到提示符。
2. **PTY 以 0x0 尺寸启动**：原 \`pty.Start(cmd)\` 未传初始 Winsize，部分 shell 在 0 列下 readline 不绘制提示符 / 不回显，且首屏尺寸与前端不同步。

### 修复
- **后端缓冲而非丢弃**（\`app.go\`）：新增 \`wsPending\` 机制，WS 注册前到达的输出缓冲起来（带上限 256KB 与 30s 过期保护），WS 注册时 \`flushPendingWsOutput\` 一次性 flush 给新连接，保证帧顺序。
- **传初始 Winsize**（\`local_conn_unix.go\`）：\`pty.Start\` → \`pty.StartWithSize(cmd, 24x80)\`，避免 0x0 出生。
- **前端补发初始尺寸**（\`Terminal.jsx\`）：\`ws.onopen\` 时主动 \`ResizeTerminal\` 同步一次实际尺寸，给 bash/zsh（收到 SIGWINCH 重绘提示符）兜底自愈机会。

### 并发正确性
\`WriteWsOutput\` 与 \`flushPendingWsOutput\` 都在 \`wsMu\` 下「原子取走 pending」，二者只会有一方取到，不会重复或乱序。已逐场景推演（首帧早于注册 / 注册后 flush 前 PTY 又来数据 / WS 断开重连 / 会话销毁）。

## Review 额外修复：wsPending 资源泄漏

Review 时发现 \`wsPending\` map 在会话彻底断开时未清理，PTY 在 WS 断开后缓冲的数据会残留（上限 256KB/会话）。新增 \`cleanupWsPending\` 在 \`Disconnect\` 销毁会话时调用。

注意：**不能**在单条 WS 重连时清理——重连期间 PTY 可能仍在缓冲首帧，那些数据需留给新连接 flush。

## 测试

新增 \`ws_pending_test.go\`（4 个单测）：
- 首帧注册前到达时缓冲而非丢弃
- 注册后 flush 顺序正确（先缓冲帧后实时帧）
- 缓冲上限截断
- 会话销毁时清理 pending

## 验证
- \`go build ./...\` ✓
- \`go test\`（4 个新单测）✓
- \`vite build\` ✓
- Linux 真机实测：两个问题均已修复 ✓，Windows 不受影响 ✓