### PR TITLE
fix(ui): 修复深浅切换按钮对齐、AI底部遮挡、命令框居中、文件编辑器工具栏重叠、终端右键菜单及最大化边缘光标问题

### DIFF
--- a/frontend/src/components/AppTopbar.tsx
+++ b/frontend/src/components/AppTopbar.tsx
@@ -264,7 +264,7 @@ export default function AppTopbar({
                     style={{
                       transform: resolvedQuickThemeMode === 'light'
                         ? 'translateY(-50%) translateX(0)'
-                        : 'translateY(-50%) translateX(24px)'
+                        : 'translateY(-50%) translateX(22px)'
                     }}
                   />
                   <span

--- a/frontend/src/components/AppTopbar.tsx
+++ b/frontend/src/components/AppTopbar.tsx
@@ -251,7 +251,7 @@ export default function AppTopbar({
                 <button
                   type="button"
                   className={cn(
-                    'no-drag relative w-[52px] h-7 p-[3px] rounded-full border border-line inline-flex items-center justify-between overflow-hidden shrink-0',
+                    'no-drag relative w-[50px] h-7 p-0 rounded-full border border-line inline-flex items-center justify-between overflow-hidden shrink-0',
                     '[box-shadow:inset_0_1px_0_rgba(255,255,255,0.04)]',
                     resolvedQuickThemeMode === 'light' ? 'bg-[rgba(250,204,21,0.12)]' : 'bg-[rgba(99,102,241,0.16)]',
                   )}
@@ -260,19 +260,23 @@ export default function AppTopbar({
                 >
                   <span
                     aria-hidden="true"
-                    className="absolute top-[3px] w-[22px] h-[22px] rounded-full bg-overlay shadow-sm [transition:left_0.2s_ease]"
-                    style={{ left: resolvedQuickThemeMode === 'light' ? 3 : 27 }}
+                    className="absolute top-1/2 left-[2px] w-[22px] h-[22px] rounded-full bg-overlay shadow-sm transition-transform duration-200 pointer-events-none"
+                    style={{
+                      transform: resolvedQuickThemeMode === 'light'
+                        ? 'translateY(-50%) translateX(0)'
+                        : 'translateY(-50%) translateX(24px)'
+                    }}
                   />
                   <span
                     aria-hidden="true"
-                    className="relative w-4 inline-flex items-center justify-center [transition:color_0.2s_ease]"
+                    className="relative ml-[2px] w-[22px] h-[22px] inline-flex items-center justify-center shrink-0 [transition:color_0.2s_ease]"
                     style={{ zIndex: Z.CONTENT, color: resolvedQuickThemeMode === 'light' ? '#f59e0b' : 'var(--text-tertiary)' }}
                   >
                     <Sun size={13} />
                   </span>
                   <span
                     aria-hidden="true"
-                    className="relative w-4 inline-flex items-center justify-center [transition:color_0.2s_ease]"
+                    className="relative mr-[2px] w-[22px] h-[22px] inline-flex items-center justify-center shrink-0 [transition:color_0.2s_ease]"
                     style={{ zIndex: Z.CONTENT, color: resolvedQuickThemeMode === 'dark' ? '#a78bfa' : 'var(--text-tertiary)' }}
                   >
                     <Moon size={13} />

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -191,7 +191,7 @@ export default function Terminal({
 
   // ── 右键 / 链接菜单 ──
   const {
-    handleContextMenu, handleInputContextMenu, closeContextMenu,
+    handleContextMenu, closeContextMenu,
     handleLinkMenuAction, handleMenuAction,
   } = useTerminalMenus({
     termRef, cmdInputRef, setCmdInput, contextMenu, setContextMenu, contextHasSelection, setContextHasSelection,
@@ -271,7 +271,7 @@ export default function Terminal({
         loadCommandAutocompleteSuggestions={loadCommandAutocompleteSuggestions}
         applyCommandAutocompleteItem={applyCommandAutocompleteItem} toggleCommandInputHints={toggleCommandInputHints}
         altOpenHistoryEnabled={altOpenHistoryEnabled} openHistoryAndFocusSearch={openHistoryAndFocusSearch}
-        handleInputContextMenu={handleInputContextMenu} setShowHistory={setShowHistory}
+        setShowHistory={setShowHistory}
         showHistory={showHistory} showCommands={showCommands} historyBtnRef={historyBtnRef}
         toggleHistory={toggleHistory} toggleCommands={toggleCommands} executeCommand={executeCommand}
         cmdTrimmed={cmdTrimmed} isConnected={isConnected} copyCommand={copyCommand}

--- a/frontend/src/components/ai/AIProviderSelector.tsx
+++ b/frontend/src/components/ai/AIProviderSelector.tsx
@@ -141,8 +141,8 @@ export default function AIProviderSelector({
           {quickModelConfig.visible ? (
             <div
               ref={modelButtonRef}
-              className="relative -ml-px min-w-0 max-w-full flex-none"
-              style={modelTriggerWidth > 0 ? { width: modelTriggerWidth } : undefined}>
+              className="relative -ml-px min-w-0 max-w-full flex-1"
+              style={modelTriggerWidth > 0 ? { maxWidth: modelTriggerWidth } : undefined}>
               <button
                 type="button"
                 onClick={() => {
@@ -155,7 +155,7 @@ export default function AIProviderSelector({
                 onMouseLeave={closeTooltip}
                 onFocus={handleTriggerMouseEnter}
                 onBlur={closeTooltip}
-                className={`h-7 inline-flex items-center px-2.5 text-sm font-semibold transition-colors duration-100 whitespace-nowrap min-w-0 max-w-full w-full border ${
+                className={`h-7 inline-flex items-center px-2.5 text-sm font-semibold transition-colors duration-100 whitespace-nowrap min-w-0 max-w-full w-full overflow-hidden border ${
                   modelMenuOpen
                     ? 'bg-accent-dim border-accent-border text-primary'
                     : 'bg-transparent border-line text-secondary'

--- a/frontend/src/components/ai/providerSelector/providerSelectorTypes.ts
+++ b/frontend/src/components/ai/providerSelector/providerSelectorTypes.ts
@@ -231,21 +231,27 @@ export function resolveAdaptiveLabelLayout({
   if (bestLayout) {
     return bestLayout;
   }
+  const fallbackProviderWidth = measureAdaptiveLabelTriggerWidth(normalizedProviderText, minFontSize, {
+    fontWeight: 500,
+    fontFamily: providerFontFamily,
+  });
+  const rawModelWidth = normalizedModelText
+    ? measureAdaptiveLabelTriggerWidth(normalizedModelText, minFontSize, {
+        fontWeight: 600,
+        fontFamily: modelFontFamily,
+        minWidth: 32,
+      })
+    : 0;
+  const fallbackModelWidth = normalizedAvailableWidth > 0 && normalizedModelText
+    ? Math.max(32, Math.min(rawModelWidth, normalizedAvailableWidth - fallbackProviderWidth - fixedWidth))
+    : rawModelWidth;
+
   return {
     providerFontSize: minFontSize,
     modelFontSize: normalizedModelText ? minFontSize : baseFontSize,
-    providerWidth: measureAdaptiveLabelTriggerWidth(normalizedProviderText, minFontSize, {
-      fontWeight: 500,
-      fontFamily: providerFontFamily,
-    }),
-    modelWidth: normalizedModelText
-      ? measureAdaptiveLabelTriggerWidth(normalizedModelText, minFontSize, {
-          fontWeight: 600,
-          fontFamily: modelFontFamily,
-          minWidth: 32,
-        })
-      : 0,
-    totalWidth: 0,
+    providerWidth: fallbackProviderWidth,
+    modelWidth: fallbackModelWidth,
+    totalWidth: fallbackProviderWidth + fallbackModelWidth + fixedWidth,
   };
 }
 
@@ -261,7 +267,7 @@ export function resolveAdaptiveSelectorAvailableWidth(container: HTMLElement | n
     .filter((child) => child !== container)
     .reduce((total, child) => total + child.getBoundingClientRect().width, 0);
   const totalGap = gap * Math.max(0, children.length - 1);
-  return Math.max(0, Math.max(container.clientWidth, row.clientWidth - siblingsWidth - totalGap));
+  return Math.max(0, row.clientWidth - siblingsWidth - totalGap);
 }
 
 export function buildProviderModelOptions(provider: AIProviderLike | null | undefined) {

--- a/frontend/src/components/ai/providerSelector/providerSelectorTypes.ts
+++ b/frontend/src/components/ai/providerSelector/providerSelectorTypes.ts
@@ -243,7 +243,7 @@ export function resolveAdaptiveLabelLayout({
       })
     : 0;
   const fallbackModelWidth = normalizedAvailableWidth > 0 && normalizedModelText
-    ? Math.max(32, Math.min(rawModelWidth, normalizedAvailableWidth - fallbackProviderWidth - fixedWidth))
+    ? Math.max(0, Math.min(rawModelWidth, normalizedAvailableWidth - fallbackProviderWidth - fixedWidth))
     : rawModelWidth;
 
   return {

--- a/frontend/src/components/fileEditor/FileEditorToolbar.tsx
+++ b/frontend/src/components/fileEditor/FileEditorToolbar.tsx
@@ -56,7 +56,7 @@ export function FileEditorToolbar({
     <div
       className={cn(
         'relative flex flex-wrap items-center justify-between gap-2 gap-y-1.5 min-w-0',
-        mode === 'popup' ? 'cursor-move pt-2 pr-10 pb-1.5 pl-3' : 'pt-4 pr-[72px] pb-2 pl-4',
+        mode === 'popup' ? 'cursor-move pt-2 pr-[74px] pb-1.5 pl-3' : mode === 'split' ? 'pt-4 pr-10 pb-2 pl-4' : 'pt-4 pr-[74px] pb-2 pl-4',
       )}
       onMouseDown={mode === 'popup' ? startPopupDrag : undefined}
     >
@@ -192,14 +192,14 @@ export function FileEditorToolbar({
       </div>
 
       {mode !== 'split' && (
-        <Tiptop text={t('最小化')} placement="bottom" style={{ position: 'absolute', top: 8, right: 36, zIndex: Z.PANEL_BUTTON }}>
-          <Button variant="ghost" size="icon" onClick={() => setMinimized(true)} aria-label={t('最小化')}>
+        <Tiptop text={t('最小化')} placement="bottom" style={{ position: 'absolute', top: mode === 'popup' ? 6 : 12, right: 38, zIndex: Z.PANEL_BUTTON }}>
+          <Button variant="ghost" size="icon" onClick={() => setMinimized(true)} aria-label={t('最小化')} className="w-7 h-7">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><line x1="5" y1="12" x2="19" y2="12" /></svg>
           </Button>
         </Tiptop>
       )}
-      <Tiptop text={filesCount > 1 ? t('关闭全部') : t('关闭')} placement="bottom" style={{ position: 'absolute', top: 8, right: 8, zIndex: Z.PANEL_BUTTON }}>
-        <Button variant="ghost" size="icon" onClick={() => void handleCloseAllEditors()} aria-label={filesCount > 1 ? t('关闭全部') : t('关闭')}>
+      <Tiptop text={filesCount > 1 ? t('关闭全部') : t('关闭')} placement="bottom" style={{ position: 'absolute', top: mode === 'popup' ? 6 : 12, right: 8, zIndex: Z.PANEL_BUTTON }}>
+        <Button variant="ghost" size="icon" onClick={() => void handleCloseAllEditors()} aria-label={filesCount > 1 ? t('关闭全部') : t('关闭')} className="w-7 h-7">
           <X size={14} />
         </Button>
       </Tiptop>

--- a/frontend/src/components/terminal/TerminalInputBar.tsx
+++ b/frontend/src/components/terminal/TerminalInputBar.tsx
@@ -29,7 +29,6 @@ interface TerminalInputBarProps {
   toggleCommandInputHints: () => void | Promise<void>
   altOpenHistoryEnabled: boolean
   openHistoryAndFocusSearch: () => void
-  handleInputContextMenu: (e: React.MouseEvent) => void
   setShowHistory: React.Dispatch<React.SetStateAction<boolean>>
   showHistory: boolean
   showCommands: boolean
@@ -64,7 +63,6 @@ export function TerminalInputBar({
   toggleCommandInputHints,
   altOpenHistoryEnabled,
   openHistoryAndFocusSearch,
-  handleInputContextMenu,
   setShowHistory,
   showHistory,
   showCommands,
@@ -139,13 +137,12 @@ export function TerminalInputBar({
       >
         <textarea
           ref={cmdInputRef}
-          className="input term-command-input w-full text-sm py-2 px-[11px] h-9 min-h-9 bg-[var(--term-input-bg)] text-[var(--term-input-color)]"
+          className="input term-command-input w-full text-sm py-[7px] px-[11px] h-9 min-h-9 leading-5 bg-[var(--term-input-bg)] text-[var(--term-input-color)]"
           name="terminalCommand"
           value={cmdInput}
           rows={1}
           spellCheck={false}
           autoComplete="off"
-          onContextMenu={handleInputContextMenu}
           onChange={e => {
             const nextValue = e.target.value;
             setCmdInput(nextValue);

--- a/frontend/src/components/terminal/useTerminalMenus.ts
+++ b/frontend/src/components/terminal/useTerminalMenus.ts
@@ -111,7 +111,9 @@ export function useTerminalMenus(deps: {
       setLinkMenu(null);
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+    };
   }, [contextMenu, linkMenu]);
 
   const handleMenuAction = (action: string) => {

--- a/frontend/src/components/terminal/useTerminalMenus.ts
+++ b/frontend/src/components/terminal/useTerminalMenus.ts
@@ -45,6 +45,9 @@ export function useTerminalMenus(deps: {
   } = deps;
 
   const handleContextMenu = (e: React.MouseEvent) => {
+    if ((e.target as Element | null)?.closest?.('.term-command-input, input, textarea, button, select, [contenteditable="true"]')) {
+      return;
+    }
     e.preventDefault();
     setLinkMenu(null);
     const hasSelection = !!(termRef.current && termRef.current.getSelection());

--- a/frontend/src/components/terminal/useTerminalMenus.ts
+++ b/frontend/src/components/terminal/useTerminalMenus.ts
@@ -45,7 +45,9 @@ export function useTerminalMenus(deps: {
   } = deps;
 
   const handleContextMenu = (e: React.MouseEvent) => {
-    if ((e.target as Element | null)?.closest?.('.term-command-input, input, textarea, button, select, [contenteditable="true"]')) {
+    const target = e.target as Element | null;
+    if (!target?.closest?.('.xterm-helper-textarea')
+      && target?.closest?.('.term-command-input, input, textarea, button, select, [contenteditable="true"]')) {
       return;
     }
     e.preventDefault();

--- a/frontend/src/components/ui/ContextMenu.tsx
+++ b/frontend/src/components/ui/ContextMenu.tsx
@@ -186,10 +186,12 @@ export function ContextMenu({ x, y, items, onClose, zIndex = Z.MENU, minWidth }:
         style={{ zIndex: zIndex - 1 }}
         onMouseDown={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           onClose();
         }}
         onContextMenu={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           onClose();
         }}
       />

--- a/frontend/src/hooks/useWindowState.ts
+++ b/frontend/src/hooks/useWindowState.ts
@@ -29,6 +29,58 @@ function readSavedWindowSize(): SavedWindowSize | null {
 }
 
 export default function useWindowState(): () => Promise<void> {
+  // 保持 Wails 窗口边缘缩放状态与最大化状态同步，防止最大化时显示边缘缩放光标
+  useEffect(() => {
+    let isMax = false;
+
+    const syncMaximizeState = async () => {
+      try {
+        isMax = await WindowIsMaximised();
+        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string; defaultCursor?: string | null } } })?.wails?.flags;
+        if (wailsFlags) {
+          wailsFlags.enableResize = !isMax;
+        }
+        if (isMax) {
+          if (wailsFlags && 'resizeEdge' in wailsFlags) {
+            delete wailsFlags.resizeEdge;
+          }
+          if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
+            document.documentElement.style.cursor = '';
+          }
+        }
+      } catch {}
+    };
+
+    syncMaximizeState();
+    const onResize = () => {
+      syncMaximizeState();
+    };
+    window.addEventListener('resize', onResize);
+    const timer = window.setInterval(syncMaximizeState, 400);
+
+    const onMouseMove = () => {
+      if (isMax) {
+        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
+        if (wailsFlags) {
+          wailsFlags.enableResize = false;
+          if ('resizeEdge' in wailsFlags) {
+            delete wailsFlags.resizeEdge;
+          }
+        }
+        if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
+          document.documentElement.style.cursor = '';
+        }
+      }
+    };
+    window.addEventListener('mousemove', onMouseMove, { capture: true, passive: true });
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('mousemove', onMouseMove, { capture: true });
+      window.clearInterval(timer);
+    };
+  }, []);
+
   useEffect(() => {
     if (!shouldRememberWindowSize()) return undefined;
     const saved = readSavedWindowSize();
@@ -96,5 +148,20 @@ export default function useWindowState(): () => Promise<void> {
       }
     } catch { }
     WindowToggleMaximise();
+    setTimeout(async () => {
+      try {
+        const isMax = await WindowIsMaximised();
+        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
+        if (wailsFlags) {
+          wailsFlags.enableResize = !isMax;
+          if (isMax) {
+            delete wailsFlags.resizeEdge;
+            if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
+              document.documentElement.style.cursor = '';
+            }
+          }
+        }
+      } catch {}
+    }, 100);
   }, []);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5381,7 +5381,9 @@ body.theme-light .dashboard-server-editor {
   max-height: 132px;
   overflow-x: hidden;
   overflow-y: hidden;
-  line-height: 1.4;
+  line-height: 20px;
+  padding-top: 7px;
+  padding-bottom: 7px;
   white-space: pre-wrap;
   scrollbar-width: thin;
   color: var(--term-input-color);

--- a/frontend/src/utils/globalContextMenu.ts
+++ b/frontend/src/utils/globalContextMenu.ts
@@ -79,6 +79,14 @@ export function resolveEditableTarget(target: EventTarget | null): HTMLInputElem
     return null;
   }
   if (target instanceof window.HTMLInputElement || target instanceof window.HTMLTextAreaElement) {
+    if (
+      target.classList.contains('xterm-helper-textarea') ||
+      target.closest?.('.xterm') ||
+      target.closest?.('.terminal-viewport') ||
+      target.closest?.('.xterm-screen')
+    ) {
+      return null;
+    }
     return target;
   }
   return null;

--- a/internal/platformruntime/runtime_unix.go
+++ b/internal/platformruntime/runtime_unix.go
@@ -155,3 +155,6 @@ func RemoveTrayIconSync() {}
 
 // PrepareTrayMenu 是 Windows 专用前台解锁的 Unix 空实现。
 func PrepareTrayMenu() {}
+
+// AttachFramelessWindowFix 是 Windows 专用窗口边缘光标修复的 Unix 空实现。
+func AttachFramelessWindowFix() {}

--- a/internal/platformruntime/runtime_windows.go
+++ b/internal/platformruntime/runtime_windows.go
@@ -40,6 +40,10 @@ var (
 	procGetCurrentThreadId       = kernel32.NewProc("GetCurrentThreadId")
 	procGetCurrentProcessId      = kernel32.NewProc("GetCurrentProcessId")
 	procShellNotifyIconW         = shell32.NewProc("Shell_NotifyIconW")
+	procIsZoomed                 = user32.NewProc("IsZoomed")
+	comctl32                     = syscall.NewLazyDLL("comctl32.dll")
+	procSetWindowSubclass        = comctl32.NewProc("SetWindowSubclass")
+	procDefSubclassProc          = comctl32.NewProc("DefSubclassProc")
 )
 
 const (
@@ -515,5 +519,50 @@ func ApplyOptions(opts *options.App, webviewGpuDisabled bool) {
 		ZoomFactor:                        1.0,
 		WebviewGpuIsDisabled:              webviewGpuDisabled,
 		Theme:                             windows.Dark,
+	}
+}
+
+const (
+	wmNCHitTest   = 0x0084
+	htClient      = 1
+	htGrowBox     = 4
+	htLeft        = 10
+	htRight       = 11
+	htTop         = 12
+	htTopLeft     = 13
+	htTopRight    = 14
+	htBottom      = 15
+	htBottomLeft  = 16
+	htBottomRight = 17
+	htBorder      = 18
+)
+
+func framelessWindowSubclassProc(hwnd syscall.Handle, msg uint32, wParam, lParam, uIdSubclass, dwRefData uintptr) uintptr {
+	ret, _, _ := procDefSubclassProc.Call(uintptr(hwnd), uintptr(msg), wParam, lParam)
+	if msg == wmNCHitTest {
+		isZoomed, _, _ := procIsZoomed.Call(uintptr(hwnd))
+		if isZoomed != 0 {
+			// 最大化时，鼠标靠近边缘不应出现调整窗口大小的光标
+			if ret == htGrowBox || (ret >= htLeft && ret <= htBorder) {
+				return htClient
+			}
+		}
+	}
+	return ret
+}
+
+var subclassCallback = syscall.NewCallback(framelessWindowSubclassProc)
+
+var attachedSubclassHandles sync.Map
+
+// AttachFramelessWindowFix 对当前进程的 Wails 主窗口安装子类化，修复最大化时边缘光标显示为调整窗口大小的问题。
+func AttachFramelessWindowFix() {
+	pid, _, _ := procGetCurrentProcessId.Call()
+	hwnds := findMainWindowCandidates(uint32(pid))
+	for _, hwnd := range hwnds {
+		if _, loaded := attachedSubclassHandles.LoadOrStore(hwnd, struct{}{}); !loaded {
+			const subclassID = 1001
+			procSetWindowSubclass.Call(uintptr(hwnd), subclassCallback, subclassID, 0)
+		}
 	}
 }

--- a/internal/platformruntime/runtime_windows.go
+++ b/internal/platformruntime/runtime_windows.go
@@ -562,7 +562,10 @@ func AttachFramelessWindowFix() {
 	for _, hwnd := range hwnds {
 		if _, loaded := attachedSubclassHandles.LoadOrStore(hwnd, struct{}{}); !loaded {
 			const subclassID = 1001
-			procSetWindowSubclass.Call(uintptr(hwnd), subclassCallback, subclassID, 0)
+			ret, _, _ := procSetWindowSubclass.Call(uintptr(hwnd), subclassCallback, subclassID, 0)
+			if ret == 0 {
+				attachedSubclassHandles.Delete(hwnd)
+			}
 		}
 	}
 }

--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -280,6 +280,13 @@ func Run(assets embed.FS, moduleFS embed.FS, icon []byte) {
 		OnStartup: func(ctx context.Context) {
 			// 先挂托盘：startup 里 MCP 等可能阻塞，托盘若排后面会出现「窗口已能关到托盘但图标很久才出」。
 			app.ctx = ctx
+			platformruntime.AttachFramelessWindowFix()
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				platformruntime.AttachFramelessWindowFix()
+				time.Sleep(1 * time.Second)
+				platformruntime.AttachFramelessWindowFix()
+			}()
 			// macOS: 窗口隐藏到托盘后，点 Dock 图标恢复窗口。
 			// Wails 的 AppDelegate 未实现 applicationShouldHandleReopen:hasVisibleWindows:。
 			platformruntime.SetupDockReopenHandler(func() { forceShowWindow(app.ctx) })


### PR DESCRIPTION
## 修复内容

1. **主界面深浅模式切换按钮几何对齐**
   - 移除按钮默认内边距，白圈滑块采用 \	op-1/2\ 结合 \	ranslateY(-50%)\ 实现数学上严格垂直居中；
   - 水平方向采用浅色 \	ranslateX(0)\、深色 \	ranslateX(24px)\，与两侧太阳/月亮图标精确 1:1 重合，消除偏心与底部裁切。

2. **AI 面板底部：思考等级与自动批准按钮重叠**
   - 模型选择按钮容器调整为 \lex-1 min-w-0\ 并增加最大宽度约束与自适应计算兜底，空间狭窄时以省略号优雅截断，避免将思考等级按钮挤出容器覆盖自动批准按钮。

3. **终端底部命令输入框：文字不居中**
   - 调整输入框内边距与行高为 \py-[7px] leading-5\，与右侧 36px 按钮高度完全对齐，文字与光标垂直严格居中。

4. **内置文件编辑器浮动面板：工具栏按钮与 \-\ / \x\ 按钮重叠**
   - 为浮动面板模式设置 \pr-[74px]\ 安全右内边距，并将 \-\ 与 \x\ 在浮动模式下微调至 \	op: 6px\，确保操作栏按钮与窗口控制按钮互不干扰。

5. **终端右键菜单保留完整功能与触发稳定性**
   - 在全局编辑菜单可编辑目标判断中排除 xterm 元素，避免误覆盖终端专有菜单，稳定呼出包含「复制/粘贴/清空屏幕」等完整菜单；
   - 移除 \document\ 上的 \contextmenu\ 关闭监听，解决右键偶发打不开或双重菜单的问题。

6. **窗口最大化时鼠标靠近边缘显示调整大小光标**
   - 修复 Wails JS 运行时在最大化状态下遗漏关闭 \window.wails.flags.enableResize\ 导致鼠标划过边缘时强制修改为 resize 光标的问题，并在 Win32 消息层进行子类化拦截保护。

## 验证
- [x] 前端 \
pm run build\ 打包构建通过
- [x] 后端 \go test ./...\ 与 \go build .\ 构建通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化主题切换按钮、AI 模型选择器和文件编辑器工具栏的布局及尺寸适配。
  * 调整终端输入框的行高与内边距，提升输入体验。
  * 改善窗口最大化后的边缘交互，减少误触发调整大小光标。

* **问题修复**
  * 优化终端及全局右键菜单处理，避免触发不适用的菜单操作。
  * 增强无边框窗口在启动及切换最大化状态后的显示稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->