### PR TITLE
fix: 修复 Linux WebKitGTK 环境下快捷命令条滚动条遮挡按钮的问题

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5186,7 +5186,7 @@ body.theme-light .dashboard-server-editor {
 /* ── 终端固定命令条（输入框上方，横向滚动 + 右侧搜索） ── */
 .term-quick-cmd-bar {
   display: flex;
-  align-items: center;
+  align-items: flex-start; /* 顶部对齐，确保按钮和搜索按钮完美对齐 */
   gap: 6px;
   padding: 4px 8px;
   background: var(--term-input-bar-bg);
@@ -5201,16 +5201,15 @@ body.theme-light .dashboard-server-editor {
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: thin;
-  /* 底部留白：Linux/WebKitGTK 横向滚动条较宽，6px 确保不遮挡按钮点击区 */
+  /* 底部留白：在按钮下方预留滚动条空间。不使用负 margin，防止滚动条被下方输入栏遮挡 */
   padding-bottom: 6px;
-  margin-bottom: -3px;
   /* 右侧边界渐隐：滚动时药丸淡出，而不是被搜索框硬切 */
   mask-image: linear-gradient(to right, #000 calc(100% - 16px), transparent 100%);
   -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 16px), transparent 100%);
 }
 .term-quick-cmd-list::-webkit-scrollbar {
   height: 4px;
+  background: transparent;
 }
 .term-quick-cmd-list::-webkit-scrollbar-track {
   background: transparent;


### PR DESCRIPTION
### 问题原因
1. **属性冲突**：在 CSS 中同时设置了 \scrollbar-width: thin;\ 和 \::-webkit-scrollbar\，导致 WebKitGTK 引擎（Linux WebView）优先使用标准属性并忽略了自定义的 4px 细滚动条样式，从而回退为系统默认的粗滚动条。
2. **遮挡与层级问题**：使用负的 \margin-bottom\ 来强制对齐和贴边，但因为滚动条变粗，导致滚动条侵入药丸按钮区域遮挡了部分点击区。同时，如果留白不足，负 margin 还会导致滚动条在视觉上被下方的 \.term-input-bar\ 背景色完全遮挡。

### 修复方案
1. **移除 \scrollbar-width: thin;\**：由于 Wails 在 macOS/Linux 上均使用 WebKit 内核，移除 Firefox 专属的 \scrollbar-width\ 属性可以让 WebKitGTK 正确应用 \::-webkit-scrollbar\ 渲染出符合预期的 4px 细滚动条。
2. **优化对齐及底部留白（不使用负 margin）**：
   - 将 \.term-quick-cmd-bar\ 设置为 \lign-items: flex-start;\（顶部对齐），使得按钮（22px）与右侧搜索栏（22px）在顶部完美对齐，不需要依靠负 margin 做视觉微调。
   - 去掉 \.term-quick-cmd-list\ 的 \margin-bottom\，增加 \padding-bottom: 6px\。这为 4px 滚动条在按钮下方预留了足够的空间，且避免被下方输入栏遮挡，实现滚动条既能完全显示又不会遮挡按钮。