### PR TITLE
perf(frontend): Monaco 编辑器瘦身 + AI 还原按钮状态修复

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,6 @@
         "@codemirror/lang-xml": "^6.1.0",
         "@codemirror/legacy-modes": "^6.4.2",
         "@codemirror/theme-one-dark": "^6.1.2",
-        "@monaco-editor/react": "^4.7.0",
         "@uiw/react-codemirror": "^4.23.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-search": "^0.15.0",
@@ -73,6 +72,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -524,6 +524,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
       "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
@@ -1068,29 +1069,6 @@
       "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
-    "node_modules/@monaco-editor/loader": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
-      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
-      "license": "MIT",
-      "dependencies": {
-        "state-local": "^1.0.6"
-      }
-    },
-    "node_modules/@monaco-editor/react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
-      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@monaco-editor/loader": "^1.5.0"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1547,6 +1525,7 @@
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1562,6 +1541,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1692,7 +1672,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -1737,6 +1718,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3212,6 +3194,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3224,6 +3207,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3442,12 +3426,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/state-local": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
-      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3695,6 +3673,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "@codemirror/lang-xml": "^6.1.0",
     "@codemirror/legacy-modes": "^6.4.2",
     "@codemirror/theme-one-dark": "^6.1.2",
-    "@monaco-editor/react": "^4.7.0",
     "@uiw/react-codemirror": "^4.23.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-search": "^0.15.0",

