### PR TITLE
修复(Linux): WebSocket Origin 白名单缺少 wails://wails.localhost，dev 模式终端空白无输出

### DIFF
--- a/internal/wailsapp/app.go
+++ b/internal/wailsapp/app.go
@@ -229,10 +229,22 @@ func (a *App) startup(ctx context.Context) {
 			if origin == "" {
 				return false
 			}
+			// Wails WebView 自定义协议 Origin（不同平台 / Wails 版本表现不一）：
+			//   wails://wails                       —— Windows WebView2（旧版）
+			//   wails://wails.localhost[:port]      —— Linux/macOS WebKit dev 模式实测
+			//                                          （页面 origin=wails://wails.localhost:<vitePort>）
+			//   wails://localhost[:port]            —— 部分环境 WebKit baseURL
+			//   http(s)://wails.localhost[:port]    —— Windows WebView2
+			// dev 模式下 host 后会带 vite/dev 端口。每个 host 用「精确匹配 + 带冒号前缀」，
+			// 避免误匹配 wails.localhost.attacker.com 之类的子域（DNS-rebinding 防护）。
 			if origin == "wails://wails" ||
+				origin == "wails://wails.localhost" ||
+				strings.HasPrefix(origin, "wails://wails.localhost:") ||
+				origin == "wails://localhost" ||
+				strings.HasPrefix(origin, "wails://localhost:") ||
 				origin == "http://wails.localhost" ||
-				origin == "https://wails.localhost" ||
 				strings.HasPrefix(origin, "http://wails.localhost:") ||
+				origin == "https://wails.localhost" ||
 				strings.HasPrefix(origin, "https://wails.localhost:") {
 				return true
 			}


### PR DESCRIPTION
## 问题

在 Linux（Wails WebKit）开发模式下，终端区域完全空白，前端控制台持续报：

```
WebSocket connection to 'ws://127.0.0.1:<port>/ws/<session>?token=...' failed:
The server did not accept the WebSocket handshake.
```

xterm 收不到任何数据，**导致 Linux 下无法正常进行开发调试**。

## 根因（已实测确认，非推测）

后端本地 WebSocket 终端服务（`internal/wailsapp/app.go`）的 `CheckOrigin` 白名单未覆盖 Linux WebKit dev 模式实际的页面 Origin。

在 `CheckOrigin` 增加诊断日志后实测，dev 模式下页面 Origin 为：

```
wails://wails.localhost:<vitePort>     例如 wails://wails.localhost:34115
```

它既不是 Windows WebView2 的 `wails://wails`，也不是部分环境假设的 `wails://localhost`，因此不在白名单内 → 握手被 403 拒绝 → 终端无输出。

```
[WS-DEBUG] CheckOrigin origin="wails://wails.localhost:34115" allowed=false
```

## 修复

在 `CheckOrigin` 白名单中补全各 Wails 自定义协议 Origin：

- 新增 `wails://wails.localhost`（精确匹配 + 带端口前缀）—— 本次实测的 Linux dev 模式
- 补全 `wails://localhost`、`http(s)://wails.localhost` 各项

每个 host 统一采用「精确匹配 + 带冒号前缀」（如 `wails://wails.localhost:`），避免误匹配 `wails.localhost.attacker.com` 之类的子域，保留原有 DNS-rebinding 防护强度。

## 验证

- ✅ Linux dev 模式重新构建运行后，终端正常输出，WebSocket 握手成功
- ✅ `go build ./internal/wailsapp/` 编译通过

## 影响范围

仅补全 Origin 白名单，解决 Linux 开发环境下的终端连接问题，不影响 Windows 等其他平台既有行为。