### PR TITLE
fix(terminal): 修复 macOS 触摸板轻划被误识别为选中文字的问题

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -653,6 +653,20 @@ export default function Terminal({
   const terminalLeftClickCopyOnSelectionModeRef = useRef(localStorage.getItem('terminalLeftClickCopyOnSelectionMode') === 'mouseup' ? 'mouseup' : 'click');
   const terminalMouseDownSelectionRef = useRef<{ mode: 'mouseup' | 'click'; startClientX: number; startClientY: number; text?: string } | null>(null);
   const isTerminalPointerDownRef = useRef(false);
+  // macOS WKWebView / 系统手势可能吞掉 mouseup，导致 xterm 拖选状态机卡死（此后划动指针 = 持续划选）。
+  // 主动向 document 派发合成 mouseup 闭合状态机：xterm 的选区收尾监听挂在 document 上且不校验 isTrusted；
+  // 事件坐标仅 altClickMovesCursor 分支使用（合成事件 altKey=false 不会进入），无指针信息时传 0 即可。
+  const dispatchSyntheticTerminalMouseUp = useCallback((clientX = 0, clientY = 0) => {
+    document.dispatchEvent(new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+      clientX,
+      clientY,
+      buttons: 0,
+      button: 0,
+    }));
+  }, []);
   const [timestampsVisible, setTimestampsVisible] = useState(localStorage.getItem('terminalTimestamps') === 'true');
   // 命令块：左侧折叠钮 + 树线，可收起输出
   const commandBlocksEnabledRef = useRef(localStorage.getItem('terminalCommandBlocks') === 'true');
