### PR TITLE
fix(windows): restore window on tray double-click

### DIFF
--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -60,6 +60,13 @@ func setupSystray(app *App) {
 			showMain()
 		})
 
+		// Windows sends WM_LBUTTONDBLCLK separately from WM_LBUTTONUP.
+		// Register the double-click callback explicitly so a double-click on the
+		// tray icon restores the main window just like a single click.
+		systray.SetOnDClick(func(menu systray.IMenu) {
+			showMain()
+		})
+
 		// 右键点击托盘图标：显示菜单。
 		// Windows 久置后 TrackPopupMenu 常因托盘窗抢不到前台而不弹出；
 		// 先解锁前台再 ShowMenu（与主窗久置唤起同源限制）。


### PR DESCRIPTION
## Problem
On Windows, double-clicking the Lumin system tray icon does not restore the main window.

## Cause
`github.com/energye/systray` handles `WM_LBUTTONUP` and `WM_LBUTTONDBLCLK` through separate callbacks. Lumin registers `SetOnClick` and `SetOnRClick`, but not `SetOnDClick`, so the double-click message is ignored.

## Fix
Register `SetOnDClick` and route it through the same `forceShowWindow` path used by single-click and the Show menu item.

## Verification
- `go test ./internal/wailsapp/...`
- `git diff --check`