### PR TITLE
fix: 修复 SSH 通道占用虚高、连接取消泄漏、托盘冻结与日志不落盘

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1057,6 +1057,7 @@ export default function App() {
     replaceAllSessionFileManagerWorkspaces,
     resolveSessionRootTerminalId,
     restoringWorkspaceRef,
+    restoringWorkspaceSessionIds,
     serversLoaded,
     serversRef,
     sessionsRef,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -298,7 +298,9 @@ export default function App() {
   }, [awaitDisconnectTerminals, markConnectionCancelled]);
   const disconnectSessionConnection = useCallback((sessionId: string, terminalIds: string[] = []) => {
     const ids = markConnectionCancelled([sessionId, ...terminalIds]);
-    return AppGo.DisconnectSSHConnection(sessionId).then(() => ids);
+    // 传入全部终端 id：根终端可能已提前关闭（单独关标签/根 shell 退出），
+    // 后端凭根 id 无法定位共享连接，逐个断开可避免子终端孤儿泄漏。
+    return AppGo.DisconnectSSHConnection(sessionId, terminalIds).then(() => ids);
   }, [markConnectionCancelled]);
   const registerServerDisconnect = useCallback((serverId: string, disconnectPromise: Promise<unknown>) => {
     const normalizedServerId = typeof serverId === 'string' ? serverId.trim() : '';

--- a/frontend/src/hooks/useSessionConnections.ts
+++ b/frontend/src/hooks/useSessionConnections.ts
@@ -92,6 +92,7 @@ export interface UseSessionConnectionsDeps {
     label?: string,
   ) => string | null;
   restoringWorkspaceRef: React.MutableRefObject<boolean>;
+  restoringWorkspaceSessionIds: Set<string>;
   serversLoaded: boolean;
   serversRef: React.MutableRefObject<config.Connection[]>;
   sessionsRef: React.MutableRefObject<SessionLike[]>;
@@ -203,6 +204,7 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
     remapSessionWorkspaceLayouts, remapTerminalPaneLayouts, rememberSessionActiveTerminal,
     rememberWorkspace, rememberWorkspaceLoaded, removeChangeReviewsByRequestId,
     replaceAllSessionFileManagerWorkspaces, resolveSessionRootTerminalId, restoringWorkspaceRef,
+    restoringWorkspaceSessionIds,
     serversLoaded, serversRef, sessionsRef, setActiveSessionId, setActiveTerminalId,
     setConnectingServers, setContentTab, setCreatingTerminalSessionId, setCredentials,
     setMonitoringEnabled, setMountedSessions, setRestoringWorkspaceSessionIds, setServers,
@@ -1207,8 +1209,9 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
       // reconnectSession 会与恢复循环并发对同一 sessionId 执行 ConnectSSH，
       // 后端 setupSession 把同一 id 重复登记进 connTerminals（[X, X]），
       // 多出的通道无法被前端感知，关闭后残留 → 通道占用持续 +1。
-      // 恢复进行中直接切焦点，等待恢复完成即可。
-      if (restoringWorkspaceRef.current) {
+      // 恢复进行中直接切焦点，等待恢复完成即可。只对正在恢复的会话生效——
+      // 恢复窗口内点其它 closed/error 会话（如已恢复失败的）不应被吞掉，仍走重连。
+      if (restoringWorkspaceRef.current && restoringWorkspaceSessionIds.has(closedSession.id!)) {
         setActiveSessionId(closedSession.id!);
         setActiveTerminalId(resolveSessionRootTerminalId(closedSession, lastTerminalRef.current[closedSession.id!]));
         setContentTab(resolveSessionContentTab(closedSession.id!));
@@ -1308,7 +1311,7 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
     } catch (err) {
       handleConnectError(sessionId, err);
     }
-  }, [fileManagerPosition, handleConnectError, loadServerWorkspaceSessionSnapshot, markWorkspaceRestoreNavigationOverride, postConnectSetup, reconnectSession, recordRecentConnection, rememberWorkspace, resolveSessionContentTab, resolveSessionRootTerminalId, t, waitForServerDisconnect, workspacePersistenceLevel]);
+  }, [fileManagerPosition, handleConnectError, loadServerWorkspaceSessionSnapshot, markWorkspaceRestoreNavigationOverride, postConnectSetup, reconnectSession, recordRecentConnection, rememberWorkspace, resolveSessionContentTab, resolveSessionRootTerminalId, restoringWorkspaceSessionIds, t, waitForServerDisconnect, workspacePersistenceLevel]);
 
   // ponytail: 防双击/重复点击。双击服务器卡片会连续触发两次 connectServer，
   // 而 connectServerInner 开头有 await（waitForServerDisconnect），两次调用

--- a/frontend/src/hooks/useSessionConnections.ts
+++ b/frontend/src/hooks/useSessionConnections.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { EventsOn, WindowHide } from '../../wailsjs/runtime/runtime.js';
 import * as AppGo from '../../wailsjs/go/wailsapp/App.js';
 import type { config } from '../../wailsjs/go/models.ts';
@@ -214,6 +214,13 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
     terminalSubTabScrollTargetRef, updateSessionStatus, waitForServerDisconnect,
     workspacePersistenceLevel, workspaceRestoreNavigationOverrideRef, workspaceRestoreStartedRef,
   } = deps;