@@ -1529,15 +1543,7 @@ export default function Terminal({
       // 且当前无物理按键按下，主动释放状态并闭合选区，防止滚动后单指滑动意外划选文字
       if (isTerminalPointerDownRef.current && (e.buttons === 0 || !(e.buttons & 1))) {
         isTerminalPointerDownRef.current = false;
-        document.dispatchEvent(new MouseEvent('mouseup', {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          buttons: 0,
-          button: 0,
-        }));
+        dispatchSyntheticTerminalMouseUp(e.clientX, e.clientY);
       }
       // 无论向上还是向下滚动，都检查当前位置并更新锁定状态
       requestAnimationFrame(() => {
@@ -2537,15 +2543,7 @@ export default function Terminal({
       // 说明上一次 mousedown 对应的 mouseup 已丢失。主动派发合成 mouseup 闭合 xterm 拖拽选区状态机。
       if (isTerminalPointerDownRef.current && (event.buttons === 0 || !(event.buttons & 1))) {
         isTerminalPointerDownRef.current = false;
-        document.dispatchEvent(new MouseEvent('mouseup', {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-          clientX: event.clientX,
-          clientY: event.clientY,
-          buttons: 0,
-          button: 0,
-        }));
+        dispatchSyntheticTerminalMouseUp(event.clientX, event.clientY);
       }
     };
 
@@ -2575,19 +2573,20 @@ export default function Terminal({
     const handleWindowPointerCancel = () => {
       if (isTerminalPointerDownRef.current) {
         isTerminalPointerDownRef.current = false;
-        document.dispatchEvent(new MouseEvent('mouseup', {
-          bubbles: true,
-          cancelable: true,
-          view: window,
-          buttons: 0,
-          button: 0,
-        }));
+        dispatchSyntheticTerminalMouseUp();
       }
     };
 
     const handleWindowBlur = () => {
+      // 失焦常意味着按键最终在 WebView 之外释放（mouseup 不会送达），xterm 仍卡在拖选态。
+      // 若只清 isTerminalPointerDownRef，检测基准被清空后这个卡死态将永远无法被发现，划动又会拖选；
+      // 因此失焦时同样派发合成 mouseup 闭合它。快照需先清，避免合成 mouseup 冒泡触发 mouseup 模式的复制。
+      const wasPointerDown = isTerminalPointerDownRef.current;
       isTerminalPointerDownRef.current = false;
       terminalMouseDownSelectionRef.current = null;
+      if (wasPointerDown) {
+        dispatchSyntheticTerminalMouseUp();
+      }
     };
 
     window.addEventListener('mousemove', handleWindowMouseMove, { capture: true, passive: true });

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -652,6 +652,7 @@ export default function Terminal({
   const terminalLeftClickCopyOnSelectionRef = useRef(localStorage.getItem('terminalLeftClickCopyOnSelection') === 'true');
   const terminalLeftClickCopyOnSelectionModeRef = useRef(localStorage.getItem('terminalLeftClickCopyOnSelectionMode') === 'mouseup' ? 'mouseup' : 'click');
   const terminalMouseDownSelectionRef = useRef<{ mode: 'mouseup' | 'click'; startClientX: number; startClientY: number; text?: string } | null>(null);
+  const isTerminalPointerDownRef = useRef(false);
   const [timestampsVisible, setTimestampsVisible] = useState(localStorage.getItem('terminalTimestamps') === 'true');
   // 命令块：左侧折叠钮 + 树线，可收起输出
   const commandBlocksEnabledRef = useRef(localStorage.getItem('terminalCommandBlocks') === 'true');
@@ -1523,6 +1524,21 @@ export default function Terminal({
       syncTuiState(buffer.type === 'alternate' || screenScrollbackRef.current.active);
     });
     const wheelHandler = (e: WheelEvent) => {
+      // 触控板双指滚动打断选区状态防呆：
+      // 当双指滚动开始时，若由于单指先行接触残留了 isTerminalPointerDownRef 状态，
+      // 且当前无物理按键按下，主动释放状态并闭合选区，防止滚动后单指滑动意外划选文字
+      if (isTerminalPointerDownRef.current && (e.buttons === 0 || !(e.buttons & 1))) {
+        isTerminalPointerDownRef.current = false;
+        document.dispatchEvent(new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          buttons: 0,
+          button: 0,
+        }));
+      }
       // 无论向上还是向下滚动，都检查当前位置并更新锁定状态
       requestAnimationFrame(() => {
         const buf = term.buffer.active;
@@ -2450,6 +2466,9 @@ export default function Terminal({
   }, [t]);
 
   const handleTerminalMouseDownCapture = useCallback((event: React.MouseEvent) => {
+    if (event.button === 0) {
+      isTerminalPointerDownRef.current = true;
+    }
     if (event.button !== 0 || !terminalLeftClickCopyOnSelectionRef.current) {
       terminalMouseDownSelectionRef.current = null;
       return;
@@ -2480,6 +2499,9 @@ export default function Terminal({
   }, [getTerminalBufferCellPositionFromMouseEvent, isTerminalBufferCellWithinRange]);
 
   const handleTerminalMouseUpCapture = useCallback((event: React.MouseEvent) => {
+    if (event.button === 0) {
+      isTerminalPointerDownRef.current = false;
+    }
     const snapshot = terminalMouseDownSelectionRef.current;
     terminalMouseDownSelectionRef.current = null;
     if (event.button !== 0 || !terminalLeftClickCopyOnSelectionRef.current || !snapshot) {
@@ -2509,7 +2531,28 @@ export default function Terminal({
   }, [copyTerminalSelectionText]);
 
   useEffect(() => {
+    const handleWindowMouseMove = (event: MouseEvent) => {
+      // macOS WKWebView / 触控板手势丢失 mouseup 防呆：
+      // 当物理上没有按键处于按下状态（buttons === 0 或未按左键），但终端仍记录着按下状态时，
+      // 说明上一次 mousedown 对应的 mouseup 已丢失。主动派发合成 mouseup 闭合 xterm 拖拽选区状态机。
+      if (isTerminalPointerDownRef.current && (event.buttons === 0 || !(event.buttons & 1))) {
+        isTerminalPointerDownRef.current = false;
+        document.dispatchEvent(new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          buttons: 0,
+          button: 0,
+        }));
+      }
+    };
+
     const handleWindowMouseUp = (event: MouseEvent) => {
+      if (event.button === 0) {
+        isTerminalPointerDownRef.current = false;
+      }
       const snapshot = terminalMouseDownSelectionRef.current;
       if (event.button !== 0 || !terminalLeftClickCopyOnSelectionRef.current || !snapshot || snapshot.mode !== 'mouseup') {
         return;
@@ -2529,14 +2572,34 @@ export default function Terminal({
       });
     };
 
+    const handleWindowPointerCancel = () => {
+      if (isTerminalPointerDownRef.current) {
+        isTerminalPointerDownRef.current = false;
+        document.dispatchEvent(new MouseEvent('mouseup', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          buttons: 0,
+          button: 0,
+        }));
+      }
+    };
+
     const handleWindowBlur = () => {
+      isTerminalPointerDownRef.current = false;
       terminalMouseDownSelectionRef.current = null;
     };
 
+    window.addEventListener('mousemove', handleWindowMouseMove, { capture: true, passive: true });
     window.addEventListener('mouseup', handleWindowMouseUp);
+    window.addEventListener('pointercancel', handleWindowPointerCancel);
+    window.addEventListener('dragend', handleWindowPointerCancel);
     window.addEventListener('blur', handleWindowBlur);
     return () => {
+      window.removeEventListener('mousemove', handleWindowMouseMove, true);
       window.removeEventListener('mouseup', handleWindowMouseUp);
+      window.removeEventListener('pointercancel', handleWindowPointerCancel);
+      window.removeEventListener('dragend', handleWindowPointerCancel);
       window.removeEventListener('blur', handleWindowBlur);
     };
   }, [copyTerminalSelectionText]);


### PR DESCRIPTION
## 问题

Fixes #226

macOS 上用触摸板轻划移动指针时，有很大概率被识别为「按住左键拖拽」，实际在持续选中文字，效果等同于按住触摸板移动。

## 根因分析

核对 `@xterm/xterm@5.5.0` 源码确认其选区状态机机制：

- mousedown 时 xterm 在 `document` 上挂 `mousemove`/`mouseup` 监听，且 `_handleMouseMove` 不检查 `event.buttons`；
- 只有收到 `document` 上的 mouseup 才会移除监听、结束拖选。

WKWebView / macOS 系统手势存在整类「已派发 mousedown 但 mouseup 未送达」的已知缺陷（窗口外释放收不到 mouseup、系统手势扣留、事件投递丢失等）。一旦 mouseup 丢失，xterm 就永久卡在拖选态——此后任何指针移动都会持续划选文字，与 issue 症状完全一致（「效果跟按住触摸板移动相同」）。

## 修复方案

不依赖「mouseup 为何丢失」，按 `buttons` 反映的物理按键状态做一致性检测（防呆兜底）：

- 跟踪终端区域左键按下状态（`isTerminalPointerDownRef`）；
- window `mousemove`（捕获阶段）/ 终端 `wheel` 时检测「逻辑上记录按下、但物理上无左键」的不一致，立即向 `document` 派发合成 mouseup 闭合 xterm 拖选状态机。合成事件在 xterm 的 document 监听处命中（不校验 `isTrusted`），时序上先于 xterm 处理 mousemove，误选来不及出现；
- `pointercancel` / `dragend` / 窗口失焦时同样闭合——失焦通常意味着按键在 WebView 外释放，若只清标记，卡死态将无法再被检测到；
- 合成事件 `altKey=false`，不会误触发 `altClickMovesCursor`；无指针坐标的场景（失焦等）安全。

不影响正常使用：真实按住左键时 `buttons=1` 检测不触发；三指拖移、按住按键滚动不受影响；合成事件不会进入 React 事件系统，也不会产生多余的 click。

## 测试

- Windows 开发环境功能自测（选中、复制、右键、拖拽）正常；
- TypeScript 类型检查与 vite 生产构建通过；
- macOS 触摸板场景待打包发版后请 issue 报告者回归验证。