--- a/frontend/src/components/AIPanel.tsx
+++ b/frontend/src/components/AIPanel.tsx
@@ -5296,13 +5296,14 @@ export default function AIPanel({ width, side, terminalId = 'global', sessionId 
     try {
       await restoreAIChatTool(restoreArtifactPath, terminalId)
       clearRestorePreview()
+      addToast?.(translate('已还原'), 'success', 3200)
       return true
     } catch (error) {
       // error.message 为后端动态文案（可能不在翻译表），translate() 内部有兜底
       await showAlert(error instanceof Error ? translate(error.message as I18nKey) : translate('当前状态不支持还原'))
       return false
     }
-  }, [clearRestorePreview, showAlert, terminalId])
+  }, [addToast, clearRestorePreview, showAlert, terminalId, translate])
 
   const handleListCommandTerminalCandidates = useCallback(async () => {
     if (!panelState.activeRequestId) {

--- a/frontend/src/components/SessionWorkspace.tsx
+++ b/frontend/src/components/SessionWorkspace.tsx
@@ -1,7 +1,6 @@
 import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Cpu, Folder, Globe, Monitor, Plus, RefreshCw, ScrollText, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, lazy, Suspense, useMemo, useRef, useState } from 'react';
 import * as AppGo from '../../wailsjs/go/wailsapp/App.js';
-import AIChangeReviewWorkbench from './ai/AIChangeReviewWorkbench.tsx';
 import AIConversationDiffOverlay from './ai/AIConversationDiffOverlay.tsx';
 import CommandHistory from './CommandHistory.tsx';
 import ConnectingCard from './ConnectingCard.tsx';
@@ -25,6 +24,10 @@ import type { TerminalTabContextMenuState } from './AppOverlays.tsx';
 import type { ServerFormData } from '../hooks/useServerCatalog.ts';
 import type { PanelResizeDirection } from '../hooks/useWorkspacePanelDocking.ts';
 import type { ConversationDiffItem } from '../hooks/useAIReview.ts';
+
+// 懒加载：AIChangeReviewWorkbench 依赖 Monaco（瘦身后核心仍在 ~2MB），
+// 只在打开变更审阅/恢复预览时按需加载，避免进入应用启动路径
+const AIChangeReviewWorkbench = lazy(() => import('./ai/AIChangeReviewWorkbench.tsx'));
 
 const FILE_MANAGER_LEFT_MIN = 180;
 const FILE_MANAGER_BOTTOM_MIN = 100;
@@ -1354,30 +1357,34 @@ export default function SessionWorkspace({ dashboard = {}, session = {}, fileMan
                 />
                 <div id="editor-split-host" style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', order: 2, width: 0, transition: 'width 0.2s ease, height 0.2s ease' }} />
                 {activeChangeReview ? (
-                  <AIChangeReviewWorkbench
-                    review={activeChangeReview as Parameters<typeof AIChangeReviewWorkbench>[0]['review']}
-                    queueLength={(activeChangeReviewQueue as unknown[]).length}
-                  />
+                  <Suspense fallback={null}>
+                    <AIChangeReviewWorkbench
+                      review={activeChangeReview as Parameters<typeof AIChangeReviewWorkbench>[0]['review']}
+                      queueLength={(activeChangeReviewQueue as unknown[]).length}
+                    />
+                  </Suspense>
                 ) : null}
                 {activeRestorePreviewReview && (activeRestorePreviewReview as { review?: unknown }).review ? (
-                  <AIChangeReviewWorkbench
-                    review={(activeRestorePreviewReview as { review: unknown }).review as Parameters<typeof AIChangeReviewWorkbench>[0]['review']}
-                    queueLength={1}
-                    previewOnly={true}
-                    onClose={() => {
-                      if (!activeWorkspaceTerminalKey) {
-                        return;
-                      }
-                      (setRestorePreviewReviews as (updater: (prev: Record<string, unknown>) => Record<string, unknown>) => void)((prev) => {
-                        if (!prev[activeWorkspaceTerminalKey]) {
-                          return prev;
+                  <Suspense fallback={null}>
+                    <AIChangeReviewWorkbench
+                      review={(activeRestorePreviewReview as { review: unknown }).review as Parameters<typeof AIChangeReviewWorkbench>[0]['review']}
+                      queueLength={1}
+                      previewOnly={true}
+                      onClose={() => {
+                        if (!activeWorkspaceTerminalKey) {
+                          return;
                         }
-                        const next = { ...prev };
-                        delete next[activeWorkspaceTerminalKey];
-                        return next;
-                      });
-                    }}
-                  />
+                        (setRestorePreviewReviews as (updater: (prev: Record<string, unknown>) => Record<string, unknown>) => void)((prev) => {
+                          if (!prev[activeWorkspaceTerminalKey]) {
+                            return prev;
+                          }
+                          const next = { ...prev };
+                          delete next[activeWorkspaceTerminalKey];
+                          return next;
+                        });
+                      }}
+                    />
+                  </Suspense>
                 ) : null}
                 {activeConversationDiffPanel ? (
                   <AIConversationDiffOverlay

--- a/frontend/src/components/ai/AIConversationDiffOverlay.tsx
+++ b/frontend/src/components/ai/AIConversationDiffOverlay.tsx
@@ -14,6 +14,8 @@ export interface ConversationDiffItem {
   status: string
   copyContent: string
   order: number
+  /** 该条目已被还原（按钮持久显示「已还原」并禁用） */
+  restored?: boolean
 }
 
 function normalizeItems(items: unknown): ConversationDiffItem[] {
@@ -30,6 +32,7 @@ function normalizeItems(items: unknown): ConversationDiffItem[] {
         status: typeof item.status === 'string' ? item.status.trim() : '',
         copyContent: typeof item.copyContent === 'string' ? item.copyContent : '',
         order: Number.isFinite(Number(item.order)) ? Number(item.order) : index + 1,
+        restored: item.restored === true,
       }))
       .filter((item) => item.artifactPath)
     : []
@@ -193,7 +196,9 @@ export default function AIConversationDiffOverlay({
 }: AIConversationDiffOverlayProps) {
   const { t } = useTranslation()
   const [copiedItemId, setCopiedItemId] = useState('')
-  const [actionSucceeded, setActionSucceeded] = useState({ itemId: '', kind: '' })
+  // 仅用于左键「重新应用」成功后的短暂「已应用」反馈（可重复触发，故保留 1.2s 重置）；
+  // 还原态则由全局 item.restored 持久驱动，不再用本地临时态
+  const [appliedItemId, setAppliedItemId] = useState('')
   const normalizedItems = useMemo(() => normalizeItems(items), [items])
   const activeItem = useMemo(() => (
     normalizedItems.find((item) => item.messageId === selectedMessageId)
@@ -210,12 +215,12 @@ export default function AIConversationDiffOverlay({
   }, [copiedItemId])
 
   useEffect(() => {
-    if (!actionSucceeded.itemId) {
+    if (!appliedItemId) {
       return undefined
     }
-    const timer = window.setTimeout(() => setActionSucceeded({ itemId: '', kind: '' }), 1200)
+    const timer = window.setTimeout(() => setAppliedItemId(''), 1200)
     return () => window.clearTimeout(timer)
-  }, [actionSucceeded])
+  }, [appliedItemId])
 
   const handleCopyItemContent = async (item: ConversationDiffItem) => {
     const itemId = typeof item?.id === 'string' ? item.id : ''
@@ -239,26 +244,23 @@ export default function AIConversationDiffOverlay({
   const handlePreviewItemRestore = async (item: ConversationDiffItem) => {
     const artifactPath = typeof item?.artifactPath === 'string' ? item.artifactPath.trim() : ''
     const itemId = typeof item?.id === 'string' ? item.id : ''
-    if (!artifactPath) {
+    if (!artifactPath || item?.restored) {
       return
     }
     const applied = await onPreviewRestore?.(artifactPath)
     if (applied === true && itemId) {
-      setActionSucceeded({ itemId, kind: 'apply' })
+      setAppliedItemId(itemId)
     }
   }
 
   const handleApplyItemRestore = async (event: React.MouseEvent, item: ConversationDiffItem) => {
     const artifactPath = typeof item?.artifactPath === 'string' ? item.artifactPath.trim() : ''
-    const itemId = typeof item?.id === 'string' ? item.id : ''
-    if (!artifactPath) {
+    if (!artifactPath || item?.restored) {
       return
     }
     event.preventDefault()
-    const applied = await onApplyRestore?.(artifactPath)
-    if (applied === true && itemId) {
-      setActionSucceeded({ itemId, kind: 'restore' })
-    }
+    // 还原成功后由 useAIReview 标记 item.restored=true（全局单一数据源），按钮持久显示「已还原」并禁用
+    await onApplyRestore?.(artifactPath)
   }
 
   return (
@@ -351,8 +353,8 @@ export default function AIConversationDiffOverlay({
           {normalizedItems.map((item) => {
             const isActive = activeItem?.id === item.id
             const isCopied = copiedItemId === item.id
-            const isActionSucceeded = actionSucceeded.itemId === item.id
-            const itemActionKind = isActionSucceeded ? actionSucceeded.kind : ''
+            const isRestored = item.restored === true
+            const isApplied = appliedItemId === item.id
             const itemTitle = item.title || item.toolName || item.id
             const itemSummary = item.summary && item.summary !== itemTitle ? item.summary : ''
             const review = item.artifactPath && reviewByArtifactPath && typeof reviewByArtifactPath === 'object'
@@ -465,17 +467,17 @@ export default function AIConversationDiffOverlay({
                       </Tiptop>
                     ) : null}
                     {item.artifactPath ? (
-                      <Tiptop text={isActionSucceeded ? (itemActionKind === 'restore' ? t('已还原') : t('已应用')) : t('左键应用/右键还原')} style={{ display: 'inline-flex' }}>
+                      <Tiptop text={isRestored ? t('已还原') : (isApplied ? t('已应用') : t('左键应用/右键还原'))} style={{ display: 'inline-flex' }}>
                         <button
                           type="button"
-                          onClick={() => {
+                          onClick={isRestored ? undefined : () => {
                             void handlePreviewItemRestore(item)
                           }}
                           onMouseDown={(event) => {
                             event.preventDefault()
                             event.stopPropagation()
                           }}
-                          onContextMenu={(event) => {
+                          onContextMenu={isRestored ? undefined : (event) => {
                             void handleApplyItemRestore(event, item)
                           }}
                           style={{
@@ -485,15 +487,15 @@ export default function AIConversationDiffOverlay({
                             gap: 5,
                             padding: '0 8px',
                             borderRadius: 999,
-                            border: isActionSucceeded ? '1px solid rgba(var(--success-rgb), 0.28)' : '1px solid rgba(var(--accent-rgb), 0.24)',
-                            background: isActionSucceeded ? 'rgba(var(--success-rgb), 0.10)' : 'rgba(var(--accent-rgb), 0.08)',
-                            color: isActionSucceeded ? 'var(--success)' : 'var(--text-secondary)',
+                            border: isRestored || isApplied ? '1px solid rgba(var(--success-rgb), 0.28)' : '1px solid rgba(var(--accent-rgb), 0.24)',
+                            background: isRestored || isApplied ? 'rgba(var(--success-rgb), 0.10)' : 'rgba(var(--accent-rgb), 0.08)',
+                            color: isRestored || isApplied ? 'var(--success)' : 'var(--text-secondary)',
                             fontSize: 11,
                             fontWeight: 700,
-                            cursor: 'pointer',
+                            cursor: isRestored ? 'default' : 'pointer',
                           }}>
-                          <RotateCcw size={11} color={isActionSucceeded ? 'currentColor' : 'var(--accent)'} />
-                          <span>{isActionSucceeded ? (itemActionKind === 'restore' ? t('已还原') : t('已应用')) : t('应用')}</span>
+                          <RotateCcw size={11} color={isRestored || isApplied ? 'currentColor' : 'var(--accent)'} />
+                          <span>{isRestored ? t('已还原') : (isApplied ? t('已应用') : t('应用'))}</span>
                         </button>
                       </Tiptop>
                     ) : null}

--- a/frontend/src/components/ai/AIDiffViewerPair.tsx
+++ b/frontend/src/components/ai/AIDiffViewerPair.tsx
@@ -1,10 +1,49 @@
-import { DiffEditor, loader } from '@monaco-editor/react'
-import * as monaco from 'monaco-editor'
-import cssWorker from '../../../node_modules/monaco-editor/esm/vs/language/css/css.worker.js?worker'
-import htmlWorker from '../../../node_modules/monaco-editor/esm/vs/language/html/html.worker.js?worker'
+// 瘦身：不再全量引入 'monaco-editor'（editor.main 会带入全部 84 种语言 + LSP features + lsp-client，
+// 主包增量约 4MB）。改为 editor.api 核心 + 按需注册 LANGUAGE_BY_EXTENSION 映射所需的语言（26 种全保留）。
+// 类型声明见 src/types/monaco-slim.d.ts（复用主包类型，纯声明不进 bundle）。
+// 注：monaco-editor 的 exports 为 "./*": "./esm/vs/*.js"，子路径不带 esm/vs 前缀
+import * as monaco from 'monaco-editor/editor/editor.api.js'
+// 纯 tokenizer 语言（definitions/，无需语言 worker）；cpp 注册文件同时注册 c + cpp
+import 'monaco-editor/languages/definitions/bat/register.js'
+import 'monaco-editor/languages/definitions/cpp/register.js'
+import 'monaco-editor/languages/definitions/csharp/register.js'
+import 'monaco-editor/languages/definitions/css/register.js'
+import 'monaco-editor/languages/definitions/dockerfile/register.js'
+import 'monaco-editor/languages/definitions/go/register.js'
+import 'monaco-editor/languages/definitions/html/register.js'
+import 'monaco-editor/languages/definitions/ini/register.js'
+import 'monaco-editor/languages/definitions/java/register.js'
+import 'monaco-editor/languages/definitions/javascript/register.js'
+import 'monaco-editor/languages/definitions/kotlin/register.js'
+import 'monaco-editor/languages/definitions/less/register.js'
+import 'monaco-editor/languages/definitions/markdown/register.js'
+import 'monaco-editor/languages/definitions/php/register.js'
+import 'monaco-editor/languages/definitions/powershell/register.js'
+import 'monaco-editor/languages/definitions/python/register.js'
+import 'monaco-editor/languages/definitions/ruby/register.js'
+import 'monaco-editor/languages/definitions/rust/register.js'
+import 'monaco-editor/languages/definitions/scss/register.js'
+import 'monaco-editor/languages/definitions/shell/register.js'
+import 'monaco-editor/languages/definitions/sql/register.js'
+import 'monaco-editor/languages/definitions/swift/register.js'
+import 'monaco-editor/languages/definitions/xml/register.js'
+import 'monaco-editor/languages/definitions/yaml/register.js'
+// worker 版语言（features/）：0.56 中 json/typescript 仅此版本，保留对应 worker
+import 'monaco-editor/languages/features/json/register.js'
+import 'monaco-editor/languages/features/typescript/register.js'
+// 补注册精简版缺失的编辑器服务：editor.api 精简版中 contrib 已注册但对应服务未注册，
+// 创建编辑器实例化贡献时抛 "depends on UNKNOWN service"（全量版 editor.main 连带加载）。
+// 逐个补齐（与 outlineModel 同一模式）：
+import 'monaco-editor/editor/contrib/documentSymbols/browser/outlineModel.js'
+import 'monaco-editor/editor/contrib/codelens/browser/codeLensCache.js'
+import 'monaco-editor/editor/contrib/inlayHints/browser/inlayHintsController.js'
+import 'monaco-editor/editor/contrib/suggest/browser/suggestMemory.js'
+import 'monaco-editor/editor/common/services/treeViewsDndService.js'
+import 'monaco-editor/platform/actionWidget/browser/actionWidget.js'
+// worker：只保留 editor / json / ts（css/html 用 tokenizer 版后无需语言 worker）
+import editorWorker from '../../../node_modules/monaco-editor/esm/vs/editor/editor.worker.js?worker'
 import jsonWorker from '../../../node_modules/monaco-editor/esm/vs/language/json/json.worker.js?worker'
 import tsWorker from '../../../node_modules/monaco-editor/esm/vs/language/typescript/ts.worker.js?worker'
-import editorWorker from '../../../node_modules/monaco-editor/esm/vs/editor/editor.worker.js?worker'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { I18nKey } from '../../i18n.ts'
 import { getAppThemeMode } from '../../utils/theme.ts'
@@ -99,6 +138,24 @@ const LANGUAGE_BY_EXTENSION: Record<string, string> = {
   zsh: 'shell',
 }
 
+function createMonacoWorker(kind: 'editor' | 'json' | 'ts'): Worker {
+  // dev 模式：esm/vs 的 worker 是 ESM 模块，classic worker（importScripts）无法加载，
+  // Monaco 会回退主线程执行语言服务导致 UI 卡顿（打开审阅面板时尤其明显），且 diff 计算
+  // （computeDiff）依赖 worker——worker 失败会导致变更行红绿高亮消失。
+  // 故 dev 下用 vite 插件（vite.config.ts monacoDevWorkersPlugin）预先打包的 iife worker
+  // （esbuild 产物，classic worker 可直接加载，同版本 postMessage 协议兼容），生产用 vite 打包的 iife worker。
+  if (import.meta.env.DEV) {
+    return new Worker(`/node_modules/.cache/monaco-workers/${kind}.worker.js`)
+  }
+  if (kind === 'json') {
+    return new jsonWorker()
+  }
+  if (kind === 'ts') {
+    return new tsWorker()
+  }
+  return new editorWorker()
+}
+
 function ensureMonacoConfigured() {
   if (monacoConfigured || typeof globalThis === 'undefined') {
     return
@@ -106,21 +163,14 @@ function ensureMonacoConfigured() {
   globalThis.MonacoEnvironment = {
     getWorker(_workerId: string, label: string): Worker {
       if (label === 'json') {
-        return new jsonWorker()
-      }
-      if (label === 'css' || label === 'scss' || label === 'less') {
-        return new cssWorker()
-      }
-      if (label === 'html' || label === 'handlebars' || label === 'razor') {
-        return new htmlWorker()
+        return createMonacoWorker('json')
       }
       if (label === 'typescript' || label === 'javascript') {
-        return new tsWorker()
+        return createMonacoWorker('ts')
       }
-      return new editorWorker()
+      return createMonacoWorker('editor')
     },
   }
-  loader.config({ monaco })
   monacoConfigured = true
 }
 
@@ -208,9 +258,13 @@ export interface DiffEditorPairProps {
 
 export function DiffEditorPair({ block, index = 0, path = '', reviewId = '', showBlockBadge = false, t, onNavigateReady = null }: DiffEditorPairProps) {
   const [themeName, setThemeName] = useState(resolveMonacoThemeName())
+  const [editorReady, setEditorReady] = useState(false)
+  const hostRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<monaco.editor.IStandaloneDiffEditor | null>(null)
+  const modelsRef = useRef<{ original: monaco.editor.ITextModel; modified: monaco.editor.ITextModel } | null>(null)
   const diffUpdateDisposableRef = useRef<monaco.IDisposable | null>(null)
   const firstDiffRevealedRef = useRef(false)
+  const createdRef = useRef(false)
   const rawBlock = block as ReviewBlock | null | undefined
   const original = typeof rawBlock?.before === 'string' ? normalizeText(rawBlock.before) : ''
   const modified = typeof rawBlock?.after === 'string' ? normalizeText(rawBlock.after) : ''
@@ -250,6 +304,79 @@ export function DiffEditorPair({ block, index = 0, path = '', reviewId = '', sho
     firstDiffRevealedRef.current = true
     editor.goToDiff('next')
   }, [])
+
+  // 创建 + 内容更新合并为单一 effect（依赖变化即触发）：
+  // - 首次（createdRef=false）：创建 editor + models + diff 更新订阅
+  // - 后续（createdRef=true）：先 dispose 旧 models 再 create 新 models（新模型复用同一 URI，必须先释放旧的避免 already exists）
+  // 注意：不能拆成两个 effect——挂载时所有 effect 都会执行，拆分会重复 createModel 同一 uri 报 already exists
+  useEffect(() => {
+    if (!createdRef.current) {
+      const host = hostRef.current
+      if (!host) {
+        return undefined
+      }
+      const editor = monaco.editor.createDiffEditor(host, editorOptions)
+      editorRef.current = editor
+      const models = {
+        original: monaco.editor.createModel(original, language, monaco.Uri.parse(originalModelPath)),
+        modified: monaco.editor.createModel(modified, language, monaco.Uri.parse(modifiedModelPath)),
+      }
+      modelsRef.current = models
+      editor.setModel(models)
+      diffUpdateDisposableRef.current?.dispose()
+      diffUpdateDisposableRef.current = editor.onDidUpdateDiff(revealFirstDiff)
+      revealFirstDiff()
+      if (focusLine > 0 && !firstDiffRevealedRef.current) {
+        editor.revealLineInCenter(focusLine)
+      }
+      createdRef.current = true
+      setEditorReady(true)
+      return undefined
+    }
+    const editor = editorRef.current
+    if (!editor) {
+      return undefined
+    }
+    const oldModels = modelsRef.current
+    // 先 dispose 旧模型再 create 新模型：新模型复用同一 URI（path/reviewId/index 不变仅内容变），
+    // 若旧模型仍存活，createModel 会抛 "model with uri already exists"（@monaco-editor/react 内部同此顺序）
+    oldModels?.original.dispose()
+    oldModels?.modified.dispose()
+    const next = {
+      original: monaco.editor.createModel(original, language, monaco.Uri.parse(originalModelPath)),
+      modified: monaco.editor.createModel(modified, language, monaco.Uri.parse(modifiedModelPath)),
+    }
+    modelsRef.current = next
+    editor.setModel(next)
+    firstDiffRevealedRef.current = false
+    return undefined
+  }, [original, modified, language, originalModelPath, modifiedModelPath, editorOptions, revealFirstDiff, focusLine])
+
+  // 卸载：先 dispose editor（widget 先 reset），后 dispose models——
+  // 顺序与 @monaco-editor/react 相反，避免 "TextModel got disposed before DiffEditorWidget model got reset"
+  useEffect(() => () => {
+    diffUpdateDisposableRef.current?.dispose()
+    diffUpdateDisposableRef.current = null
+    const oldModels = modelsRef.current
+    modelsRef.current = null
+    const editor = editorRef.current
+    editorRef.current = null
+    createdRef.current = false
+    editor?.dispose()
+    oldModels?.original.dispose()
+    oldModels?.modified.dispose()
+  }, [])
+
+  // 选项变化（ariaLabel 等）时同步
+  useEffect(() => {
+    editorRef.current?.updateOptions(editorOptions)
+  }, [editorOptions])
+
+  // 主题同步（setTheme 为全局调用，Monaco 仅本面板使用，安全）
+  useEffect(() => {
+    monaco.editor.setTheme(themeName)
+  }, [themeName])
+
   useEffect(() => {
     if (typeof onNavigateReady !== 'function') {
       return undefined
@@ -257,14 +384,7 @@ export function DiffEditorPair({ block, index = 0, path = '', reviewId = '', sho
     onNavigateReady(goToDiff)
     return () => onNavigateReady(null)
   }, [goToDiff, onNavigateReady])
-  useEffect(() => {
-    firstDiffRevealedRef.current = false
-  }, [original, modified])
-  useEffect(() => () => {
-    diffUpdateDisposableRef.current?.dispose()
-    diffUpdateDisposableRef.current = null
-    editorRef.current = null
-  }, [])
+
   useEffect(() => {
     const refreshTheme = () => setThemeName(resolveMonacoThemeName())
     refreshTheme()
@@ -328,30 +448,11 @@ export function DiffEditorPair({ block, index = 0, path = '', reviewId = '', sho
           ) : null}
         </div>
       ) : null}
-      <div style={{ minHeight: 0 }}>
-        <DiffEditor
-          height="100%"
-          width="100%"
-          original={original}
-          modified={modified}
-          language={language}
-          originalModelPath={originalModelPath}
-          modifiedModelPath={modifiedModelPath}
-          keepCurrentOriginalModel={false}
-          keepCurrentModifiedModel={false}
-          theme={themeName}
-          loading={buildLoadingNode(t('加载中...'))}
-          options={editorOptions}
-          onMount={(editor) => {
-            editorRef.current = editor
-            diffUpdateDisposableRef.current?.dispose()
-            diffUpdateDisposableRef.current = editor.onDidUpdateDiff(revealFirstDiff)
-            revealFirstDiff()
-            if (focusLine > 0 && !firstDiffRevealedRef.current) {
-              editor.revealLineInCenter(focusLine)
-            }
-          }}
-        />
+      <div style={{ minHeight: 0, position: 'relative' }}>
+        {!editorReady ? (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>{buildLoadingNode(t('加载中...'))}</div>
+        ) : null}
+        <div ref={hostRef} style={{ height: '100%', minHeight: 0 }} />
       </div>
     </div>
   )

--- a/frontend/src/components/ai/chat/AIChatToolCard.tsx
+++ b/frontend/src/components/ai/chat/AIChatToolCard.tsx
@@ -447,14 +447,6 @@ export default function AIChatToolCard({ restoreArtifactPath = '', copyContent =
     }
   }, [hasSubsequentAssistantMessage])
 
-  useEffect(() => {
-    if (!restored) {
-      return undefined
-    }
-    const timer = window.setTimeout(() => setRestored(false), 1200)
-    return () => window.clearTimeout(timer)
-  }, [restored])
-
   const normalizedRestoreArtifactPath = typeof restoreArtifactPath === 'string' ? restoreArtifactPath.trim() : ''
   const showRevertTitleButton = ['apply_diff', 'write_to_file', 'search_replace', 'edit_file', 'apply_patch'].includes(String(actionLabel || '').trim())
   const showInlineDiffPreview = showRevertTitleButton && extra?.conversationDiffHasPreview === true && Boolean(normalizedRestoreArtifactPath) && typeof onPreviewDiffFetch === 'function'
@@ -543,14 +535,14 @@ export default function AIChatToolCard({ restoreArtifactPath = '', copyContent =
   }
 
   const handlePreviewRestore = () => {
-    if (!normalizedRestoreArtifactPath) {
+    if (restored || !normalizedRestoreArtifactPath) {
       return
     }
     void onPreviewRestore?.(normalizedRestoreArtifactPath)
   }
 
   const handleApplyRestore = async () => {
-    if (!normalizedRestoreArtifactPath) {
+    if (restored || !normalizedRestoreArtifactPath) {
       return
     }
     const applied = await onApplyRestore?.(normalizedRestoreArtifactPath)
@@ -607,7 +599,7 @@ export default function AIChatToolCard({ restoreArtifactPath = '', copyContent =
             <Tiptop text={restored ? t('已还原') : t('左键预览/右键还原')} style={{ display: 'inline-flex' }}>
               <button
                 type="button"
-                onClick={(event) => {
+                onClick={restored ? undefined : (event) => {
                   event.stopPropagation()
                   handlePreviewRestore()
                 }}
@@ -615,7 +607,7 @@ export default function AIChatToolCard({ restoreArtifactPath = '', copyContent =
                   event.preventDefault()
                   event.stopPropagation()
                 }}
-                onContextMenu={(event) => {
+                onContextMenu={restored ? undefined : (event) => {
                   event.preventDefault()
                   event.stopPropagation()
                   void handleApplyRestore()
@@ -632,7 +624,7 @@ export default function AIChatToolCard({ restoreArtifactPath = '', copyContent =
                   color: restored ? 'var(--success)' : 'var(--text-secondary)',
                   fontSize: 11,
                   fontWeight: 700,
-                  cursor: 'pointer',
+                  cursor: restored ? 'default' : 'pointer',
                   flexShrink: 0,
                 }}>
                 <RotateCcw size={11} color={restored ? 'currentColor' : 'var(--accent)'} />

--- a/frontend/src/hooks/useAIReview.ts
+++ b/frontend/src/hooks/useAIReview.ts
@@ -31,6 +31,8 @@ export interface ConversationDiffItem {
   status: string;
   copyContent: string;
   order: number;
+  /** 该条目已被还原（按钮持久显示「已还原」并禁用，单一数据源） */
+  restored?: boolean;
 }
 
 /** 对话差异面板 */
@@ -294,12 +296,39 @@ export default function useAIReview({ sessionsRef, addToast, t }: UseAIReviewOpt
   const handleApplyConversationDiffRestore = useCallback(async (artifactPath: string, targetSessionId: string, targetTerminalId: string) => {
     try {
       await restoreAIChatTool(artifactPath, targetTerminalId);
+      addToast(t('已还原'), 'success', 3200);
+      // 还原成功：标记该条目 restored=true（按钮持久显示「已还原」并禁用），保留条目不再移除
+      const binding = resolveAIWorkspaceTerminalBindingByTerminalId(sessionsRef.current, targetSessionId || targetTerminalId);
+      const panelKey = binding ? buildAIWorkspaceTerminalPanelKey(binding.sessionId, binding.terminalId) : '';
+      if (panelKey) {
+        setConversationDiffPanels((prev) => {
+          const panel = prev[panelKey];
+          if (!panel || !Array.isArray(panel.items)) {
+            return prev;
+          }
+          let changed = false;
+          const nextItems = panel.items.map((item) => {
+            const p = typeof (item as { artifactPath?: unknown }).artifactPath === 'string'
+              ? String((item as { artifactPath: string }).artifactPath).trim()
+              : '';
+            if (p === artifactPath.trim() && !item.restored) {
+              changed = true;
+              return { ...item, restored: true };
+            }
+            return item;
+          });
+          if (!changed) {
+            return prev;
+          }
+          return { ...prev, [panelKey]: { ...panel, items: nextItems } };
+        });
+      }
       return true;
     } catch (error) {
       addToast(error instanceof Error ? t(error.message) : t('当前状态不支持还原'), 'error', 3200);
       return false;
     }
-  }, [addToast]);
+  }, [addToast, t]);
 
   const handleSelectConversationDiffItem = useCallback(async (item: ConversationDiffItem, options: {
     sessionId?: string;
@@ -434,6 +463,7 @@ export default function useAIReview({ sessionsRef, addToast, t }: UseAIReviewOpt
             status: typeof raw.status === 'string' ? raw.status.trim() : '',
             copyContent: typeof raw.copyContent === 'string' ? raw.copyContent : '',
             order: Number.isFinite(Number(raw.order)) ? Number(raw.order) : index + 1,
+            restored: raw.restored === true,
           };
         })
         .filter((item) => item.artifactPath);

--- a/frontend/src/types/monaco-slim.d.ts
+++ b/frontend/src/types/monaco-slim.d.ts
@@ -1,0 +1,8 @@
+// Monaco 瘦身类型桥：
+// 运行时从 editor.api.js 引入（不含 84 语言 / LSP features / lsp-client，主包 -4MB），
+// 类型复用主包 monaco-editor.d.ts（仅声明，不产生运行时依赖）。
+// 用法限制：仅使用 editor.api 提供的 API 子集（createDiffEditor / goToDiff / 主题等），
+// 语言注册一律走 esm/vs/languages/definitions|features 的 register.js 按需导入。
+declare module 'monaco-editor/editor/editor.api.js' {
+  export * from 'monaco-editor'
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,72 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { build } from 'esbuild';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+// 读取已安装的 monaco-editor 版本，用于 dev worker 缓存失效：monaco 升级后旧版 worker 的
+// postMessage 协议可能不兼容（node_modules/.cache 不会被 npm install 自动清除），需按版本重建。
+function readMonacoVersion(): string {
+  try {
+    const pkgPath = join(process.cwd(), 'node_modules', 'monaco-editor', 'package.json');
+    return String(JSON.parse(readFileSync(pkgPath, 'utf-8')).version || 'unknown');
+  } catch {
+    return 'unknown';
+  }
+}
+
+// dev 模式：monaco 的 ESM worker 无法被 classic worker 加载（vite dev 不转换 node_modules 的 ?worker），
+// Monaco 会回退主线程执行语言服务导致 UI 卡顿（打开 AI 审阅面板时尤其明显）。
+// dev server 启动时用 esbuild 将 monaco worker 打包为 iife 缓存到 node_modules/.cache/monaco-workers/，
+// 前端 dev 分支（AIDiffViewerPair.createMonacoWorker）从该目录加载；生产构建仍用 ?worker 打包，不受影响。
+function monacoDevWorkersPlugin() {
+  return {
+    name: 'monaco-dev-workers',
+    apply: 'serve' as const,
+    async configureServer() {
+      const outputDir = join(process.cwd(), 'node_modules', '.cache', 'monaco-workers');
+      const version = readMonacoVersion();
+      const versionFile = join(outputDir, '.version');
+      // 版本不一致（或首次无标记）→ 清空旧缓存重建，避免跨版本协议错位
+      let versionStale = true;
+      try {
+        if (existsSync(versionFile) && readFileSync(versionFile, 'utf-8').trim() === version) {
+          versionStale = false;
+        }
+      } catch {
+        versionStale = true;
+      }
+      if (versionStale) {
+        rmSync(outputDir, { recursive: true, force: true });
+      }
+      const workers = [
+        { name: 'editor', entry: 'monaco-editor/editor/editor.worker.js' },
+        { name: 'json', entry: 'monaco-editor/language/json/json.worker.js' },
+        { name: 'ts', entry: 'monaco-editor/language/typescript/ts.worker.js' },
+      ];
+      for (const w of workers) {
+        const outfile = join(outputDir, `${w.name}.worker.js`);
+        if (existsSync(outfile)) {
+          continue;
+        }
+        mkdirSync(dirname(outfile), { recursive: true });
+        await build({
+          entryPoints: [w.entry],
+          bundle: true,
+          format: 'iife',
+          outfile,
+          platform: 'browser',
+          logLevel: 'silent',
+        });
+      }
+      // 全部构建完成后再写版本标记；构建中途抛错则不会到达此处，下次启动自动重试
+      mkdirSync(outputDir, { recursive: true });
+      try {
+        writeFileSync(versionFile, version, 'utf-8');
+      } catch {}
+    },
+  };
+}
 
 const buildTime = new Intl.DateTimeFormat('sv-SE', {
   timeZone: 'Asia/Shanghai',
@@ -16,10 +83,7 @@ export default defineConfig({
   define: {
     __APP_BUILD_TIME__: JSON.stringify(buildTime),
   },
-  plugins: [react()],
-  optimizeDeps: {
-    include: ['monaco-editor'],
-  },
+  plugins: [react(), monacoDevWorkersPlugin()],
   server: {
     port: 5173,
     host: '127.0.0.1',


### PR DESCRIPTION
## 背景

前端 Monaco 编辑器全量引入（`editor.main` 含 84 种语言 + LSP features），主包约 +4MB，dev/prod 编译明显变慢。本次对其瘦身，并顺带修复 AI 还原按钮的状态问题与几处健壮性隐患。

## Monaco 瘦身
- 移除 `@monaco-editor/react`，改用 `editor.api` 核心 + 按需注册所需语言
- CSS/HTML 改 tokenizer-only（只读 diff 无需语言 worker），仅保留 editor/json/ts worker
- `AIChangeReviewWorkbench` 改 `lazy` 加载，移出应用启动路径
- 补齐精简版缺失的编辑器服务（outlineModel 等），避免实例化时 `depends on UNKNOWN service`

## 健壮性
- **DiffEditorPair 更新分支**：改为先 dispose 旧模型再 create 新模型，消除同 URI 下 `model already exists` 地雷（迁移遗留）
- **dev worker 缓存**：按 monaco 版本失效，升级后自动重建（`node_modules/.cache` 不会被 npm 清除，避免跨版本协议错位）
- 移除遗留的 `optimizeDeps.include: ['monaco-editor']`（bare 全量入口，dev 会预打包全量 monaco）

## AI 还原按钮「已还原」态修复
- 还原成功后按钮**持久显示「已还原」并禁用**（原先 1.2s 后闪回「还原」，再点弹「当前状态不支持还原」）
- 还原态改为单一数据源：浮层 `item.restored`（全局）、内联卡片本地 `restored`，去掉 1.2s 临时定时器
- 浮层（对话变更浮层）与内联卡片（聊天工具卡）行为统一；还原成功统一 toast「已还原」反馈

## 验证
- `npx tsc --noEmit` 通过
- monaco 版本读取实测 `0.56.0`，worker 缓存失效逻辑正常
- 手动验证：浮层 / 内联卡片右键还原 → 持久「已还原」+ 不可点击、无报错；左键重新应用正常