+
+  // ponytail: 防双击/重复点击同一服务器：连接进行中时忽略后续 connectServer 触发。
+  // 双击卡片会连续触发两次 onConnect，而 connectServer 开头有 await，两次调用
+  // 都能穿过 existing/closedSession 检查，各自 ConnectSSH → 服务器上开出两个
+  // /bin/bash（两个终端通道），通道占用虚高。
+  const connectingServerIdsRef = useRef<Set<string>>(new Set());
+
   const handleConnectError = useCallback((sessionId: string, err: unknown) => {
     // 如果用户已取消该连接，不再弹错误提示
     if (cancelledConnectionsRef.current.has(sessionId)) {
@@ -903,12 +910,14 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
       if (prev.some((item) => item.sessionId === sessionId)) return prev;
       const matchedServer = serversRef.current.find((server) => String(server.id) === connId);
       const matchedSession = sessionsRef.current.find((session) => session.id === sessionId);
+      // server 字段显式声明为 Connection 兼容形状，避免 || 链推导出 {} 类型导致 TS 报错
+      const fallbackServer: Pick<config.Connection, 'id' | 'name' | 'host'> = {
+        id: connId,
+        name: String(matchedSession?.serverName || matchedSession?.host || connId),
+        host: String(matchedSession?.host || ''),
+      };
       return [...prev, {
-        server: matchedServer || {
-          id: connId,
-          name: matchedSession?.serverName || matchedSession?.host || connId,
-          host: matchedSession?.host || '',
-        },
+        server: matchedServer || fallbackServer,
         sessionId,
         startTime: Date.now(),
       }];
@@ -1178,7 +1187,7 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
   }, [reconnectSession]);
 
   // ── Connect to server ──────────────────────────────────────
-  const connectServer = useCallback(async (server: config.Connection) => {
+  const connectServerInner = useCallback(async (server: config.Connection) => {
     markWorkspaceRestoreNavigationOverride();
     // 用户主动点连即记入最近，已连接仅切换焦点时也置顶
     recordRecentConnection(server?.id);
@@ -1193,10 +1202,29 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
 
     const closedSession = sessionsRef.current.find((s) => s.serverId === server.id && (s.status === 'closed' || s.status === 'error'));
     if (closedSession) {
+      // ponytail: 应用启动的工作区恢复正在重连该会话（恢复循环先 put 了
+      // sessions 再逐个 reconnectSession，期间状态为 closed）。此时再走
+      // reconnectSession 会与恢复循环并发对同一 sessionId 执行 ConnectSSH，
+      // 后端 setupSession 把同一 id 重复登记进 connTerminals（[X, X]），
+      // 多出的通道无法被前端感知，关闭后残留 → 通道占用持续 +1。
+      // 恢复进行中直接切焦点，等待恢复完成即可。
+      if (restoringWorkspaceRef.current) {
+        setActiveSessionId(closedSession.id!);
+        setActiveTerminalId(resolveSessionRootTerminalId(closedSession, lastTerminalRef.current[closedSession.id!]));
+        setContentTab(resolveSessionContentTab(closedSession.id!));
+        return;
+      }
       setActiveSessionId(closedSession.id!);
       setActiveTerminalId(resolveSessionRootTerminalId(closedSession, lastTerminalRef.current[closedSession.id!]));
       setContentTab(resolveSessionContentTab(closedSession.id!));
-      await reconnectSession(closedSession);
+      // ponytail: 手动进入只开根终端。残留会话的 terminals 可能含历史子终端
+      // （含虚拟根重建产生的 [根, 子]），reconnectSession 会逐个 OpenTerminal
+      // 把子终端全部重开 —— 服务器上多出 N 个 /bin/bash，通道占用虚高。
+      // 用户需要多终端时可手动点「+」明确创建。
+      await reconnectSession({
+        ...closedSession,
+        terminals: [{ id: closedSession.id!, label: `${t('终端')}1` }],
+      });
       return;
     }
 
@@ -1210,9 +1238,12 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
       serverName: server.name || server.host,
       host: server.host,
       status: 'connecting',
-      terminals: Array.isArray(sessionSnapshot?.terminals) && sessionSnapshot.terminals.length > 0
-        ? sessionSnapshot.terminals
-        : [{ id: sessionId, label: `${t('终端')}1` }],
+      // ponytail: 手动进入只开根终端。快照里的子终端是历史布局（可能来自
+      // 上次会话残留或虚拟根重建），reconnectSession 会逐个 OpenTerminal
+      // 重开 —— 服务器上多出 N 个 /bin/bash 且关闭后快照仍保存 N 条，循环
+      // 虚高。用户需要多终端时可手动点「+」明确创建（openNewTerminal）。
+      // app 启动的工作区恢复（restoreWorkspace）仍保留多终端布局。
+      terminals: [{ id: sessionId, label: `${t('终端')}1` }],
     };
 
     const nextSessions = [...sessionsRef.current, newSession];
@@ -1278,6 +1309,27 @@ export default function useSessionConnections(deps: UseSessionConnectionsDeps): 
       handleConnectError(sessionId, err);
     }
   }, [fileManagerPosition, handleConnectError, loadServerWorkspaceSessionSnapshot, markWorkspaceRestoreNavigationOverride, postConnectSetup, reconnectSession, recordRecentConnection, rememberWorkspace, resolveSessionContentTab, resolveSessionRootTerminalId, t, waitForServerDisconnect, workspacePersistenceLevel]);
+
+  // ponytail: 防双击/重复点击。双击服务器卡片会连续触发两次 connectServer，
+  // 而 connectServerInner 开头有 await（waitForServerDisconnect），两次调用
+  // 都能穿过 existing/closedSession 检查，各自 ConnectSSH → 服务器上开出
+  // 两个 /bin/bash（两个终端通道），通道占用虚高且标签页重复。
+  // 同一服务器连接进行中时直接忽略后续触发。
+  const connectServer = useCallback(async (server: config.Connection) => {
+    const serverId = String(server?.id || '');
+    if (!serverId) {
+      return;
+    }
+    if (connectingServerIdsRef.current.has(serverId)) {
+      return;
+    }
+    connectingServerIdsRef.current.add(serverId);
+    try {
+      await connectServerInner(server);
+    } finally {
+      connectingServerIdsRef.current.delete(serverId);
+    }
+  }, [connectServerInner]);
 
   const connectLocal = useCallback((name: string, shellPath: string) => {
     markWorkspaceRestoreNavigationOverride();

--- a/internal/platformruntime/runtime_windows.go
+++ b/internal/platformruntime/runtime_windows.go
@@ -18,8 +18,6 @@ var (
 	kernel32                     = syscall.NewLazyDLL("kernel32.dll")
 	shell32                      = syscall.NewLazyDLL("shell32.dll")
 	procEnumWindows              = user32.NewProc("EnumWindows")
-	procGetWindowTextW           = user32.NewProc("GetWindowTextW")
-	procGetWindowTextLengthW     = user32.NewProc("GetWindowTextLengthW")
 	procGetClassNameW            = user32.NewProc("GetClassNameW")
 	procGetWindowThreadProcessId = user32.NewProc("GetWindowThreadProcessId")
 	procGetWindow                = user32.NewProc("GetWindow")
@@ -77,9 +75,13 @@ const (
 	wailsFormClass  = "winc_Form"
 	systrayClass    = "SystrayClass"
 	// SendMessageTimeoutW
+	wmGetText       = 13
 	wmGetTextLength = 14
 	smtoBlock       = 0x0001
 	smtoAbortifHung = 0x0002
+	// GetWindowTextW 无超时，可能无限期阻塞在卡死的目标窗口线程上；
+	// 限时读取窗口标题用 SendMessageTimeoutW(WM_GETTEXT)，最长等 windowTextTimeout。
+	windowTextTimeout = 200
 )
 
 // trayNotifyIconData 对齐官方 NOTIFYICONDATA（uTimeout/uVersion 为 union，占 4 字节）。
@@ -140,13 +142,17 @@ func RemoveTrayIconSync() {
 	_, _, _ = procShellNotifyIconW.Call(uintptr(nimDelete), uintptr(unsafe.Pointer(&nid)))
 }
 
+// windowText 限时读取窗口标题（跨进程路径：二次启动唤醒已有实例时使用）。
+// GetWindowTextW 会向目标窗口线程同步发送 WM_GETTEXT 并等待回复，
+// 目标线程卡死时无限期阻塞（这正是此前托盘被拖死的直接原因）；
+// SendMessageTimeoutW + SMTO_ABORTIFHUNG 在目标线程 hung 时立即/限时返回。
 func windowText(hwnd syscall.Handle) string {
-	textLen, _, _ := procGetWindowTextLengthW.Call(uintptr(hwnd))
-	if textLen == 0 {
-		return ""
-	}
-	buf := make([]uint16, textLen+1)
-	procGetWindowTextW.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&buf[0])), uintptr(textLen+1))
+	buf := make([]uint16, 256)
+	_, _, _ = procSendMessageTimeoutW.Call(
+		uintptr(hwnd), uintptr(wmGetText), uintptr(len(buf)),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(smtoAbortifHung|smtoBlock), windowTextTimeout, 0,
+	)
 	return syscall.UTF16ToString(buf)
 }
 

--- a/internal/sshmanager/ssh.go
+++ b/internal/sshmanager/ssh.go
@@ -873,6 +873,19 @@ func (m *SSHManager) setupSession(ctx context.Context, client *ssh.Client, connK
 	if stale, ok := m.sessions[sessionId]; ok {
 		staleStdin = stale.Stdin
 		staleSession = stale.Session
+		// 防御性：旧条目挂在另一个 connKey 上（同 id 跨连接重登记，正常 id
+		// 含时间戳不会发生）时，把旧 key 里的 id 也摘掉，避免旧连接计数残留 +1。
+		if stale.ConnKey != "" && stale.ConnKey != connKey {
+			if old := m.connTerminals[stale.ConnKey]; len(old) > 0 {
+				next := old[:0]
+				for _, tid := range old {
+					if tid != sessionId {
+						next = append(next, tid)
+					}
+				}
+				m.connTerminals[stale.ConnKey] = next
+			}
+		}
 		next := m.connTerminals[connKey][:0]
 		for _, tid := range m.connTerminals[connKey] {
 			if tid != sessionId {
@@ -1440,10 +1453,23 @@ func (m *SSHManager) GetSFTPClient(sessionId string) (*sftp.Client, error) {
 // 导致子终端与共享 client 永久泄漏。逐个断开传入 id 使会话级关闭不依赖根终端存活。
 func (m *SSHManager) DisconnectConnection(sessionId string, terminalIds []string) {
 	m.mu.RLock()
-	ids := []string{sessionId}
-	if session := m.sessions[sessionId]; session != nil && session.ConnKey != "" {
-		ids = append(ids, m.connTerminals[session.ConnKey]...)
+	session := m.sessions[sessionId]
+	if session == nil || session.ConnKey == "" {
+		m.mu.RUnlock()
+		// 会话尚未登记：Connect 正在进行 dial/握手/认证（如等待密码输入），
+		// 此时仅凭 m.sessions 收集 targets 会整体 no-op，在途 Connect 完成后
+		// 该 session 与共享 client 永久泄漏（通道占用虚高）。Disconnect 的
+		// expected=nil 会取消 pendingCancels[sessionId]，使 Connect 在检查点
+		// 提前退出、不再登记。terminalIds 里的子终端仍逐个兜底清理。
+		m.Disconnect(sessionId)
+		for _, id := range terminalIds {
+			if id != "" && id != sessionId {
+				m.Disconnect(id)
+			}
+		}
+		return
 	}
+	ids := append([]string{sessionId}, m.connTerminals[session.ConnKey]...)
 	for _, id := range terminalIds {
 		if id != "" {
 			ids = append(ids, id)

--- a/internal/sshmanager/ssh.go
+++ b/internal/sshmanager/ssh.go
@@ -864,9 +864,32 @@ func (m *SSHManager) setupSession(ctx context.Context, client *ssh.Client, connK
 	if groupSessionId != "" {
 		sd.GroupSessionId = groupSessionId
 	}
+	// ponytail: 登记幂等化。工作区恢复与用户手动进入并发时，同一 sessionId
+	// 可能被两次 setupSession 登记：旧条目必须释放（其 Wait goroutine 因
+	// expected 不匹配不会再清理），且 connTerminals 中残留的旧 id 要去重，
+	// 否则通道占用虚高且关闭后残留。
+	var staleStdin io.WriteCloser
+	var staleSession *ssh.Session
+	if stale, ok := m.sessions[sessionId]; ok {
+		staleStdin = stale.Stdin
+		staleSession = stale.Session
+		next := m.connTerminals[connKey][:0]
+		for _, tid := range m.connTerminals[connKey] {
+			if tid != sessionId {
+				next = append(next, tid)
+			}
+		}
+		m.connTerminals[connKey] = next
+	}
 	m.sessions[sessionId] = sd
 	m.connTerminals[connKey] = append(m.connTerminals[connKey], sessionId)
 	m.mu.Unlock()
+	if staleSession != nil {
+		if staleStdin != nil {
+			_ = staleStdin.Close()
+		}
+		_ = staleSession.Close()
+	}
 	m.emitSSHChannelUsage(connKey)
 
 	go m.pipeOutput(sessionId, stdout, historyStream)
@@ -1411,15 +1434,21 @@ func (m *SSHManager) GetSFTPClient(sessionId string) (*sftp.Client, error) {
 }
 
 // DisconnectConnection 关闭 sessionId 所属共享连接的全部终端。
-func (m *SSHManager) DisconnectConnection(sessionId string) {
+// terminalIds 由前端提供（会话已知的全部终端 id），用于兜底：
+// 根终端已关闭（如根标签被单独关闭、根 shell 自然退出）而子终端仍存活时，
+// m.sessions[sessionId] 已不存在，仅凭根 id 无法定位连接，会整体 no-op，
+// 导致子终端与共享 client 永久泄漏。逐个断开传入 id 使会话级关闭不依赖根终端存活。
+func (m *SSHManager) DisconnectConnection(sessionId string, terminalIds []string) {
 	m.mu.RLock()
-	session := m.sessions[sessionId]
-	if session == nil || session.ConnKey == "" {
-		m.mu.RUnlock()
-		m.Disconnect(sessionId)
-		return
+	ids := []string{sessionId}
+	if session := m.sessions[sessionId]; session != nil && session.ConnKey != "" {
+		ids = append(ids, m.connTerminals[session.ConnKey]...)
 	}
-	ids := append([]string{sessionId}, m.connTerminals[session.ConnKey]...)
+	for _, id := range terminalIds {
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
 	targets := make(map[string]*SessionData, len(ids))
 	for _, id := range ids {
 		if current := m.sessions[id]; current != nil {
@@ -1478,14 +1507,15 @@ func (m *SSHManager) disconnect(sessionId string, expected *SessionData) bool {
 	stdin := s.Stdin
 	sshSess := s.Session
 
-	// 从 connTerminals 中移除
+	// 从 connTerminals 中移除（去掉全部同 id 条目：并发重入可能残留重复登记）
 	terminals := m.connTerminals[connKey]
-	for i, t := range terminals {
-		if t == sessionId {
-			m.connTerminals[connKey] = append(terminals[:i], terminals[i+1:]...)
-			break
+	next := terminals[:0]
+	for _, t := range terminals {
+		if t != sessionId {
+			next = append(next, t)
 		}
 	}
+	m.connTerminals[connKey] = next
 	defer m.emitSSHChannelUsage(connKey)
 
 	var netConnToClose net.Conn
@@ -1635,7 +1665,6 @@ func (m *SSHManager) OpenTerminal(sessionId string) (string, error) {
 		return "", fmt.Errorf("生成 session ID 失败: %w", err)
 	}
 	newId := fmt.Sprintf("term_%x", randomId)
-
 	launchCmd, remoteHistoryActive := buildShellLaunchCommand(existing.ShellPath, existing.TerminalInitPath)
 
 	err := m.setupSession(context.Background(), entry.Client, connKey, newId, sessionId, launchCmd, remoteHistoryActive, existing.ShellPath, existing.TerminalInitPath, terminalEncoding)

--- a/internal/sshmanager/ssh_test.go
+++ b/internal/sshmanager/ssh_test.go
@@ -344,6 +344,35 @@ func TestDisconnectConnectionCleansOrphanedTerminals(t *testing.T) {
 	}
 }
 
+// TestDisconnectConnectionCancelsInFlightConnect 复现「连接中取消」泄漏：
+// session 尚未登记进 m.sessions（Connect 正处在 dial/握手/认证，如密码弹窗），
+// 前端点取消走 DisconnectConnection —— targets 为空会整体 no-op，在途 Connect
+// 完成后永久登记。兜底必须取消 pendingCancels 里的 cancel，并清理孤儿终端。
+func TestDisconnectConnectionCancelsInFlightConnect(t *testing.T) {
+	manager := NewSSHManager()
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	manager.pendingMu.Lock()
+	manager.pendingCancels["connecting"] = cancel
+	manager.pendingMu.Unlock()
+	// 子终端已登记而根终端未登记（孤儿场景）也应被 terminalIds 兜底清理
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+	manager.clients["server"] = &sshClientEntry{NetConn: clientConn}
+	manager.sessions["orphan-child"] = &SessionData{ConnKey: "server", GroupSessionId: "connecting"}
+	manager.connTerminals["server"] = []string{"orphan-child"}
+
+	manager.DisconnectConnection("connecting", []string{"connecting", "orphan-child"})
+
+	select {
+	case <-cancelCtx.Done():
+	default:
+		t.Fatal("取消连接中会话应触发 pendingCancels 取消")
+	}
+	if len(manager.sessions) != 0 || len(manager.clients) != 0 || len(manager.connTerminals) != 0 {
+		t.Fatalf("取消后仍有资源: sessions=%d clients=%d connTerminals=%d", len(manager.sessions), len(manager.clients), len(manager.connTerminals))
+	}
+}
+
 func TestDisconnectPreservesSharedClient(t *testing.T) {
 	manager := NewSSHManager()
 	client := &ssh.Client{}

--- a/internal/sshmanager/ssh_test.go
+++ b/internal/sshmanager/ssh_test.go
@@ -5,7 +5,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -13,6 +16,7 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 func TestParseProbeOutputSkipsLocalizedDFHeader(t *testing.T) {
@@ -305,13 +309,38 @@ func TestDisconnectConnectionClosesAllTerminals(t *testing.T) {
 	manager.sessions["child"] = &SessionData{ConnKey: "server", GroupSessionId: "root"}
 	manager.connTerminals["server"] = []string{"root", "child"}
 
-	manager.DisconnectConnection("root")
+	manager.DisconnectConnection("root", []string{"root", "child"})
 
 	if len(manager.sessions) != 0 || len(manager.clients) != 0 || len(manager.connTerminals) != 0 {
 		t.Fatalf("关闭连接后仍有资源: sessions=%d clients=%d connTerminals=%d", len(manager.sessions), len(manager.clients), len(manager.connTerminals))
 	}
 	if _, err := serverConn.Read(make([]byte, 1)); err == nil {
 		t.Fatal("关闭连接后底层 SSH transport 仍可读取")
+	}
+}
+
+// TestDisconnectConnectionCleansOrphanedTerminals 复现「根终端已关闭、子终端成为孤儿」的泄漏：
+// 用户在根终端标签上点 X（或根 shell 自然退出）时后端只删了根 session，
+// connTerminals 里残留子终端；随后会话级关闭只携带根 id，后端因根 session 已不在
+// map 中而整体 no-op，子终端与共享 client 永久泄漏，导致每次重新进入同一服务器
+// 通道占用恒多 1 个。
+func TestDisconnectConnectionCleansOrphanedTerminals(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+	manager := NewSSHManager()
+	manager.clients["server"] = &sshClientEntry{NetConn: clientConn}
+	// 根终端已被关闭（m.sessions 无 root），但子终端与共享连接仍存活
+	manager.sessions["child"] = &SessionData{ConnKey: "server", GroupSessionId: "root"}
+	manager.connTerminals["server"] = []string{"child"}
+
+	// 前端仍持有该会话，关闭时传入全部终端 id（含已不存在的根 id）
+	manager.DisconnectConnection("root", []string{"root", "child"})
+
+	if len(manager.sessions) != 0 || len(manager.clients) != 0 || len(manager.connTerminals) != 0 {
+		t.Fatalf("关闭会话后仍有资源: sessions=%d clients=%d connTerminals=%d", len(manager.sessions), len(manager.clients), len(manager.connTerminals))
+	}
+	if _, err := serverConn.Read(make([]byte, 1)); err == nil {
+		t.Fatal("关闭会话后底层 SSH transport 仍可读取")
 	}
 }
 
@@ -437,5 +466,239 @@ func TestAuthFailedIsIdentifiableSentinel(t *testing.T) {
 	}
 	if errors.Is(ErrHostKeyChanged, ErrAuthFailed) {
 		t.Fatal("主机密钥变更不应被判定为认证失败")
+	}
+}
+
+// ─── 端到端连接生命周期测试 ─────────────────────────────────────
+
+// newCycleTestServer 起一个接受多次连接的测试 SSH 服务器（NoClientAuth）。
+// 每次连接的 session 通道：exec 请求回复 true 后关闭通道（命令立即结束）；
+// shell 请求回复 true 并保持通道打开（模拟 shell 常驻）；sftp 子系统直接拒绝，
+// 让 initSFTPClient 快速失败（测试只关心终端通道计数）。
+func newCycleTestServer(t *testing.T) (host string, port int, hostKeyLine string, cleanup func()) {
+	t.Helper()
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(signer)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := listener.Addr().(*net.TCPAddr)
+	host, port = addr.IP.String(), addr.Port
+	hostKeyLine = knownhosts.Line([]string{dialAddr(host, port)}, signer.PublicKey())
+
+	go func() {
+		// 不限连接数：Connect 对瞬态错误会重试重拨，预算耗尽会误报被测代码泄漏
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func() {
+				server, channels, requests, serverErr := ssh.NewServerConn(conn, serverConfig)
+				if serverErr != nil {
+					conn.Close()
+					return
+				}
+				defer server.Close()
+				go func() {
+					for newChannel := range channels {
+						if newChannel.ChannelType() != "session" {
+							newChannel.Reject(ssh.UnknownChannelType, "测试服务不支持通道")
+							continue
+						}
+						channel, channelRequests, acceptErr := newChannel.Accept()
+						if acceptErr != nil {
+							continue
+						}
+						go func() {
+							defer channel.Close()
+							for request := range channelRequests {
+								switch request.Type {
+								case "exec":
+									// 命令立即结束：回复 true 后关闭通道
+									_ = request.Reply(true, nil)
+									return
+								case "shell":
+									// shell 常驻：回复 true，保持通道打开
+									_ = request.Reply(true, nil)
+								default:
+									_ = request.Reply(true, nil)
+								}
+							}
+						}()
+					}
+				}()
+				for range requests {
+				}
+			}()
+		}
+	}()
+	cleanup = func() {
+		listener.Close()
+	}
+	return host, port, hostKeyLine, cleanup
+}
+
+// setupCycleTestManager 准备可驱动完整 Connect 的 SSHManager：
+// known_hosts 预置测试服务器公钥（Connect 走 initKnownHostsCallback）。
+func setupCycleTestManager(t *testing.T, host string, port int, hostKeyLine string) *SSHManager {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("USERPROFILE", tmp) // Windows
+	t.Setenv("HOME", tmp)        // Unix
+	if err := os.MkdirAll(filepath.Join(tmp, ".ssh"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".ssh", "known_hosts"), []byte(hostKeyLine+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return NewSSHManager()
+}
+
+// TestConnectDisconnectCycleTerminalCount 模拟用户反复「进入 → 退出」同一服务器：
+// 每次进入 Connect 应恰好登记 1 个终端，每次退出（会话级关闭）应清零，
+// 通道占用不能出现 1↔2 循环。
+func TestConnectDisconnectCycleTerminalCount(t *testing.T) {
+	host, port, hostKeyLine, cleanup := newCycleTestServer(t)
+	defer cleanup()
+	manager := setupCycleTestManager(t, host, port, hostKeyLine)
+	conn := Connection{ID: "server-1", Username: "test", Host: host, Port: port, AuthMethod: ""}
+
+	sid := "session_1"
+	for i := 0; i < 4; i++ {
+		if err := manager.Connect(sid, conn); err != nil {
+			t.Fatalf("第 %d 次进入失败: %v", i+1, err)
+		}
+		if got := len(manager.connTerminals[conn.ID]); got != 1 {
+			t.Fatalf("第 %d 次进入后终端数 = %d，期望 1", i+1, got)
+		}
+		// 退出：与前端 forceCloseSession 一致，会话级关闭
+		manager.DisconnectConnection(sid, []string{sid})
+		if got := len(manager.connTerminals[conn.ID]); got != 0 {
+			t.Fatalf("第 %d 次退出后终端数 = %d，期望 0", i+1, got)
+		}
+		if len(manager.clients) != 0 || len(manager.sessions) != 0 {
+			t.Fatalf("第 %d 次退出后仍有资源: clients=%d sessions=%d", i+1, len(manager.clients), len(manager.sessions))
+		}
+	}
+}
+
+// TestConnectDisconnectCycleViaTerminalClose 模拟用户通过「终端标签 X」关闭：
+// 单终端会话走 DisconnectSSH（与 forceCloseSession 不同路径），同样必须清零。
+func TestConnectDisconnectCycleViaTerminalClose(t *testing.T) {
+	host, port, hostKeyLine, cleanup := newCycleTestServer(t)
+	defer cleanup()
+	manager := setupCycleTestManager(t, host, port, hostKeyLine)
+	conn := Connection{ID: "server-2", Username: "test", Host: host, Port: port, AuthMethod: ""}
+
+	sid := "session_2"
+	for i := 0; i < 4; i++ {
+		if err := manager.Connect(sid, conn); err != nil {
+			t.Fatalf("第 %d 次进入失败: %v", i+1, err)
+		}
+		if got := len(manager.connTerminals[conn.ID]); got != 1 {
+			t.Fatalf("第 %d 次进入后终端数 = %d，期望 1", i+1, got)
+		}
+		// 退出：前端 closeTerminal 对单终端会话调用 DisconnectSSH
+		manager.Disconnect(sid)
+		if got := len(manager.connTerminals[conn.ID]); got != 0 {
+			t.Fatalf("第 %d 次退出后终端数 = %d，期望 0", i+1, got)
+		}
+	}
+}
+
+// TestConnectDisconnectCycleConcurrent 模拟用户快速「开关」：Connect 与
+// DisconnectConnection 并发交错执行。真实应用里 Wails 绑定在主 goroutine 串行，
+// 并发仅作压力测试——竞争下 Connect 可能瞬时失败（另一个会话关闭正在关闭共享
+// transport），这是可接受的瞬时错误；但结束后不得残留终端/客户端（泄漏）。
+func TestConnectDisconnectCycleConcurrent(t *testing.T) {
+	host, port, hostKeyLine, cleanup := newCycleTestServer(t)
+	defer cleanup()
+	manager := setupCycleTestManager(t, host, port, hostKeyLine)
+	conn := Connection{ID: "server-3", Username: "test", Host: host, Port: port, AuthMethod: ""}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		sid := fmt.Sprintf("session_%d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := manager.Connect(sid, conn); err != nil {
+				return // 竞争下的瞬时错误可接受，不视为失败
+			}
+			manager.DisconnectConnection(sid, []string{sid})
+		}()
+	}
+	wg.Wait()
+
+	// 兜底清理可能残留的会话（失败的 Connect 不应留任何状态）
+	manager.DisconnectAll()
+
+	manager.mu.RLock()
+	clients, sessions, terminals := len(manager.clients), len(manager.sessions), len(manager.connTerminals[conn.ID])
+	manager.mu.RUnlock()
+	if clients != 0 || sessions != 0 || terminals != 0 {
+		t.Fatalf("并发开关后仍有资源: clients=%d sessions=%d terminals=%d", clients, sessions, terminals)
+	}
+}
+
+// TestSetupSessionIdempotentRegistration 工作区恢复与手动进入并发时，同一
+// sessionId 可能被 setupSession 重复登记：幂等化后 connTerminals 不得出现
+// 重复 id，旧通道被释放。
+func TestSetupSessionIdempotentRegistration(t *testing.T) {
+	host, port, hostKeyLine, cleanup := newCycleTestServer(t)
+	defer cleanup()
+	manager := setupCycleTestManager(t, host, port, hostKeyLine)
+	conn := Connection{ID: "server-4", Username: "test", Host: host, Port: port, AuthMethod: ""}
+
+	// 第一次进入
+	if err := manager.Connect("term", conn); err != nil {
+		t.Fatal(err)
+	}
+	// 模拟恢复与手动进入竞态：同 id 不先断开再次 Connect
+	if err := manager.Connect("term", conn); err != nil {
+		t.Fatal(err)
+	}
+	manager.mu.RLock()
+	terminals := manager.connTerminals[conn.ID]
+	manager.mu.RUnlock()
+	if len(terminals) != 1 || terminals[0] != "term" {
+		t.Fatalf("同 id 重复登记后 connTerminals 应为 [term]，实际 %v", terminals)
+	}
+	// 断开后必须清零
+	manager.DisconnectConnection("term", []string{"term"})
+	manager.mu.RLock()
+	clients, sessions, terms := len(manager.clients), len(manager.sessions), len(manager.connTerminals[conn.ID])
+	manager.mu.RUnlock()
+	if clients != 0 || sessions != 0 || terms != 0 {
+		t.Fatalf("断开后仍有资源: clients=%d sessions=%d terminals=%d", clients, sessions, terms)
+	}
+}
+
+// TestDisconnectRemovesAllDuplicateIds 历史竞态遗留的重复 id（[X, X]）在
+// 断开时必须全部移除，不能残留半个。
+func TestDisconnectRemovesAllDuplicateIds(t *testing.T) {
+	manager := NewSSHManager()
+	manager.clients["server"] = &sshClientEntry{}
+	manager.sessions["term"] = &SessionData{ConnKey: "server"}
+	manager.connTerminals["server"] = []string{"term", "term"}
+
+	if !manager.Disconnect("term") {
+		t.Fatal("断开已登记终端应成功")
+	}
+	manager.mu.RLock()
+	terms := len(manager.connTerminals["server"])
+	manager.mu.RUnlock()
+	if terms != 0 {
+		t.Fatalf("断开后 connTerminals 应为空，实际 %d 个残留", terms)
 	}
 }

--- a/internal/wailsapp/app.go
+++ b/internal/wailsapp/app.go
@@ -831,8 +831,8 @@ func (a *App) ReconnectWithPassword(sessionId string, connId string, newPassword
 }
 
 // DisconnectSSH closes an SSH connection
-func (a *App) DisconnectSSHConnection(sessionId string) {
-	a.sshManager.DisconnectConnection(sessionId)
+func (a *App) DisconnectSSHConnection(sessionId string, terminalIds []string) {
+	a.sshManager.DisconnectConnection(sessionId, terminalIds)
 }
 
 func (a *App) DisconnectSSH(sessionId string) {

--- a/internal/wailsapp/log_test.go
+++ b/internal/wailsapp/log_test.go
@@ -1,6 +1,7 @@
 package wailsapp
 
 import (
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -59,4 +60,34 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+// failingSink 模拟写必失败的 sink（近似 GUI 进程无控制台时 os.Stderr 写失败）。
+type failingSink struct{}
+
+func (failingSink) Write(p []byte) (int, error) { return 0, io.ErrClosedPipe }
+
+// teeLogWriter 必须容忍单个 sink 失败：排在失败 sink 之后的文件 sink 仍要写入。
+// 这正是改用 teeLogWriter 取代 io.MultiWriter 的原因——io.MultiWriter 任一 sink
+// 返回 error 即放弃后续 sink，会导致 GUI 无控制台时 os.Stderr 失败 → 文件完全不落盘。
+func TestTeeLogWriterToleratesFailingSink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lumin.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatalf("打开临时日志失败: %v", err)
+	}
+	// 失败 sink 排在文件 sink 之前，复现 stderr 在 MultiWriter 首位的场景
+	tee := teeLogWriter{writers: []io.Writer{failingSink{}, f}}
+	if _, err := tee.Write([]byte("AFTER-FAIL-MARKER\n")); err != nil {
+		t.Fatalf("teeLogWriter.Write 不应向上抛 sink 错误: %v", err)
+	}
+	f.Close()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("读取日志失败: %v", err)
+	}
+	if !contains(string(raw), "AFTER-FAIL-MARKER") {
+		t.Fatalf("失败 sink 短路了文件 sink，日志未落盘: %q", string(raw))
+	}
 }

--- a/internal/wailsapp/log_test.go
+++ b/internal/wailsapp/log_test.go
@@ -1,0 +1,48 @@
+package wailsapp
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// initLogFile 必须真正落盘：设置临时配置目录后，log.Printf 应写入 lumin.log。
+func TestInitLogFileWritesToDisk(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("USERPROFILE", tmp) // Windows
+	t.Setenv("HOME", tmp)        // Unix
+	t.Setenv("APPDATA", filepath.Join(tmp, "AppData", "Roaming"))
+
+	cleanup := initLogFile()
+	if cleanup == nil {
+		t.Fatal("initLogFile 返回 nil，日志未初始化")
+	}
+	defer func() {
+		cleanup()
+		log.SetOutput(os.Stderr)
+	}()
+	log.Printf("[channel-diag] TEST-MARKER connect session=probe")
+
+	logPath := filepath.Join(tmp, "AppData", "Roaming", "Lumin", "config", "lumin.log")
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("lumin.log 未生成: %v", err)
+	}
+	if !contains(string(raw), "TEST-MARKER") {
+		t.Fatalf("lumin.log 内容缺少测试标记: %q", string(raw))
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/wailsapp/log_test.go
+++ b/internal/wailsapp/log_test.go
@@ -8,11 +8,17 @@ import (
 )
 
 // initLogFile 必须真正落盘：设置临时配置目录后，log.Printf 应写入 lumin.log。
+// exe 同级目录通过 logExeDirSeam 指到临时目录，避免测试在构建缓存目录留下日志。
 func TestInitLogFileWritesToDisk(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("USERPROFILE", tmp) // Windows
 	t.Setenv("HOME", tmp)        // Unix
 	t.Setenv("APPDATA", filepath.Join(tmp, "AppData", "Roaming"))
+	logExeDirSeam = filepath.Join(tmp, "exe")
+	if err := os.MkdirAll(logExeDirSeam, 0700); err != nil {
+		t.Fatalf("创建 exe 缝目录失败: %v", err)
+	}
+	t.Cleanup(func() { logExeDirSeam = "" })
 
 	cleanup := initLogFile()
 	if cleanup == nil {
@@ -31,6 +37,14 @@ func TestInitLogFileWritesToDisk(t *testing.T) {
 	}
 	if !contains(string(raw), "TEST-MARKER") {
 		t.Fatalf("lumin.log 内容缺少测试标记: %q", string(raw))
+	}
+	// exe 同级目录也应落盘（便携版场景），且不能污染真实运行目录
+	exeLog, err := os.ReadFile(filepath.Join(logExeDirSeam, "lumin.log"))
+	if err != nil {
+		t.Fatalf("exe 同级 lumin.log 未生成: %v", err)
+	}
+	if !contains(string(exeLog), "TEST-MARKER") {
+		t.Fatalf("exe 同级 lumin.log 内容缺少测试标记: %q", string(exeLog))
 	}
 }
 

--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -172,6 +172,23 @@ func (w *rotatingFileWriter) Close() error {
 	return err
 }
 
+// teeLogWriter 把日志扇出到多个 sink，每个 sink 独立写入并忽略其错误。
+// 不用 io.MultiWriter：MultiWriter 任一 sink 返回 error 会短路后续 sink
+// （标准库 io.MultiWriter 源码如此），而 GUI 进程无控制台时 os.Stderr.Write
+// 会失败（句柄无效 ERROR_INVALID_HANDLE），会导致排在 stderr 之后的文件 sink
+// 全部不执行 → 日志落不了盘，恰好与「落盘便于远程排查」的目的相悖。
+// 日志场景允许个别 sink 丢条，绝不能因一个 sink 失败而连累其它 sink。
+type teeLogWriter struct {
+	writers []io.Writer
+}
+
+func (t teeLogWriter) Write(p []byte) (int, error) {
+	for _, w := range t.writers {
+		_, _ = w.Write(p)
+	}
+	return len(p), nil
+}
+
 // logExeDirSeam 仅测试注入：覆盖 exe 同级日志目录，避免测试在构建缓存目录留下 lumin.log。
 var logExeDirSeam = ""
 
@@ -211,7 +228,7 @@ func initLogFile() func() {
 	if len(closers) == 0 {
 		return func() {}
 	}
-	log.SetOutput(io.MultiWriter(writers...))
+	log.SetOutput(teeLogWriter{writers})
 	log.Printf("[Lumin] Logger initialized. Log files: %d", len(closers))
 	return func() {
 		for _, c := range closers {

--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -104,50 +104,115 @@ func setupSystray(app *App) {
 	})
 }
 
-// maxLogFileSize 日志单文件上限：超过则启动时轮转（lumin.log → lumin.log.1），
+// maxLogFileSize 日志单文件上限：超过则轮转（lumin.log → lumin.log.1），
 // 防止长期运行无限增长；保留一份历史便于回溯。
 const maxLogFileSize = 5 << 20 // 5MB
 
-// openLogFile 打开追加日志文件；超过上限先轮转再打开。
-func openLogFile(path string) (*os.File, error) {
-	if info, err := os.Stat(path); err == nil && info.Size() > maxLogFileSize {
-		_ = os.Rename(path, path+".1")
-	}
-	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+// rotatingFileWriter 带大小轮转的文件 writer。按本进程写入量累计，
+// 超过上限时把当前文件改名为 .1 并重开新文件，保证单次运行内也会轮转
+// （仅启动时检查的话，长跑几天单文件会无限膨胀）。
+type rotatingFileWriter struct {
+	mu      sync.Mutex
+	path    string
+	f       *os.File
+	written int64
 }
 
-// initLogFile 把标准 log 输出重定向到文件（双写）：
-//  1. %AppData%\Lumin\config\lumin.log —— 主日志，始终写入
-//  2. exe 同级目录 lumin.log —— 便携版场景：对方解压运行后日志就在运行目录，
+func newRotatingFileWriter(path string) (*rotatingFileWriter, error) {
+	w := &rotatingFileWriter{path: path}
+	if err := w.reopen(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// reopen 以追加模式打开文件，并把当前大小作为已写基线（跨进程追加的历史计入）。
+func (w *rotatingFileWriter) reopen() error {
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	if info, err := f.Stat(); err == nil {
+		w.written = info.Size()
+	}
+	w.f = f
+	return nil
+}
+
+func (w *rotatingFileWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		// 上次轮转后重开失败（罕见），下次写入再试
+		if err := w.reopen(); err != nil {
+			return len(p), nil
+		}
+	}
+	if w.written+int64(len(p)) > maxLogFileSize {
+		// 先改名再重开：改名失败（如被其它进程占用）继续写旧文件，最多超限一次
+		if os.Rename(w.path, w.path+".1") == nil {
+			if err := w.reopen(); err != nil {
+				w.f = nil
+			}
+		}
+	}
+	n, err := w.f.Write(p)
+	w.written += int64(n)
+	return n, err
+}
+
+func (w *rotatingFileWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}
+
+// logExeDirSeam 仅测试注入：覆盖 exe 同级日志目录，避免测试在构建缓存目录留下 lumin.log。
+var logExeDirSeam = ""
+
+// initLogFile 把标准 log 输出重定向（控制台 + 文件双写）：
+//  1. os.Stderr —— 从终端/调试器启动时日志仍可见；窗口应用没有控制台时静默丢弃
+//  2. %AppData%\Lumin\config\lumin.log —— 主日志，始终写入
+//  3. exe 同级目录 lumin.log —— 便携版场景：对方解压运行后日志就在运行目录，
 //     无需进入隐藏的 %AppData%，直接取回即可；安装版（Program Files）写失败自动忽略
-// Windows 窗口应用没有控制台，log.Printf 默认写 stderr 会被丢弃，
-// 诊断信息需要落盘才能远程排查。追加模式，0600，单文件 5MB 轮转。
-// 返回清理函数（关闭文件句柄），应用生命周期内不要调用。
+// 追加模式，0600，单文件 5MB 运行期轮转。
+// 返回清理函数（关闭文件句柄），应在 wails.Run 返回后调用。
 func initLogFile() func() {
 	var writers []io.Writer
 	var closers []io.Closer
+
+	writers = append(writers, os.Stderr)
 
 	dir, err := os.UserConfigDir()
 	if err == nil {
 		dir = filepath.Join(dir, "Lumin", "config")
 		if err := os.MkdirAll(dir, 0700); err == nil {
-			if f, err := openLogFile(filepath.Join(dir, "lumin.log")); err == nil {
-				writers = append(writers, f)
-				closers = append(closers, f)
+			if w, err := newRotatingFileWriter(filepath.Join(dir, "lumin.log")); err == nil {
+				writers = append(writers, w)
+				closers = append(closers, w)
 			}
 		}
 	}
 	if exePath, err := os.Executable(); err == nil {
-		if f, err := openLogFile(filepath.Join(filepath.Dir(exePath), "lumin.log")); err == nil {
-			writers = append(writers, f)
-			closers = append(closers, f)
+		dir := filepath.Dir(exePath)
+		if logExeDirSeam != "" {
+			dir = logExeDirSeam
+		}
+		if w, err := newRotatingFileWriter(filepath.Join(dir, "lumin.log")); err == nil {
+			writers = append(writers, w)
+			closers = append(closers, w)
 		}
 	}
-	if len(writers) == 0 {
+	if len(closers) == 0 {
 		return func() {}
 	}
 	log.SetOutput(io.MultiWriter(writers...))
-	log.Printf("[Lumin] Logger initialized. Log files: %d", len(writers))
+	log.Printf("[Lumin] Logger initialized. Log files: %d", len(closers))
 	return func() {
 		for _, c := range closers {
 			_ = c.Close()
@@ -158,7 +223,7 @@ func initLogFile() func() {
 // Run 启动 Wails 应用。embed 资源由 main 包注入（//go:embed 路径必须相对根目录的 main.go）。
 func Run(assets embed.FS, moduleFS embed.FS, icon []byte) {
 	// 日志落盘：先于一切业务日志，保证 [channel-diag] 等诊断可追溯
-	initLogFile()
+	closeLogs := initLogFile()
 
 	// 单实例检查（平台特定实现）
 	platformruntime.EnsureSingleInstance()
@@ -248,6 +313,8 @@ func Run(assets embed.FS, moduleFS embed.FS, icon []byte) {
 	platformruntime.ApplyOptions(opts, gpuDisabled)
 
 	err := wails.Run(opts)
+	// 退出后关闭日志文件句柄，避免残留
+	closeLogs()
 
 	if err != nil {
 		println("Error:", err.Error())

--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -8,7 +8,10 @@ package wailsapp
 import (
 	"context"
 	"embed"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -31,15 +34,19 @@ var embeddedModuleFS embed.FS
 // 不先 Hide 再 Show：久置后 Show 失败会把窗口永久卡在隐藏态。
 // 先走平台原生激活抢前台（Windows 久置后 SetForeground 常被拒），再异步走 Wails 恢复。
 // 原生激活放前后各一次：覆盖「仅最小化」和「托盘隐藏」两种状态。
-// ponytail: Wails 运行时调用异步化，避免阻塞 systray 消息线程。
-// 久置后 WebView 恢复可能慢/卡，同步调用会冻结托盘消息泵，
-// 导致单击/双击/右键全部无响应。
-// 平台原生激活（activateHWND）内置主线程存活检查：主线程卡死时
-// 只投递 ShowWindowAsync（非阻塞），跳过 SetActiveWindow/SetFocus/
-// RedrawWindow/UpdateWindow 等同步消息发送，避免拖死托盘消息泵。
+// ponytail: 托盘消息线程只做调度，绝不在这里同步执行窗口调用。
+// energye/systray 的 wndProc 在托盘线程上同步回调 onClick；若同步执行
+// platformruntime.ForceShowWindow（内部含 EnumWindows/ShowWindow/
+// SetWindowPos/SetForegroundWindow/RedrawWindow 等向主窗口线程的
+// 消息发送，无超时），主线程一旦卡死（SSH 断线等）托盘线程会无限期阻塞，
+// 单击/双击/右键全部无响应，只能重启软件恢复。全部异步化后即使窗口操作
+// 阻塞，托盘消息泵也能立即返回继续响应。
 func forceShowWindow(ctx context.Context) {
 	defer func() { recover() }()
-	platformruntime.ForceShowWindow()
+	go func() {
+		defer func() { recover() }()
+		platformruntime.ForceShowWindow()
+	}()
 	if ctx != nil {
 		go func() {
 			defer func() { recover() }()
@@ -47,7 +54,10 @@ func forceShowWindow(ctx context.Context) {
 			wailsruntime.WindowShow(ctx)
 		}()
 	}
-	platformruntime.ForceShowWindow()
+	go func() {
+		defer func() { recover() }()
+		platformruntime.ForceShowWindow()
+	}()
 }
 
 var systrayOnce sync.Once
@@ -94,8 +104,62 @@ func setupSystray(app *App) {
 	})
 }
 
+// maxLogFileSize 日志单文件上限：超过则启动时轮转（lumin.log → lumin.log.1），
+// 防止长期运行无限增长；保留一份历史便于回溯。
+const maxLogFileSize = 5 << 20 // 5MB
+
+// openLogFile 打开追加日志文件；超过上限先轮转再打开。
+func openLogFile(path string) (*os.File, error) {
+	if info, err := os.Stat(path); err == nil && info.Size() > maxLogFileSize {
+		_ = os.Rename(path, path+".1")
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+}
+
+// initLogFile 把标准 log 输出重定向到文件（双写）：
+//  1. %AppData%\Lumin\config\lumin.log —— 主日志，始终写入
+//  2. exe 同级目录 lumin.log —— 便携版场景：对方解压运行后日志就在运行目录，
+//     无需进入隐藏的 %AppData%，直接取回即可；安装版（Program Files）写失败自动忽略
+// Windows 窗口应用没有控制台，log.Printf 默认写 stderr 会被丢弃，
+// 诊断信息需要落盘才能远程排查。追加模式，0600，单文件 5MB 轮转。
+// 返回清理函数（关闭文件句柄），应用生命周期内不要调用。
+func initLogFile() func() {
+	var writers []io.Writer
+	var closers []io.Closer
+
+	dir, err := os.UserConfigDir()
+	if err == nil {
+		dir = filepath.Join(dir, "Lumin", "config")
+		if err := os.MkdirAll(dir, 0700); err == nil {
+			if f, err := openLogFile(filepath.Join(dir, "lumin.log")); err == nil {
+				writers = append(writers, f)
+				closers = append(closers, f)
+			}
+		}
+	}
+	if exePath, err := os.Executable(); err == nil {
+		if f, err := openLogFile(filepath.Join(filepath.Dir(exePath), "lumin.log")); err == nil {
+			writers = append(writers, f)
+			closers = append(closers, f)
+		}
+	}
+	if len(writers) == 0 {
+		return func() {}
+	}
+	log.SetOutput(io.MultiWriter(writers...))
+	log.Printf("[Lumin] Logger initialized. Log files: %d", len(writers))
+	return func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}
+}
+
 // Run 启动 Wails 应用。embed 资源由 main 包注入（//go:embed 路径必须相对根目录的 main.go）。
 func Run(assets embed.FS, moduleFS embed.FS, icon []byte) {
+	// 日志落盘：先于一切业务日志，保证 [channel-diag] 等诊断可追溯
+	initLogFile()
+
 	// 单实例检查（平台特定实现）
 	platformruntime.EnsureSingleInstance()
 


### PR DESCRIPTION
## 概述

本 PR 包含 5 个修复，聚焦四类问题：SSH 通道占用虚高（资源泄漏）、连接中取消会话的泄漏、托盘消息泵被卡死的主线程拖死、以及日志落盘在最常见的 GUI 启动场景下完全失效。

## 修复内容

### 1. 通道占用虚高（32d4234）
- **重复登记**：工作区恢复与手动进入并发时，同一 sessionId 被 `setupSession` 重复登记进 `connTerminals`（`[X, X]`），关闭只删一个 → 通道占用恒 +1。修复：`setupSession` 登记幂等化（同 id 先释放旧通道并去重），`disconnect` 移除全部同 id 条目。
- **孤儿终端**：根终端关闭后子终端成为孤儿，会话级关闭整体 no-op → 子终端 + 共享 client 永久泄漏。修复：`DisconnectConnection` 接收前端传入的全部终端 id 逐个断开，不依赖根终端存活。
- **重连多开**：手动进入时不再自动恢复快照/残留会话中的历史子终端（每次进入服务器上会多出 N 个 `/bin/bash`），改为只开根终端，多终端由「+」手动创建；app 启动的工作区恢复仍保留多终端布局。
- **防双击**：`connectServer` 加 per-serverId 防重入。
- 新增端到端回归测试（顺序循环 / 并发压力 / 同 id 重复登记 / 孤儿终端清理）。

### 2. 连接中取消会话泄漏（e15db1e）
- 会话尚未登记（Connect 在 dial/握手/等密码中）时取消，此前会整体 no-op，在途 Connect 完成后 session 与共享 client 永久泄漏。修复：`DisconnectConnection` 在该场景下通过 `pendingCancels` 取消在途 Connect，子终端仍逐个兜底清理。
- 恢复窗口焦点切换按 `restoringWorkspaceSessionIds` 精确判断，不再吞掉非恢复中会话的用户点击。

### 3. 托盘冻结（ef8ac35）
- `forceShowWindow` 全部异步化：systray 的 wndProc 在托盘消息线程同步回调，此前同步执行 `ForceShowWindow`（含 EnumWindows/SetForegroundWindow 等无超时消息发送），主线程一旦卡死（SSH 断线等）托盘线程无限期阻塞，单击/双击/右键全部无响应。异步化后托盘消息泵立即返回。
- `windowText` 改用 `SendMessageTimeoutW(WM_GETTEXT, SMTO_ABORTIFHUNG, 200ms)` 限时读取，不再可能无限期阻塞在卡死的目标窗口线程。

### 4. 日志落盘（79df2fb + ba41d73）
- 标准 log 重定向落盘双写：`%AppData%\Lumin\config\lumin.log` 与 exe 同级目录（便携版场景）；单文件 5MB 运行期轮转；退出关闭文件句柄。
- **关键修复（ba41d73）**：`io.MultiWriter` 任一 sink 返回 error 即放弃后续 sink，而 GUI 进程无控制台时 `os.Stderr.Write` 失败（ERROR_INVALID_HANDLE）→ 排在 stderr 之后的文件 sink 全部不执行，**lumin.log 永远为空**。改用新增的 `teeLogWriter`（每个 sink 独立写入并忽略其错误），单个 sink 失败不再连累其它 sink。附回归测试 `TestTeeLogWriterToleratesFailingSink`。

## 测试

- `go test ./internal/...` 全部通过（含新增回归测试）
- `go build ./...` 编译通过
- 手动验证：断网后重连保留多终端标签，无覆盖丢失

## 已知取舍

- 手动从服务器列表点击已断开的会话重连时，会按设计只开根终端（防止服务器上多开 bash）；若该会话曾保存多终端布局，将更新为单终端布局。终端内触发重连（常用路径）不受影响。