### PR TITLE
fix(probe): OpenWrt top6 进程采样修复——去 join 依赖 + comm 提取模式

### DIFF
--- a/internal/sshmanager/procstat_test.go
+++ b/internal/sshmanager/procstat_test.go
@@ -1,8 +1,11 @@
 package sshmanager
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -473,13 +476,13 @@ func TestDynamicProbeScriptRemoteTopProcs(t *testing.T) {
 			t.Fatalf("%s 段应为 时间戳 + %s, 实际:\n%s", c.marker, c.pass, dynamicProbeScript)
 		}
 	}
-	// pass1 落盘(sleep 1 之前):时间戳 + sample_procs | sort > proctmp
+	// pass1 落盘(sleep 1 之前):时间戳 + sample_procs > proctmp
 	if !strings.Contains(dynamicProbeScript, `ts1p=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || date +%s)
-sample_procs | sort > "$proctmp"`) {
-		t.Fatal("pass1 须落盘 proctmp(sample_procs | sort),且在 sleep 1 之前")
+sample_procs > "$proctmp"`) {
+		t.Fatal("pass1 须落盘 proctmp(sample_procs),且在 sleep 1 之前")
 	}
-	// pass2 选 top6:sample_procs | sort | sample_procs_select > proctop
-	if !strings.Contains(dynamicProbeScript, `sample_procs | sort | sample_procs_select "$proctmp" > "$proctop"`) {
+	// pass2 选 top6:sample_procs | sample_procs_select > proctop
+	if !strings.Contains(dynamicProbeScript, `sample_procs | sample_procs_select "$proctmp" > "$proctop"`) {
 		t.Fatal("pass2 须经 sample_procs_select 选 top6 落 proctop")
 	}
 	// 三个函数定义齐全
@@ -492,9 +495,9 @@ sample_procs | sort > "$proctmp"`) {
 	if !strings.Contains(dynamicProbeScript, "IFS= read -r s") {
 		t.Fatal("sample_procs 必须用 read 内建读取 stat")
 	}
-	// select 必须用 join 配对 + 按 delta 降序取前 6
-	if !strings.Contains(dynamicProbeScript, `join -t "$sep" -1 1 -2 1`) {
-		t.Fatal("sample_procs_select 必须用 join 按 pid 配对双采样")
+	// select 必须用 awk 配对(不得依赖 join:OpenWrt BusyBox 无该 applet)+ 按 delta 降序取前 6
+	if !strings.Contains(dynamicProbeScript, "awk -F") {
+		t.Fatal("sample_procs_select 必须用 awk 按 pid 配对双采样")
 	}
 	if !strings.Contains(dynamicProbeScript, "sort -rn | head -6") {
 		t.Fatal("sample_procs_select 必须按 delta 降序取前 6")
@@ -752,5 +755,120 @@ func TestWrapShCmd(t *testing.T) {
 	}
 	if got := string(out); got != "quoted double\nline2\n" {
 		t.Fatalf("回环输出不符: %q", got)
+	}
+}
+
+// ─── dynamicProbeScript 进程采样端到端(OpenWrt 兼容回归) ─────────────
+
+// sample_procs_select 不得依赖 join:OpenWrt 官方 BusyBox 配置树(main/24.10/
+// 23.05)不含 join applet(有 sort/head/awk 却无 join),stock OpenWrt 上
+// `join: not found` 导致 PROC 段静默为空,系统监控 top6 不显示任何进程且不报错。
+// BusyBox awk 是 OpenWrt 默认编入的 applet(BUSYBOX_DEFAULT_AWK=y),配对应走 awk。
+func TestDynamicProbeScriptNoJoinDependency(t *testing.T) {
+	if strings.Contains(dynamicProbeScript, "join -t") {
+		t.Fatal("sample_procs_select 不得依赖 join(OpenWrt BusyBox 无该 applet),应改用 awk 配对双采样")
+	}
+	if !strings.Contains(dynamicProbeScript, "awk -F") {
+		t.Fatal("sample_procs_select 应用 awk -F 按分隔符解析字段并按 pid 配对双采样")
+	}
+}
+
+// 端到端:伪造 /proc(含无 cmdline 的内核线程、comm 被 15 字符截断的用户进程),
+// 在真实 POSIX sh 下执行 dynamicProbeScript,经 parseProbeOutput 全链解析,
+// 断言 top6 进程名干净。回归覆盖:
+//  1. comm 提取模式写错(${comm%)*)} 永不匹配)导致内核线程(cmdline 空,
+//     回退 comm)显示整行 stat 垃圾,如 "kworker/u:2) S 1 0 0 0..."。
+//  2. 段落/时间戳/双采样配对在真实 sh 管线下的正确性(Go 端单测覆盖不到)。
+// 生产环境目标为 BusyBox ash,同为 POSIX 子集;awk/sort/head/cut/tr 为
+// OpenWrt BusyBox 默认编入的 applet。
+func TestDynamicProbeScriptEndToEndCleanProcessNames(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX sh available")
+	}
+	if _, err := exec.LookPath("awk"); err != nil {
+		t.Skip("no awk available")
+	}
+
+	dir := t.TempDir()
+	procDir := filepath.ToSlash(filepath.Join(dir, "proc"))
+	if err := os.MkdirAll(filepath.Join(dir, "proc", "100"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "proc", "200"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "proc", "300"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "tmp", ".lumin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "proc", "net"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// statLine(pid, comm, utime, stime, starttime, rss):三进程 utime 静态,
+	// 双采样 delta=0,断言聚焦名称与字段而非排序。
+	write := func(rel, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 真实 /proc/pid/stat 以 \n 结尾,无换行时 read 返回非零会被 || continue 跳过
+	write("proc/100/stat", statLine(100, "nginx", 3000, 1500, 900, 512)+"\n")
+	write("proc/200/stat", statLine(200, "kworker/u:2", 800, 400, 700, 64)+"\n")
+	// comm 恰为 15 字符截断形态(TASK_COMM_LEN-1),cmdline 含完整名验证 basename 提取
+	write("proc/300/stat", statLine(300, "openclaw-gatewa", 600, 200, 800, 128)+"\n")
+	write("proc/100/cmdline", "/usr/sbin/nginx\x00")
+	write("proc/300/cmdline", "/opt/openclaw/bin/openclaw-gateway\x00")
+	write("proc/200/cmdline", "") // 内核线程 cmdline 为空,须回退 comm
+	write("proc/uptime", "12345.67 99999.99\n")
+	write("proc/loadavg", "0.00 0.00 0.00 1/500 1000\n")
+	write("proc/meminfo", "MemTotal: 1024 kB\nMemFree: 512 kB\n")
+	write("proc/stat", "cpu 100 0 100 1000 0 0 0 0 0 0\n")
+	write("proc/net/dev", "Inter-|   Receive                    |  Transmit\n face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n  eth0: 123 4 0 0 0 0 0 0 56 7 0 0 0 0 0 0\n")
+	write("proc/diskstats", "")
+
+	// 把脚本中的 /proc 与 /tmp/.lumin 重定向到临时目录,其余逐字保留
+	script := strings.ReplaceAll(dynamicProbeScript, "/proc/", procDir+"/")
+	script = strings.ReplaceAll(script, "/tmp/.lumin", filepath.ToSlash(filepath.Join(dir, "tmp", ".lumin")))
+	scriptPath := filepath.Join(dir, "probe.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(sh, scriptPath, "procs")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("探针脚本执行失败: %v, stderr: %s, stdout: %s", err, stderr.String(), stdout.String())
+	}
+
+	result, err := parseProbeOutput(stdout.String(), false)
+	if err != nil {
+		t.Fatalf("探针输出解析失败: %v, 输出:\n%s", err, stdout.String())
+	}
+	procs, _ := result["processes"].([]map[string]interface{})
+	want := map[string]string{
+		"100": "nginx",              // 用户进程:cmdline argv[0] basename
+		"200": "kworker/u:2",        // 内核线程:cmdline 空回退 comm,必须干净无 stat 尾巴
+		"300": "openclaw-gateway",   // comm 截断 15 字符,cmdline basename 还原全名
+	}
+	if len(procs) != len(want) {
+		t.Fatalf("应有 %d 个进程, 得到 %d, stderr:\n%s\n输出:\n%s", len(want), len(procs), stderr.String(), stdout.String())
+	}
+	got := map[string]string{}
+	for _, p := range procs {
+		pid, _ := p["pid"].(string)
+		cmdName, _ := p["cmd"].(string)
+		got[pid] = cmdName
+	}
+	for pid, name := range want {
+		if got[pid] != name {
+			t.Fatalf("pid %s 进程名应为 %q, 得到 %q(全部: %v), 输出:\n%s", pid, name, got[pid], got, stdout.String())
+		}
 	}
 }

--- a/internal/sshmanager/ssh.go
+++ b/internal/sshmanager/ssh.go
@@ -2231,7 +2231,7 @@ const dynamicProbeScript = `#!/bin/sh
 # ── 进程双采样 + 远端选 top6(只传 6 条,流量与 1.2.7 ps|head -6 持平)──
 # sample_procs 逐进程 read /proc/[pid]/stat(不逐 PID fork),输出 6 字段
 # (pid comm utime stime starttime rss,\x1f 分隔)。供 pass1 落盘与 pass2 流式输入。
-# sample_procs_select 按 pid 配对双采样(join),算 CPU delta,按 delta 降序取前 6。
+# sample_procs_select 用 awk 按 pid 配对双采样,算 CPU delta,按 delta 降序取前 6。
 # emit_procs_pass 把选出的 6 条转成 Go 端 parseProcStatSample 的 6 字段格式,
 # 分 PROC1(pass1)/PROC2(pass2)两段输出——Go 端 parseProbeProcSections 照旧
 # 算 delta 并校验 starttime(PID 复用);远端只负责「选哪 6 个」,不越权算 cpu%。
@@ -2240,7 +2240,7 @@ sample_procs() {
     [ -r "$f" ] || continue
     IFS= read -r s < "$f" || continue
     pid=${s%% *}
-    comm=${s#*\(}; comm=${comm%)*)}
+    comm=${s#*\(}; comm=${comm%)*}
     rest=${s##*)}
     set -- $rest
     # $1=state $12=utime $13=stime $20=starttime $22=rss (1-based in rest)
@@ -2249,24 +2249,34 @@ sample_procs() {
   done
 }
 
-# sample_procs_select: pass1 文件($1, 须按 pid 排序)与 pass2(stdin, 须按 pid
-# 排序)按 pid join 配对,算 CPU delta,按 delta 降序取前 6。
+# sample_procs_select: pass1 文件($1)载入 awk 关联数组,pass2(stdin)逐条按
+# pid 配对,算 CPU delta,按 delta 降序取前 6。
 # 出参(stdout): 至多 6 行,每行 10 个 \x1f 字段:
 #   delta pid comm ut1 st1 start1 ut2 st2 start2 rss2
-# join 默认只输出双侧均有的 pid(等价丢弃单侧样本,即采样窗口内创建/退出);
-# starttime 不一致(PID 复用)在 while 中剔除。
-# ponytail: 依赖 join(POSIX,BusyBox 含 applet);join 缺失则无输出,进程段为空,
-# 与无 /proc 的非 Linux 同路径降级(进程列表空,不报错)。升级路径:若需去 join
-# 依赖,可改纯 sh 归并排序(双流 read 指针推进,O(n) 无 fork),但脚本复杂度翻倍。
+# 仅双侧均有的 pid 配对(等价丢弃单侧样本,即采样窗口内创建/退出);
+# starttime 不一致(PID 复用)剔除。
+# ponytail: 配对用 BusyBox awk(OpenWrt 默认编入,BUSYBOX_DEFAULT_AWK=y),
+# 不得依赖 join——OpenWrt 官方 BusyBox 配置树(main/24.10/23.05)不含 join
+# applet,stock OpenWrt 上 join 缺失会让进程段静默为空(系统监控
+# top6 不显示任何进程且不报错)。awk 缺失同理降级为空,与无 /proc 的非
+# Linux 同路径(进程列表空,不报错)。BEGIN+getline 读 pass1 而非 FILENAME
+# 判别输入流:对 "-" 的 FILENAME 取值各 awk 实现有差异,getline 语义无歧义。
 sample_procs_select() {
   sep=$(printf '\037')
-  join -t "$sep" -1 1 -2 1 "$1" - | while IFS="$sep" read -r \
-    pid comm1 ut1 st1 start1 rss1 comm2 ut2 st2 start2 rss2; do
-    [ "$start1" = "$start2" ] || continue
-    d=$(( ut2 + st2 - ut1 - st1 ))
-    [ "$d" -lt 0 ] && d=0
-    printf '%s\n' "$d${sep}$pid${sep}$comm2${sep}$ut1${sep}$st1${sep}$start1${sep}$ut2${sep}$st2${sep}$start2${sep}$rss2"
-  done | sort -rn | head -6
+  awk -F"$sep" -v SEP="$sep" -v F1="$1" '
+    BEGIN {
+      while ((getline line < F1) > 0) {
+        split(line, a, SEP)
+        ut1[a[1]] = a[3]; st1[a[1]] = a[4]; start1[a[1]] = a[5]
+      }
+      close(F1)
+    }
+    ($1 in ut1) && start1[$1] == $5 {
+      d = $3 + $4 - ut1[$1] - st1[$1]
+      if (d < 0) d = 0
+      printf "%d%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n", d, SEP, $1, SEP, $2, SEP, ut1[$1], SEP, st1[$1], SEP, start1[$1], SEP, $3, SEP, $4, SEP, $5, SEP, $6
+    }
+  ' - | sort -rn | head -6
 }
 
 # emit_procs_pass: 将 sample_procs_select 输出($1 文件)按采样($2=1|2)转成
@@ -2316,7 +2326,7 @@ if [ "$1" = "procs" ]; then
 mkdir -p /tmp/.lumin 2>/dev/null
 proctmp=/tmp/.lumin/.ptop.$$
 ts1p=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || date +%s)
-sample_procs | sort > "$proctmp"
+sample_procs > "$proctmp"
 fi
 sleep 1
 echo ---CPU2---
@@ -2330,7 +2340,7 @@ cat /proc/diskstats
 if [ "$1" = "procs" ]; then
 ts2p=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || date +%s)
 proctop=/tmp/.lumin/.ptop6.$$
-sample_procs | sort | sample_procs_select "$proctmp" > "$proctop"
+sample_procs | sample_procs_select "$proctmp" > "$proctop"
 rm -f "$proctmp"
 echo ---PROC1---
 printf '%s\n' "$ts1p"


### PR DESCRIPTION
## 背景

`4231b41`(重写进程采样远端选 top6)在普通 Linux 上工作正常、流量也确实降下来了,但引入了两处缺陷,均**只在特定环境现形**,普通 Linux 服务器上测试不可见。

## 问题一(严重):join 依赖导致 stock OpenWrt 上 top6 进程列表静默为空

`sample_procs_select` 用 `join -t "$sep" -1 1 -2 1` 按 pid 配对双采样,注释断言「BusyBox 含 applet」——**该断言对 OpenWrt 不成立**。核对 OpenWrt 官方 BusyBox 配置树([main](https://github.com/openwrt/openwrt/tree/main/package/utils/busybox/config)、24.10、23.05 三个分支):`coreutils/Config.in` 里有 SORT、TAIL、甚至 TSORT,唯独没有 JOIN;`Config-defaults.in` 也不存在 `BUSYBOX_DEFAULT_JOIN`。即官方固件的 BusyBox 编译时就编不进 join。

后果链:`join: not found`(stderr 独立捕获,不污染 stdout)→ `proctop` 为空 → PROC1/PROC2 段只有时间戳 → `processes: []` → **OpenWrt 上系统监控 top6 不显示任何进程,且不报错**。

容易误判为「没问题」的原因:进程管理页(`fullProcListScript`)不走这条路径(原始 stat 行透传 Go 解析,不用 join),在 OpenWrt 真机上打开进程管理能看到完整进程列表;受影响的只有系统监控探针的 top6。

## 问题二:comm 提取模式多一个右括号,内核线程显示整行 stat 垃圾

\`sample_procs\` 中 \`comm=${comm%)*)}\` 的后缀模式要求以 \`)\
 开头**且以 \`)\
 结尾**,而 stat 行以数字结尾,永不匹配 → comm 携带整行 stat 尾部:

```
200^_kworker/u:2) S 1 0 0 0 -1 0 ... ^_800^_400^_700^_64     ← 实际输出
200^_kworker/u:2^_800^_400^_700^_64                           ← 预期
```

普通用户进程被 emit pass2 的 cmdline basename 覆盖而掩盖;**内核线程**(cmdline 为空,回退 comm)在 top6 显示整行垃圾——而 kworker/softirq 恰是路由器上 CPU top6 常客。同时每行从 ~25B 膨胀到 ~140B。

## 修复

1. **配对改用 BusyBox awk**(OpenWrt 默认编入,\`BUSYBOX_DEFAULT_AWK=y\`):关联数组按 pid 配对,语义与 join 一致——仅双侧均有的 pid 配对(窗口内创建/退出丢弃),starttime 不一致(PID 复用)剔除。BEGIN+getline 读 pass1 落盘文件,不依赖各 awk 实现有差异的 FILENAME 对 \`-\`\
 的取值。配对改为数组后,pass1/pass2 原本为 join 准备的 \`| sort\` 不再必要,一并移除(少 2 次 fork)。
2. **\`${comm%)*)}\` → \`${comm%)*}\`**:与 Go 端 \`parseProcStatLine\` 的 comm 语义(首 \`(\` 到最后 \`)\` 之间)一致,含空格/含括号的 comm(\`my workerd\`、\`(sd-pam)\`、\`sh (dash)\`)已逐一验证等价。

## 流量影响

不增反降:top6 仍在远端选出,过 SSH 的仍只有 6 行 × 2 段;comm 修复后每行 ~140B → ~25B。

## 测试(RED → GREEN)

按 TDD 先验证新测试按预期失败再修复:

- **\`TestDynamicProbeScriptEndToEndCleanProcessNames\`(新增 e2e)**:伪造 \`/proc\`(含无 cmdline 的内核线程、comm 恰 15 字符截断的用户进程)在真实 POSIX sh 下执行 \`dynamicProbeScript\`,经 \`parseProbeOutput\` 全链解析,断言内核线程名干净(\`kworker/u:2\`)、cmdline basename 还原全名(\`openclaw-gatewa\` → \`openclaw-gateway\`)。修复前该测试以预期方式失败(pid 200 得到整行 stat 垃圾)。这补上了此前只做脚本文本断言、测不出 shell 实际行为的盲区。
- **\`TestDynamicProbeScriptNoJoinDependency\`(新增)**:静态断言不得依赖 \`join -t\`,配对须走 \`awk -F\`。
- \`TestDynamicProbeScriptRemoteTopProcs\` 的 join 断言翻转为 awk,sort 断言同步更新。
- 全仓库 \`go test ./...\` 通过。

## 手工验证

- 从源码原样提取探针脚本 + 伪造 \`/proc\`,受限 PATH 对照实验:唯一差别是 join 的有无——无 join 时修复前 PROC 段为空,修复后(仅提供 awk)进程正常出现。
- 修复后脚本在无 join、有 awk 环境下:内核线程/用户进程名全部干净,每行 ~25B。

建议合并前在 OpenWrt 真机上确认系统监控 top6 卡片恢复显示(路由器上 \`command -v join\` 为空即可复现修复前的问题)。