### PR TITLE
fix: 修复窄窗口下首页工具栏、设置外观与终端输入提示等响应式样式问题

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -250,7 +250,7 @@ export default function Dashboard({
       <div className="dashboard-right">
         <div className="hosts-section-container">
           <div className="section-title-container">
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: '1 0 280px', minWidth: 'min(100%, 280px)', maxWidth: '100%' }}>
               {/* 主机 / 最近连接 切换 */}
               <div className="segment-control dashboard-page-switch">
                 <Tiptop text={t('主机')} placement="bottom">
@@ -282,7 +282,7 @@ export default function Dashboard({
                   </button>
                 </Tiptop>
               </div>
-              <div style={{ position: 'relative', flex: 1, maxWidth: 240, minWidth: 120 }}>
+              <div style={{ position: 'relative', flex: '1 1 100px', maxWidth: 300, minWidth: 80 }}>
                 <Search size={12} style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)', pointerEvents: 'none' }} />
                 <input
                   id="server-search"
@@ -298,7 +298,7 @@ export default function Dashboard({
                 />
               </div>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 8 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', flex: '0 0 auto', marginLeft: 'auto' }}>
               {/* 本地连接 / 串口 快速连接下拉菜单 */}
               <div ref={localMenuRef} style={{ position: 'relative' }}>
                 <Tiptop text={t('本地终端 & 串口')} placement="bottom">
@@ -425,7 +425,7 @@ export default function Dashboard({
                       }}
                       style={{
                         height: 28,
-                        padding: '0 10px',
+                        padding: '0 8px',
                         fontSize: 12,
                         border: '1px solid var(--border)',
                         borderRadius: 'var(--radius-sm)',
@@ -435,6 +435,8 @@ export default function Dashboard({
                         alignItems: 'center',
                         gap: 5,
                         fontWeight: 500,
+                        whiteSpace: 'nowrap',
+                        flexShrink: 0,
                       }}
                     >
                       {allCollapsed ? <Folder size={13} /> : <FolderOpen size={13} />}
@@ -449,7 +451,7 @@ export default function Dashboard({
                       aria-label={t('数据管理')}
                       style={{
                         height: 28,
-                        padding: '0 10px',
+                        padding: '0 8px',
                         display: 'flex',
                         alignItems: 'center',
                         gap: 5,
@@ -458,6 +460,8 @@ export default function Dashboard({
                         background: 'var(--surface-overlay)',
                         color: 'var(--text-secondary)',
                         fontWeight: 500,
+                        whiteSpace: 'nowrap',
+                        flexShrink: 0,
                       }}
                     >
                       <Database size={13} />

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -2158,7 +2158,7 @@ export default function SettingsModal({
         <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
 
           {/* Settings Sidebar */}
-          <div style={{ width: 220, borderRight: '1px solid var(--border-subtle)', padding: '10px 6px', display: 'flex', flexDirection: 'column', gap: 2, background: 'var(--surface-base)' }}>
+          <div className="settings-sidebar">
             <div style={{ padding: '0 4px 8px' }}>
               <div style={{ position: 'relative' }}>
                 <input
@@ -2257,7 +2257,7 @@ export default function SettingsModal({
           </div>
 
           {/* Settings Content */}
-          <div style={{ flex: 1, padding: '20px 24px', overflowY: 'auto', background: 'var(--surface-raised)' }}>
+          <div className="settings-content-pane">
             
             {activeTab === 'app' && (
               <AppTab

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -584,6 +584,21 @@ export default function Terminal({
   const [termSearchCaseSensitive, setTermSearchCaseSensitive] = useState(false);
   const [termSearchResult, setTermSearchResult] = useState({ resultIndex: -1, resultCount: 0 });
   const cmdInputRef                           = useRef<HTMLTextAreaElement | null>(null);
+  const [cmdInputWidth, setCmdInputWidth]     = useState<number>(600);
+
+  useEffect(() => {
+    const el = cmdInputRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentRect && entry.contentRect.width > 0) {
+          setCmdInputWidth(entry.contentRect.width);
+        }
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
   const historyBtnRef                         = useRef<HTMLButtonElement | null>(null);
   const historySearchInputRef                 = useRef<HTMLInputElement | null>(null);
   const historyScrollRef                      = useRef<HTMLDivElement | null>(null);
@@ -3954,146 +3969,191 @@ export default function Terminal({
       {/* ── 底部命令输入栏 ── */}
       <div className="term-input-bar">
         {/* 命令输入框 */}
-        <textarea
-          ref={cmdInputRef}
-          className="input term-command-input"
-          name="terminalCommand"
-          value={cmdInput}
-          rows={1}
-          spellCheck={false}
-          autoComplete="off"
-          onContextMenu={handleInputContextMenu}
-          onChange={e => {
-            const nextValue = e.target.value;
-            setCmdInput(nextValue);
-            if (commandAutocompleteFocusedRef.current) {
-              scheduleCommandAutocompleteSuggestions(nextValue);
-            }
-          }}
-          onFocus={() => {
-            commandAutocompleteFocusedRef.current = true;
-            clearCommandAutocompleteBlurTimer();
-            updateCommandAutocompletePopupPosition();
-            if (cmdInput.trim()) {
-              scheduleCommandAutocompleteSuggestions(cmdInput);
-            }
-          }}
-          onBlur={() => {
-            commandAutocompleteFocusedRef.current = false;
-            clearCommandAutocompleteBlurTimer();
-            commandAutocompleteBlurTimerRef.current = setTimeout(() => {
-              closeCommandAutocomplete();
-            }, 120);
-          }}
-          onScroll={() => {
-            if (commandAutocomplete.open || commandAutocomplete.loading) {
+        <Tiptop
+          text={!cmdInput && !commandAutocomplete.open ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: '2px 4px', fontSize: 11, lineHeight: 1.5, textAlign: 'left', minWidth: 190 }}>
+              <div style={{ fontWeight: 600, color: 'var(--text-primary)', borderBottom: '1px solid var(--border-subtle)', paddingBottom: 4, marginBottom: 2, display: 'flex', alignItems: 'center', gap: 5 }}>
+                <span>⌨️</span> <span>{t('命令输入快捷键')}</span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                <span style={{ color: 'var(--text-secondary)' }}>{t('执行命令')}</span>
+                <kbd style={{ background: 'var(--surface-overlay)', border: '1px solid var(--border)', borderRadius: 3, padding: '1px 5px', fontSize: 10, fontFamily: 'var(--font-mono)' }}>Enter</kbd>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                <span style={{ color: 'var(--text-secondary)' }}>{t('换行多行输入')}</span>
+                <kbd style={{ background: 'var(--surface-overlay)', border: '1px solid var(--border)', borderRadius: 3, padding: '1px 5px', fontSize: 10, fontFamily: 'var(--font-mono)' }}>Shift + Enter</kbd>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                <span style={{ color: 'var(--text-secondary)' }}>{t('快捷命令列表')}</span>
+                <kbd style={{ background: 'var(--surface-overlay)', border: '1px solid var(--border)', borderRadius: 3, padding: '1px 5px', fontSize: 10, fontFamily: 'var(--font-mono)' }}>/</kbd>
+              </div>
+              {altOpenHistoryEnabled && (
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                  <span style={{ color: 'var(--text-secondary)' }}>{t('搜索历史指令')}</span>
+                  <kbd style={{ background: 'var(--surface-overlay)', border: '1px solid var(--border)', borderRadius: 3, padding: '1px 5px', fontSize: 10, fontFamily: 'var(--font-mono)' }}>Alt</kbd>
+                </div>
+              )}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                <span style={{ color: 'var(--text-secondary)' }}>{t('补全候选项')}</span>
+                <kbd style={{ background: 'var(--surface-overlay)', border: '1px solid var(--border)', borderRadius: 3, padding: '1px 5px', fontSize: 10, fontFamily: 'var(--font-mono)' }}>Tab</kbd>
+              </div>
+            </div>
+          ) : undefined}
+          placement="top"
+          style={{ flex: 1, display: 'flex', minWidth: 0 }}
+        >
+          <textarea
+            ref={cmdInputRef}
+            className="input term-command-input"
+            name="terminalCommand"
+            value={cmdInput}
+            rows={1}
+            spellCheck={false}
+            autoComplete="off"
+            onContextMenu={handleInputContextMenu}
+            onChange={e => {
+              const nextValue = e.target.value;
+              setCmdInput(nextValue);
+              if (commandAutocompleteFocusedRef.current) {
+                scheduleCommandAutocompleteSuggestions(nextValue);
+              }
+            }}
+            onFocus={() => {
+              commandAutocompleteFocusedRef.current = true;
+              clearCommandAutocompleteBlurTimer();
               updateCommandAutocompletePopupPosition();
-            }
-          }}
-          onSelect={() => {
-            if (commandAutocomplete.open || commandAutocomplete.loading) {
-              updateCommandAutocompletePopupPosition();
-            }
-            if (commandAutocompleteFocusedRef.current && cmdInput.trim()) {
-              scheduleCommandAutocompleteSuggestions(cmdInput);
-            }
-          }}
-          onKeyDown={async (e) => {
-            if (e.key === 'Alt' && !e.ctrlKey && !e.shiftKey && !e.metaKey && !e.repeat) {
-              if (!altOpenHistoryEnabled) return;
-              e.preventDefault();
-              e.stopPropagation();
-              closeCommandAutocomplete();
-              openHistoryAndFocusSearch();
-              return;
-            }
-
-            if (commandAutocomplete.open && e.key === 'ArrowDown') {
-              e.preventDefault();
-              if (commandAutocomplete.items.length === 0) {
+              if (cmdInput.trim()) {
+                scheduleCommandAutocompleteSuggestions(cmdInput);
+              }
+            }}
+            onBlur={() => {
+              commandAutocompleteFocusedRef.current = false;
+              clearCommandAutocompleteBlurTimer();
+              commandAutocompleteBlurTimerRef.current = setTimeout(() => {
+                closeCommandAutocomplete();
+              }, 120);
+            }}
+            onScroll={() => {
+              if (commandAutocomplete.open || commandAutocomplete.loading) {
+                updateCommandAutocompletePopupPosition();
+              }
+            }}
+            onSelect={() => {
+              if (commandAutocomplete.open || commandAutocomplete.loading) {
+                updateCommandAutocompletePopupPosition();
+              }
+              if (commandAutocompleteFocusedRef.current && cmdInput.trim()) {
+                scheduleCommandAutocompleteSuggestions(cmdInput);
+              }
+            }}
+            onKeyDown={async (e) => {
+              if (e.key === 'Alt' && !e.ctrlKey && !e.shiftKey && !e.metaKey && !e.repeat) {
+                if (!altOpenHistoryEnabled) return;
+                e.preventDefault();
+                e.stopPropagation();
+                closeCommandAutocomplete();
+                openHistoryAndFocusSearch();
                 return;
               }
-              commandAutocompleteKeyboardNavigationRef.current = true;
-              setCommandAutocomplete((previous) => ({
-                ...previous,
-                selectedIndex: previous.selectedIndex < 0
-                  ? 0
-                  : (previous.selectedIndex + 1) % previous.items.length,
-              }));
-              return;
-            }
 
-            if (commandAutocomplete.open && e.key === 'ArrowUp') {
-              e.preventDefault();
-              if (commandAutocomplete.items.length === 0) {
-                return;
-              }
-              commandAutocompleteKeyboardNavigationRef.current = true;
-              setCommandAutocomplete((previous) => ({
-                ...previous,
-                selectedIndex: previous.selectedIndex < 0
-                  ? previous.items.length - 1
-                  : (previous.selectedIndex - 1 + previous.items.length) % previous.items.length,
-              }));
-              return;
-            }
-
-            if (e.key === 'Tab' && cmdInput.trim()) {
-              e.preventDefault();
-              let items = commandAutocomplete.items;
-              if (items.length === 0) {
-                items = await loadCommandAutocompleteSuggestions(cmdInput);
-              }
-              const selectedIndex = commandAutocomplete.selectedIndex >= 0 ? commandAutocomplete.selectedIndex : 0;
-              const selectedItem = items[selectedIndex] || items[0];
-              if (selectedItem) {
-                applyCommandAutocompleteItem(selectedItem);
-              }
-              return;
-            }
-
-            if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
-              requestAnimationFrame(() => {
-                if (commandAutocompleteFocusedRef.current && cmdInputRef.current) {
-                  updateCommandAutocompletePopupPosition();
-                  void loadCommandAutocompleteSuggestions(cmdInputRef.current.value);
+              if (commandAutocomplete.open && e.key === 'ArrowDown') {
+                e.preventDefault();
+                if (commandAutocomplete.items.length === 0) {
+                  return;
                 }
-              });
-            }
+                commandAutocompleteKeyboardNavigationRef.current = true;
+                setCommandAutocomplete((previous) => ({
+                  ...previous,
+                  selectedIndex: previous.selectedIndex < 0
+                    ? 0
+                    : (previous.selectedIndex + 1) % previous.items.length,
+                }));
+                return;
+              }
 
-            if (e.key === 'Escape') {
-              if (commandAutocomplete.open) {
+              if (commandAutocomplete.open && e.key === 'ArrowUp') {
+                e.preventDefault();
+                if (commandAutocomplete.items.length === 0) {
+                  return;
+                }
+                commandAutocompleteKeyboardNavigationRef.current = true;
+                setCommandAutocomplete((previous) => ({
+                  ...previous,
+                  selectedIndex: previous.selectedIndex < 0
+                    ? previous.items.length - 1
+                    : (previous.selectedIndex - 1 + previous.items.length) % previous.items.length,
+                }));
+                return;
+              }
+
+              if (e.key === 'Tab' && cmdInput.trim()) {
+                e.preventDefault();
+                let items = commandAutocomplete.items;
+                if (items.length === 0) {
+                  items = await loadCommandAutocompleteSuggestions(cmdInput);
+                }
+                const selectedIndex = commandAutocomplete.selectedIndex >= 0 ? commandAutocomplete.selectedIndex : 0;
+                const selectedItem = items[selectedIndex] || items[0];
+                if (selectedItem) {
+                  applyCommandAutocompleteItem(selectedItem);
+                }
+                return;
+              }
+
+              if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
+                requestAnimationFrame(() => {
+                  if (commandAutocompleteFocusedRef.current && cmdInputRef.current) {
+                    updateCommandAutocompletePopupPosition();
+                    void loadCommandAutocompleteSuggestions(cmdInputRef.current.value);
+                  }
+                });
+              }
+
+              if (e.key === 'Escape') {
+                if (commandAutocomplete.open) {
+                  e.preventDefault();
+                  closeCommandAutocomplete();
+                  return;
+                }
+                setShowHistory(false);
+              }
+
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                if (e.shiftKey) {
+                  return;
+                }
                 e.preventDefault();
                 closeCommandAutocomplete();
-                return;
+                executeCommand();
               }
-              setShowHistory(false);
-            }
-
-            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-              if (e.shiftKey) {
-                return;
+            }}
+            placeholder={(() => {
+              if (cmdInputWidth >= 520) {
+                return altOpenHistoryEnabled
+                  ? `${t('输入命令')} (/ ${t('快捷命令')}) · Shift+Enter ${t('换行')} · Alt → ${t('历史指令')}`
+                  : `${t('输入命令')} (/ ${t('快捷命令')}) · Shift+Enter ${t('换行')}`;
               }
-              e.preventDefault();
-              closeCommandAutocomplete();
-              executeCommand();
-            }
-          }}
-          placeholder={altOpenHistoryEnabled
-            ? `${t('输入命令')} (/ ${t('快捷命令')}) · Shift+Enter ${t('换行')} · Alt → ${t('历史指令')} ${t('搜索')}`
-            : `${t('输入命令')} (/ ${t('快捷命令')}) · Shift+Enter ${t('换行')}`}
-          style={{
-            flex: 1,
-            fontSize: 12,
-            fontFamily: 'var(--font-terminal)',
-            padding: '7px 10px',
-            height: 32,
-            minHeight: 32,
-            background: 'var(--term-input-bg)',
-            color: 'var(--term-input-color)',
-            borderColor: cmdInput ? 'var(--border-focus)' : 'var(--term-btn-border)',
-          }}
-        />
+              if (cmdInputWidth >= 360) {
+                return `${t('输入命令')} (/ ${t('快捷命令')}) · Shift+Enter ${t('换行')}`;
+              }
+              if (cmdInputWidth >= 240) {
+                return `${t('输入命令')} (/ ${t('快捷命令')})`;
+              }
+              return `${t('输入命令')}...`;
+            })()}
+            style={{
+              width: '100%',
+              fontSize: 12,
+              fontFamily: 'var(--font-terminal)',
+              padding: '7px 10px',
+              height: 32,
+              minHeight: 32,
+              background: 'var(--term-input-bg)',
+              color: 'var(--term-input-color)',
+              borderColor: cmdInput ? 'var(--border-focus)' : 'var(--term-btn-border)',
+            }}
+          />
+        </Tiptop>
 
         {/* 历史按钮 */}
         <Tiptop text={t('历史指令')}>

--- a/frontend/src/components/settings/AppearanceTab.tsx
+++ b/frontend/src/components/settings/AppearanceTab.tsx
@@ -183,7 +183,7 @@ export default function AppearanceTab({
                 {programFontImporting ? $t('导入中...') : $t('添加字体')}
               </button>
             </div>
-            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(240px, 280px) minmax(0, 1fr)', gap: 16, alignItems: 'stretch' }}>
+            <div className="settings-font-manager-grid">
               <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
                   <span style={{ display: 'inline-flex', alignItems: 'center', minHeight: 22, padding: '0 8px', borderRadius: 999, border: '1px solid var(--border)', background: 'var(--surface-raised)', color: 'var(--text-secondary)', fontSize: 11 }}>
@@ -273,20 +273,21 @@ export default function AppearanceTab({
                         border: `1px solid ${isHighlighted ? 'var(--accent)' : 'var(--border)'}`,
                         background: isHighlighted ? 'rgba(var(--accent-rgb), 0.08)' : 'var(--surface-base)',
                         boxShadow: isHighlighted ? '0 0 0 1px rgba(var(--accent-rgb), 0.18) inset' : 'none',
-                        padding: 14,
-                        minHeight: 88,
+                        padding: 12,
+                        minHeight: 84,
                         flex: 1,
                         display: 'flex',
                         flexDirection: 'column',
                         justifyContent: 'space-between',
-                        gap: 10,
+                        gap: 8,
                         transition: 'var(--transition-fast)',
+                        minWidth: 0,
                       }}
                     >
-                      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-                        <div style={{ minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+                        <div style={{ minWidth: 0, flex: 1 }}>
                           <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>{target.title}</div>
-                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.6 }}>{target.description}</div>
+                          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5, wordBreak: 'break-word' }}>{target.description}</div>
                         </div>
                         <button
                           className="btn btn-ghost btn-sm"
@@ -297,11 +298,11 @@ export default function AppearanceTab({
                           {$t('恢复默认')}
                         </button>
                       </div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                        <span style={{ display: 'inline-flex', alignItems: 'center', minHeight: 24, padding: '0 10px', borderRadius: 999, border: '1px solid var(--border)', background: 'var(--surface-overlay)', color: 'var(--text-primary)', fontSize: 12, fontWeight: 600 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', minWidth: 0 }}>
+                        <span style={{ display: 'inline-flex', alignItems: 'center', minHeight: 22, padding: '0 8px', borderRadius: 999, border: '1px solid var(--border)', background: 'var(--surface-overlay)', color: 'var(--text-primary)', fontSize: 11, fontWeight: 600, flexShrink: 0 }}>
                           {assignedFont ? assignedFont.displayName : $t('默认')}
                         </span>
-                        <span style={{ fontSize: 11, color: 'var(--text-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <span style={{ fontSize: 11, color: 'var(--text-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flex: 1 }}>
                           {assignedFont ? assignedFont.fileName : target.defaultText}
                         </span>
                       </div>
@@ -451,7 +452,7 @@ export default function AppearanceTab({
             <button className="btn btn-secondary btn-sm" onClick={onTuneActiveThemeWithAI} disabled={themePackageBusy}>{$t('AI调色')}</button>
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)', gap: 16, alignItems: 'start' }}>
+          <div className="settings-theme-palette-grid">
             <ThemePackagePalette
               definition={appearanceSettings.fields.lightThemePackage}
               title={$t('浅色主题包')}

--- a/frontend/src/components/settings/SharedComponents.tsx
+++ b/frontend/src/components/settings/SharedComponents.tsx
@@ -85,8 +85,8 @@ export function SettingsField({ definition, title, description, action, children
   const resolvedTitle = title ?? (definition?.titleKey ? $t(definition.titleKey) : title);
   const resolvedDescription = description ?? (definition?.descriptionKey ? $t(definition.descriptionKey) : description);
   return (
-    <div data-settings-field-id={definition?.id} style={{ ...style, ...(children ? { display: 'flex', flexDirection: 'column', gap: 8 } : { display: 'flex', justifyContent: 'space-between', alignItems, gap }) }}>
-      <div style={{ minWidth: 0 }}>
+    <div data-settings-field-id={definition?.id} style={{ ...style, ...(children ? { display: 'flex', flexDirection: 'column', gap: 8 } : { display: 'flex', justifyContent: 'space-between', alignItems, gap, flexWrap: 'wrap' }) }}>
+      <div style={{ minWidth: 0, flex: '1 1 180px' }}>
         {resolvedTitle ? <div style={{ color: 'var(--text-primary)', fontSize: 13 }}>{resolvedTitle}</div> : null}
         {resolvedDescription ? <div style={{ color: 'var(--text-tertiary)', fontSize: 11 }}>{resolvedDescription}</div> : null}
       </div>

--- a/frontend/src/components/settings/SyncTab.tsx
+++ b/frontend/src/components/settings/SyncTab.tsx
@@ -71,7 +71,7 @@ function ProviderCard({ provider, providerKey, form, configured, editing, onEdit
               {$t('修改配置')}
             </button>
           </div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', marginTop: '4px' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '12px', marginTop: '4px' }}>
             {provider.summaryFields(form).map((sf, i) => (
               <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 6, background: 'var(--surface-overlay)', padding: '10px 12px', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)', ...(sf.fullWidth ? { gridColumn: '1 / -1' } : {}) }}>
                 <span style={{ fontSize: 12, color: 'var(--text-tertiary)', textTransform: 'uppercase', fontWeight: 600, letterSpacing: '0.5px' }}>{sf.label}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4354,8 +4354,9 @@ body.theme-light .editor-mode-banner {
 }
 
 .dashboard-left {
-  width: 360px;
-  min-width: 360px;
+  width: 340px;
+  min-width: 300px;
+  max-width: 380px;
   border-right: 1px solid var(--border-subtle);
   background: var(--surface-raised);
   padding: 10px;
@@ -4364,10 +4365,12 @@ body.theme-light .editor-mode-banner {
   gap: 8px;
   overflow: hidden;
   min-height: 0;
+  flex-shrink: 0;
 }
 
 .dashboard-right {
   flex: 1;
+  min-width: 0;
   padding: 10px 12px;
   display: flex;
   flex-direction: column;
@@ -4698,7 +4701,9 @@ body.theme-light .dashboard-server-editor {
 .section-title-container {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  justify-content: space-between;
+  gap: 8px 10px;
+  flex-wrap: wrap;
   margin-bottom: 0;
   padding-top: 0;
   padding-bottom: 0;
@@ -5017,30 +5022,59 @@ body.theme-light .dashboard-server-editor {
   line-height: 1;
 }
 
+/* ── 设置弹窗响应式样式 ── */
+.settings-sidebar {
+  width: 200px;
+  min-width: 170px;
+  border-right: 1px solid var(--border-subtle);
+  padding: 10px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--surface-base);
+  flex-shrink: 0;
+}
+
+.settings-content-pane {
+  flex: 1;
+  min-width: 0;
+  padding: 20px 24px;
+  overflow-y: auto;
+  background: var(--surface-raised);
+}
+
+.settings-font-manager-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.settings-theme-palette-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
 /* ── 响应式适配 ─────────────────────────────────────────────── */
 @media (max-width: 900px) {
   .dashboard-left {
-    width: 340px;
-    min-width: 340px;
+    width: 300px;
+    min-width: 280px;
   }
   .dashboard-right {
-    padding: var(--space-3);
+    padding: 8px 10px;
   }
 }
 
-@media (max-width: 700px) {
-  .dashboard-container {
-    flex-direction: column;
-  }
+@media (max-width: 720px) {
   .dashboard-left {
-    width: 100%;
-    min-width: 100%;
-    max-height: 240px;
-    border-right: none;
-    border-bottom: 1px solid var(--border);
+    width: 280px;
+    min-width: 250px;
   }
   .dashboard-right {
-    padding: var(--space-3);
+    padding: 8px;
   }
   .server-grid {
     grid-template-columns: 1fr;
@@ -5054,18 +5088,17 @@ body.theme-light .dashboard-server-editor {
   .dashboard-server-editor .form-row {
     grid-template-columns: 1fr;
   }
-  /* 触摸目标最小 44px */
-  .btn { min-height: 44px; }
-  .btn-sm { min-height: 36px; }
-  .btn-icon { min-width: 44px; min-height: 44px; }
-  .segment-control button { min-width: 44px; min-height: 36px; }
-  .server-card { min-height: 52px; }
+  .settings-sidebar {
+    width: 150px;
+    min-width: 130px;
+    padding: 8px 4px;
+  }
+  .settings-content-pane {
+    padding: 12px 14px;
+  }
 }
 
 @media (max-width: 500px) {
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
   .file-list-header,
   .file-item {
     grid-template-columns: minmax(100px, 1fr) 50px 90px 90px;
@@ -5367,9 +5400,16 @@ body.theme-light .dashboard-server-editor {
 }
 .term-command-input::placeholder {
   color: var(--term-input-placeholder, var(--term-muted));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: inherit;
 }
 .term-search-input::placeholder {
   color: var(--term-input-placeholder, var(--term-muted));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ── xterm 搜索高亮：禁用 SearchAddon 默认 outline，避免脏黑边 ── */


### PR DESCRIPTION
### 修复问题描述

在软件窗口宽度较窄（或分屏/小屏幕显示）时，修复以下几处响应式布局与样式缺陷：

1. **首页头部搜索与操作按钮重叠**：
   - 修复了在 500px ~ 620px 宽度区间下，左侧页面切换/搜索框与右侧操作按钮相互重叠穿插的问题。
   - 为左侧容器设定弹性基准（\lex: '1 0 280px'\ 与 \minWidth: 'min(100%, 280px)'\），触发平滑折行，并添加标准的行列间距。

2. **新建连接侧面板在窄窗口下被顶出截断**：
   - 移除了残余的移动端 \lex-direction: column\ 与 \max-height: 240px\ 规则，保持桌面端左右双栏布局，左侧面板宽度按屏幕宽度自适应平滑收缩，表单全高展示且内部滚动正常。

3. **设置外观面板字体管理与主题包错位**：
   - 字体管理器由写死宽度的网格改为响应式自适应网格（\epeat(auto-fit, minmax(240px, 1fr))\），防止右侧字体目标卡片文字在窄屏下被挤压成单字竖排。
   - 主题包列表引入自适应网格，设置侧边栏与内容区支持窄屏收窄。

4. **终端底部命令输入框提示文字自适应**：
   - 借助 \ResizeObserver\ 动态感知输入框宽度，提供阶梯式自适应占位提示（宽屏完整模式 -> 中等模式 -> 紧凑模式 -> 极简模式），彻底消除单行输入框在窄屏下文字换行截断半截字的问题。
   - 接入 \Tiptop\ 悬浮卡片，鼠标悬浮时展示清晰格式化的全套快捷键说明。

### 验证情况
- \
pm run build\ 前端打包成功，零报错。
- \go test ./...\ 后端单元测试全部通过。