### PR TITLE
fix(terminal): 修复标签切换/面板伸缩视口自适应、滚动条样式与缩放文字错位问题

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useCallback } from 'react';
 import type { Terminal as XTerm } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import type { SearchAddon } from '@xterm/addon-search';
-import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n.ts';
 import { createHighlightState, loadKeywordRulesFromStorage } from '../utils/terminalKeywordHighlight.ts';
 import { Z } from '../constants/zIndex';
@@ -226,7 +225,7 @@ export default function Terminal({
       <TerminalBackground T={T} bgInfo={bgInfo} />
 
       {/* 内容层（置于背景之上) */}
-      <div className="relative flex flex-col h-full" style={{ zIndex: Z.CONTENT }}>
+      <div className="relative flex flex-col flex-1 min-h-0 h-full overflow-hidden" style={{ zIndex: Z.CONTENT }}>
       <TerminalStatusBar status={status} serverName={serverName} sessionId={sessionId} t={t} />
 
       {/* ── 终端内容查找栏 ── */}

--- a/frontend/src/components/terminal/TerminalSurface.tsx
+++ b/frontend/src/components/terminal/TerminalSurface.tsx
@@ -129,7 +129,7 @@ export function TerminalViewport({
   linkUnderlineLayerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (
-    <div className="flex-1 min-h-0 flex">
+    <div className="flex-1 min-h-0 flex overflow-hidden">
       <div ref={gutterRef} className="shrink-0 pt-0 overflow-hidden box-border" style={{
         display: (timestampsVisible || commandBlocksVisible) && !alternateBufferActive ? 'block' : 'none',
         // 时间戳约 72px；命令块约 16px；两者同时开约 96px
@@ -137,13 +137,13 @@ export function TerminalViewport({
         width: timestampsVisible && commandBlocksVisible ? 90 : (timestampsVisible ? 75 : 22),
       }} />
       <div
-        className={terminalDefaultMouseCursorEnabled ? 'terminal-output-default-mouse-cursor relative flex-1 min-h-0' : 'relative flex-1 min-h-0'}
+        className={terminalDefaultMouseCursorEnabled ? 'terminal-output-default-mouse-cursor relative flex-1 min-h-0 overflow-hidden' : 'relative flex-1 min-h-0 overflow-hidden'}
         onMouseDownCapture={handleTerminalMouseDownCapture}
         onMouseUpCapture={handleTerminalMouseUpCapture}
       >
         <div
           ref={containerRef}
-          className="h-full min-h-0 p-0 bg-transparent"
+          className="h-full min-h-0 p-0 bg-transparent overflow-hidden"
         />
         {/* 常驻链接下划线（pointer-events:none，不挡点击/选区） */}
         <div

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import type * as React from 'react';
 import { Terminal as XTerm } from '@xterm/xterm';
 import type { IBufferRange, IMarker, ITerminalInitOnlyOptions, ITerminalOptions } from '@xterm/xterm';
@@ -719,52 +719,93 @@ export function useTerminalSession(deps: {
     }
   }, [status]);
 
-  // ── 监听容器大小变化进行自适应 ───────────────────────────────────
+  const safeFit = useCallback(() => {
+    if (!termRef.current || !fitAddonRef.current || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    try {
+      fitAddonRef.current.fit();
+      const term = termRef.current;
+      const { cols, rows } = term;
+      if (cols > 0 && rows > 0) {
+        AppGo.ResizeTerminal(sessionId, cols, rows);
+        // xterm 5 在后台（display:none）时 IntersectionObserver 会将 RenderService 设为 paused，
+        // 导致尺寸虽然更新但 renderer canvas 仍停留在旧高度，Viewport 因计算出 scrollHeight > height 而误显示滚动条。
+        // 此处主动解除 pause、冲刷任务队列、同步尺寸并触发 Viewport 重新计算，彻底消除切标签后误显滚动条的问题。
+        try {
+          const core = (term as any)._core;
+          if (core?._renderService) {
+            if (core._renderService._isPaused) {
+              core._renderService._isPaused = false;
+              core._renderService._pausedResizeTask?.flush();
+            }
+            core._renderService.handleResize?.(cols, rows);
+            core._renderService.refreshRows?.(0, rows - 1);
+          }
+          if (core?._viewport) {
+            core._viewport.queueSync?.();
+          }
+        } catch (_) {}
+        term.scrollToBottom();
+      }
+    } catch (e) {
+      console.error('[Terminal] safeFit error:', e);
+    }
+  }, [sessionId]);
+
+  // ── 监听容器与窗口大小变化进行自适应 ─────────────────────────────────
   useEffect(() => {
-    if (!isActive || !containerRef.current || !fitAddonRef.current || !termRef.current) return;
+    if (!isActive || !containerRef.current) return;
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    const observer = new ResizeObserver(() => {
-      if (resizeTimer) clearTimeout(resizeTimer);
-      resizeTimer = setTimeout(() => {
-        if (!termRef.current || !fitAddonRef.current || !containerRef.current) return;
-        const rect = containerRef.current.getBoundingClientRect();
-        if (rect.width <= 0 || rect.height <= 0) return;
-        try {
-          fitAddonRef.current.fit();
-          const { cols, rows } = termRef.current;
-          AppGo.ResizeTerminal(sessionId, cols, rows);
-        } catch (e) {
-          console.error('[Terminal] Resize error:', e);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.contentRect.width > 0 && entry.contentRect.height > 0) {
+          if (resizeTimer) clearTimeout(resizeTimer);
+          resizeTimer = setTimeout(() => {
+            safeFit();
+          }, 30);
         }
-      }, 50);
+      }
     });
 
     observer.observe(containerRef.current);
 
+    const handleWindowResize = () => {
+      safeFit();
+    };
+    window.addEventListener('resize', handleWindowResize);
+
     return () => {
       if (resizeTimer) clearTimeout(resizeTimer);
       observer.disconnect();
+      window.removeEventListener('resize', handleWindowResize);
     };
-  }, [isActive, sessionId]);
+  }, [isActive, safeFit]);
 
-  // ── 终端切换回来时，重新 fit ────────────────────────────────────
+  // ── 终端切换回来时，多阶段重新自适应 ──────────────────────────────
   useEffect(() => {
-    if (!isActive || !termRef.current || !fitAddonRef.current) return;
-    const term = termRef.current;
-    const fitAddon = fitAddonRef.current;
-    const raf = requestAnimationFrame(() => {
-      try {
-        const rect = containerRef.current?.getBoundingClientRect();
-        if (rect && rect.width > 0 && rect.height > 0) {
-          fitAddon.fit();
-          const { cols, rows } = term;
-          AppGo.ResizeTerminal(sessionId, cols, rows);
-        }
-      } catch (e) {
-        console.error('[Terminal] activate fit error:', e);
-      }
+    if (!isActive) return;
+
+    // 多阶段重适应：立即执行、RAF 执行、double-RAF 以及 60ms/150ms/300ms 延迟，
+    // 覆盖标签切换后容器 display:flex 恢复、子标签栏渲染以及 CSS 布局完全就绪的各个阶段
+    safeFit();
+    const raf1 = requestAnimationFrame(() => {
+      safeFit();
+      const raf2 = requestAnimationFrame(() => {
+        safeFit();
+      });
+      return () => cancelAnimationFrame(raf2);
     });
-    return () => cancelAnimationFrame(raf);
-  }, [isActive, sessionId]);
+    const t1 = setTimeout(safeFit, 60);
+    const t2 = setTimeout(safeFit, 150);
+    const t3 = setTimeout(safeFit, 300);
+
+    return () => {
+      cancelAnimationFrame(raf1);
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [isActive, safeFit]);
 }

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -785,16 +785,35 @@ export function useTerminalSession(deps: {
           term.scrollToBottom();
         }
         if (core?._viewport) {
+          core._viewport._latestYDisp = targetLine;
           core._viewport.scrollToLine?.(targetLine, true);
           core._viewport.queueSync?.(targetLine);
         }
       } catch (_) {}
+
+      // 安排下一帧（RAF）再次确认底部同步，防止 xterm 内部异步 refresh 回调覆盖底部位置
+      requestAnimationFrame(() => {
+        try {
+          const t = termRef.current;
+          if (!t) return;
+          const b = t.buffer.active;
+          const c = (t as any)._core;
+          if (!userPinnedRef.current) {
+            t.scrollToBottom();
+            if (c?._viewport) {
+              c._viewport._latestYDisp = b.baseY;
+              c._viewport.scrollToLine?.(b.baseY, true);
+              c._viewport.queueSync?.(b.baseY);
+            }
+          }
+        } catch (_) {}
+      });
     } catch (e) {
       console.error('[Terminal] safeFit error:', e);
     }
   }, [scheduleDebouncedPTYResize]);
 
-  // ── 监听容器与窗口大小变化进行自适应 ─────────────────────────────────
+  // ── 监听容器与窗口大小变化以及侧边栏切换进行自适应 ─────────────────
   useEffect(() => {
     if (!isActive || !containerRef.current) return;
 
@@ -821,11 +840,26 @@ export function useTerminalSession(deps: {
     };
     window.addEventListener('resize', handleWindowResize);
 
+    const handleAIPanelChange = () => {
+      // 侧边栏/AI面板展开或收起时，采用多阶段自适应确保尺寸与底部锚定完全就绪
+      safeFit(true);
+      requestAnimationFrame(() => {
+        safeFit(true);
+        requestAnimationFrame(() => {
+          safeFit(true);
+        });
+      });
+      setTimeout(() => safeFit(true), 60);
+      setTimeout(() => safeFit(true), 150);
+    };
+    window.addEventListener('ai-panel-visibility-changed', handleAIPanelChange);
+
     return () => {
       if (resizeTimer) clearTimeout(resizeTimer);
       if (windowResizeTimer) clearTimeout(windowResizeTimer);
       observer.disconnect();
       window.removeEventListener('resize', handleWindowResize);
+      window.removeEventListener('ai-panel-visibility-changed', handleAIPanelChange);
     };
   }, [isActive, safeFit]);
 

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -105,6 +105,32 @@ export function useTerminalSession(deps: {
   const statusRef = useRef(status);
   useEffect(() => { statusRef.current = status; }, [status]);
 
+  const lastSentPTYSizeRef = useRef<{ cols: number; rows: number }>({ cols: 0, rows: 0 });
+  const ptyResizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleDebouncedPTYResize = useCallback((cols: number, rows: number, immediate = false) => {
+    const MIN_COLS = 20;
+    const MIN_ROWS = 2;
+    const clampedCols = Math.max(MIN_COLS, cols);
+    const clampedRows = Math.max(MIN_ROWS, rows);
+    if (lastSentPTYSizeRef.current.cols === clampedCols && lastSentPTYSizeRef.current.rows === clampedRows) {
+      return;
+    }
+    if (ptyResizeTimerRef.current) {
+      clearTimeout(ptyResizeTimerRef.current);
+      ptyResizeTimerRef.current = null;
+    }
+    const send = () => {
+      lastSentPTYSizeRef.current = { cols: clampedCols, rows: clampedRows };
+      AppGo.ResizeTerminal(sessionId, clampedCols, clampedRows);
+    };
+    if (immediate) {
+      send();
+    } else {
+      ptyResizeTimerRef.current = setTimeout(send, 80);
+    }
+  }, [sessionId]);
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -128,6 +154,7 @@ export function useTerminalSession(deps: {
       cursorStyle:      'bar',
       cursorWidth:      1,
       scrollback:       5000,
+      reflowCursorLine: true,
       // SearchAddon 高亮装饰依赖 proposed API
       allowProposedApi: true,
       fastScrollModifier: 'alt',
@@ -421,7 +448,7 @@ export function useTerminalSession(deps: {
         // 尺寸变化事件被错过，本地 PTY 可能长期停留在出生尺寸；这里主动
         // 同步一次，同时给 SIGWINCH 会重绘提示符的 shell（bash/zsh）兜底自愈机会。
         if (termRef.current) {
-          AppGo.ResizeTerminal(sessionId, termRef.current.cols, termRef.current.rows);
+          scheduleDebouncedPTYResize(termRef.current.cols, termRef.current.rows, true);
         }
       };
 
@@ -610,7 +637,7 @@ export function useTerminalSession(deps: {
     });
 
     const resizeDisposable = term.onResize(({ cols, rows }) => {
-      AppGo.ResizeTerminal(sessionId, cols, rows);
+      scheduleDebouncedPTYResize(cols, rows, false);
       scheduleGutterSync();
       scheduleLinkUnderlineSync();
     });
@@ -719,39 +746,45 @@ export function useTerminalSession(deps: {
     }
   }, [status]);
 
-  const safeFit = useCallback(() => {
+  const safeFit = useCallback((immediate = false) => {
     if (!termRef.current || !fitAddonRef.current || !containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) return;
     try {
-      fitAddonRef.current.fit();
       const term = termRef.current;
-      const { cols, rows } = term;
-      if (cols > 0 && rows > 0) {
-        AppGo.ResizeTerminal(sessionId, cols, rows);
-        // xterm 5 在后台（display:none）时 IntersectionObserver 会将 RenderService 设为 paused，
-        // 导致尺寸虽然更新但 renderer canvas 仍停留在旧高度，Viewport 因计算出 scrollHeight > height 而误显示滚动条。
-        // 此处主动解除 pause、冲刷任务队列、同步尺寸并触发 Viewport 重新计算，彻底消除切标签后误显滚动条的问题。
-        try {
-          const core = (term as any)._core;
-          if (core?._renderService) {
-            if (core._renderService._isPaused) {
-              core._renderService._isPaused = false;
-              core._renderService._pausedResizeTask?.flush();
-            }
-            core._renderService.handleResize?.(cols, rows);
-            core._renderService.refreshRows?.(0, rows - 1);
-          }
-          if (core?._viewport) {
-            core._viewport.queueSync?.();
-          }
-        } catch (_) {}
-        term.scrollToBottom();
+      const dims = fitAddonRef.current.proposeDimensions();
+      if (!dims || isNaN(dims.cols) || isNaN(dims.rows)) return;
+      const MIN_COLS = 20;
+      const MIN_ROWS = 2;
+      const cols = Math.max(MIN_COLS, dims.cols);
+      const rows = Math.max(MIN_ROWS, dims.rows);
+      if (term.cols !== cols || term.rows !== rows) {
+        term.resize(cols, rows);
       }
+      scheduleDebouncedPTYResize(cols, rows, immediate);
+
+      // xterm 5 在后台（display:none）时 IntersectionObserver 会将 RenderService 设为 paused，
+      // 导致尺寸虽然更新但 renderer canvas 仍停留在旧高度，Viewport 因计算出 scrollHeight > height 而误显示滚动条。
+      // 此处主动解除 pause、冲刷任务队列、同步尺寸并触发 Viewport 重新计算，彻底消除切标签后误显滚动条的问题。
+      try {
+        const core = (term as any)._core;
+        if (core?._renderService) {
+          if (core._renderService._isPaused) {
+            core._renderService._isPaused = false;
+            core._renderService._pausedResizeTask?.flush();
+          }
+          core._renderService.handleResize?.(cols, rows);
+          core._renderService.refreshRows?.(0, rows - 1);
+        }
+        if (core?._viewport) {
+          core._viewport.queueSync?.();
+        }
+      } catch (_) {}
+      term.scrollToBottom();
     } catch (e) {
       console.error('[Terminal] safeFit error:', e);
     }
-  }, [sessionId]);
+  }, [scheduleDebouncedPTYResize]);
 
   // ── 监听容器与窗口大小变化进行自适应 ─────────────────────────────────
   useEffect(() => {
@@ -763,7 +796,7 @@ export function useTerminalSession(deps: {
         if (entry.contentRect.width > 0 && entry.contentRect.height > 0) {
           if (resizeTimer) clearTimeout(resizeTimer);
           resizeTimer = setTimeout(() => {
-            safeFit();
+            safeFit(false);
           }, 30);
         }
       }
@@ -771,13 +804,18 @@ export function useTerminalSession(deps: {
 
     observer.observe(containerRef.current);
 
+    let windowResizeTimer: ReturnType<typeof setTimeout> | null = null;
     const handleWindowResize = () => {
-      safeFit();
+      if (windowResizeTimer) clearTimeout(windowResizeTimer);
+      windowResizeTimer = setTimeout(() => {
+        safeFit(false);
+      }, 30);
     };
     window.addEventListener('resize', handleWindowResize);
 
     return () => {
       if (resizeTimer) clearTimeout(resizeTimer);
+      if (windowResizeTimer) clearTimeout(windowResizeTimer);
       observer.disconnect();
       window.removeEventListener('resize', handleWindowResize);
     };
@@ -789,17 +827,17 @@ export function useTerminalSession(deps: {
 
     // 多阶段重适应：立即执行、RAF 执行、double-RAF 以及 60ms/150ms/300ms 延迟，
     // 覆盖标签切换后容器 display:flex 恢复、子标签栏渲染以及 CSS 布局完全就绪的各个阶段
-    safeFit();
+    safeFit(true);
     const raf1 = requestAnimationFrame(() => {
-      safeFit();
+      safeFit(true);
       const raf2 = requestAnimationFrame(() => {
-        safeFit();
+        safeFit(true);
       });
       return () => cancelAnimationFrame(raf2);
     });
-    const t1 = setTimeout(safeFit, 60);
-    const t2 = setTimeout(safeFit, 150);
-    const t3 = setTimeout(safeFit, 300);
+    const t1 = setTimeout(() => safeFit(true), 60);
+    const t2 = setTimeout(() => safeFit(true), 150);
+    const t3 = setTimeout(() => safeFit(true), 300);
 
     return () => {
       cancelAnimationFrame(raf1);

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -528,6 +528,8 @@ export function useTerminalSession(deps: {
         out = normalizeTerminalPasteText(out);
       }
 
+      userPinnedRef.current = false;
+
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(textEncoder.encode(out));
       }

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -105,6 +105,7 @@ export function useTerminalSession(deps: {
   const statusRef = useRef(status);
   useEffect(() => { statusRef.current = status; }, [status]);
 
+  const userPinnedRef = useRef(false);
   const lastSentPTYSizeRef = useRef<{ cols: number; rows: number }>({ cols: 0, rows: 0 });
   const ptyResizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -252,12 +253,12 @@ export function useTerminalSession(deps: {
     setAlternateBufferActive(false);
 
     // ── 智能写入：用户手动滚动上时保持位置 ─────────────────────────
-    let userPinned = false; // 用户手动往上滚后锁定
+    userPinnedRef.current = false;
     const onTermScroll = () => {
       const buf = term.buffer.active;
       // 滚到底部时解除锁定
       if (buf.viewportY >= buf.baseY) {
-        userPinned = false;
+        userPinnedRef.current = false;
       }
       scheduleGutterSync();
       scheduleLinkUnderlineSync();
@@ -330,7 +331,7 @@ export function useTerminalSession(deps: {
       // 无论向上还是向下滚动，都检查当前位置并更新锁定状态
       requestAnimationFrame(() => {
         const buf = term.buffer.active;
-        userPinned = buf.viewportY < buf.baseY;
+        userPinnedRef.current = buf.viewportY < buf.baseY;
       });
     };
     containerRef.current?.addEventListener('wheel', wheelHandler, { passive: true });
@@ -355,7 +356,7 @@ export function useTerminalSession(deps: {
       if (keywordHighlightEnabledRef.current && typeof data === 'string') {
         writeData = highlightKeywords(data, hlStateRef.current);
       }
-      if (userPinned) {
+      if (userPinnedRef.current) {
         // xterm.js 在用户不在底部时已经会保持滚动位置。
         // 之前用 scrollToLine(savedY) 在异步回调中执行，会在用户向下滚动后
         // 把视图拉回旧位置，导致用户无法追上最新输出。
@@ -776,11 +777,16 @@ export function useTerminalSession(deps: {
           core._renderService.handleResize?.(cols, rows);
           core._renderService.refreshRows?.(0, rows - 1);
         }
+        const buf = term.buffer.active;
+        const targetLine = userPinnedRef.current ? Math.min(buf.viewportY, buf.baseY) : buf.baseY;
+        if (!userPinnedRef.current) {
+          term.scrollToBottom();
+        }
         if (core?._viewport) {
-          core._viewport.queueSync?.();
+          core._viewport.scrollToLine?.(targetLine, true);
+          core._viewport.queueSync?.(targetLine);
         }
       } catch (_) {}
-      term.scrollToBottom();
     } catch (e) {
       console.error('[Terminal] safeFit error:', e);
     }

--- a/frontend/src/components/terminal/useTerminalSession.ts
+++ b/frontend/src/components/terminal/useTerminalSession.ts
@@ -114,12 +114,15 @@ export function useTerminalSession(deps: {
     const MIN_ROWS = 2;
     const clampedCols = Math.max(MIN_COLS, cols);
     const clampedRows = Math.max(MIN_ROWS, rows);
-    if (lastSentPTYSizeRef.current.cols === clampedCols && lastSentPTYSizeRef.current.rows === clampedRows) {
-      return;
-    }
+    // 必须先取消挂起的 resize 再去重：快速拖动窗口回到 earlier size 时，
+    // 去重早退若不清定时器，过期的更大尺寸会在 80ms 后仍发给 PTY，
+    // 造成 shell 折行列数与终端实际列数长期错位
     if (ptyResizeTimerRef.current) {
       clearTimeout(ptyResizeTimerRef.current);
       ptyResizeTimerRef.current = null;
+    }
+    if (lastSentPTYSizeRef.current.cols === clampedCols && lastSentPTYSizeRef.current.rows === clampedRows) {
+      return;
     }
     const send = () => {
       lastSentPTYSizeRef.current = { cols: clampedCols, rows: clampedRows };
@@ -670,6 +673,11 @@ export function useTerminalSession(deps: {
       }
       if (linkUnderlineLayerRef.current) linkUnderlineLayerRef.current.innerHTML = '';
       clearTimeout(fitTimer);
+      // 取消挂起的防抖 PTY resize，避免拆卸后仍向会话发送过期尺寸
+      if (ptyResizeTimerRef.current) {
+        clearTimeout(ptyResizeTimerRef.current);
+        ptyResizeTimerRef.current = null;
+      }
       if (vpEl) vpEl.removeEventListener('scroll', onTermScroll);
       // 移除 wheel 监听器，避免内存泄漏
       containerRef.current?.removeEventListener('wheel', wheelHandler);

--- a/frontend/src/components/workspace/WorkspaceTerminalGrid.tsx
+++ b/frontend/src/components/workspace/WorkspaceTerminalGrid.tsx
@@ -29,6 +29,8 @@ export interface WorkspaceTerminalGridProps {
   t: (key: string, vars?: Record<string, unknown>) => string;
 }
 
+// 工作区终端网格：按会话保存的分屏布局把各终端渲染到对应网格单元（含分屏头与关闭按钮），
+// 无工作区布局时退化为绝对定位堆叠；非激活终端仅隐藏保活，恢复工作区期间显示遮罩。
 export default function WorkspaceTerminalGrid({
   session: s,
   activeSessionId,

--- a/frontend/src/components/workspace/WorkspaceTerminalGrid.tsx
+++ b/frontend/src/components/workspace/WorkspaceTerminalGrid.tsx
@@ -115,7 +115,7 @@ export default function WorkspaceTerminalGrid({
                   </Button>
                 </div>
               )}
-              <div style={{ flex: 1, minHeight: 0 }}>
+              <div className="flex-1 flex flex-col min-h-0 min-w-0 h-full overflow-hidden">
                 <ErrorBoundary label={t('终端 {id} 渲染出错', { id: term.id })}>
                   <Terminal
                     sessionId={term.id || ''}
@@ -138,7 +138,7 @@ export default function WorkspaceTerminalGrid({
       })() : (getEffectiveTerminals(s).map((term) => {
         const isTermActive = (contentTab === 'terminal' || s.status !== 'connected') && activeTerminalId === term.id;
         return (
-          <div key={term.id} className="absolute inset-0 flex flex-col" data-wallpaper-exempt="true" style={{
+          <div key={term.id} className="absolute inset-0 flex flex-col min-h-0 min-w-0 overflow-hidden" data-wallpaper-exempt="true" style={{
             visibility: isTermActive ? 'visible' : 'hidden',
             pointerEvents: isTermActive ? 'auto' : 'none',
             contain: isTermActive ? 'none' : 'strict',

--- a/frontend/src/hooks/usePanelLayout.ts
+++ b/frontend/src/hooks/usePanelLayout.ts
@@ -29,6 +29,9 @@ export interface UsePanelLayoutResult {
   setAIPanelVisibility: (value: unknown) => void;
 }
 
+// 面板布局 hook：集中管理文件管理器分栏、探测面板与 AI 面板的尺寸/位置/展开状态，
+// 全部持久化到 localStorage 并同步镜像 ref 供拖拽层直接读取；
+// AI 面板显隐变化经 ai-panel-visibility-changed 事件广播给终端等依赖方。
 export default function usePanelLayout(): UsePanelLayoutResult {
   const [leftSplitWidth, setLeftSplitWidth] = useState(() => Number.parseInt(localStorage.getItem('leftSplitWidth') || '320', 10));
   const [bottomSplitHeight, setBottomSplitHeight] = useState(() => Number.parseInt(localStorage.getItem('bottomSplitHeight') || '250', 10));

--- a/frontend/src/hooks/usePanelLayout.ts
+++ b/frontend/src/hooks/usePanelLayout.ts
@@ -82,6 +82,7 @@ export default function usePanelLayout(): UsePanelLayoutResult {
     const next = !!value;
     setShowAIPanel(next);
     localStorage.setItem('showAIPanel', String(next));
+    window.dispatchEvent(new CustomEvent('ai-panel-visibility-changed', { detail: next }));
   }, []);
 
   useEffect(() => {

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -42,17 +42,49 @@
     outline: none;
   }
 
-  /* ── 滚动条 ──────────────────────────────────────────────── */
-  ::-webkit-scrollbar { width: 8px; height: 8px; }
-  ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-full); }
-  ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
-
   button svg,
   [role='button'] svg,
   .codicon {
     opacity: var(--app-icon-opacity, 1);
   }
+}
+
+/* ── 全局滚动条样式（统一现代精致半透明胶囊风格） ── */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35));
+  border-radius: var(--radius-full);
+  transition: background 0.15s ease;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover, rgba(140, 165, 195, 0.6));
+}
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* ── 终端视口原生滚动条消除（避免空行显示空白滚动槽） ── */
+.xterm-viewport,
+.xterm .xterm-viewport {
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
+}
+.xterm-viewport::-webkit-scrollbar,
+.xterm .xterm-viewport::-webkit-scrollbar {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
 }
 
 /* ── 主布局 ─────────────────────────────────────────────────── */

--- a/frontend/src/styles/components/terminal.css
+++ b/frontend/src/styles/components/terminal.css
@@ -197,24 +197,26 @@
   overflow-x: auto;
   overflow-y: hidden;
   /* 底部留白：在按钮下方预留滚动条空间。不使用负 margin，防止滚动条被下方输入栏遮挡 */
-  padding-bottom: 6px;
+  padding-bottom: 5px;
   /* 右侧边界渐隐：滚动时药丸淡出，而不是被搜索框硬切 */
   mask-image: linear-gradient(to right, #000 calc(100% - 16px), transparent 100%);
   -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 16px), transparent 100%);
+  scrollbar-width: thin;
+  scrollbar-color: var(--term-scrollbar-thumb, rgba(140, 165, 195, 0.28)) transparent;
 }
 .term-quick-cmd-list::-webkit-scrollbar {
-  height: 8px;
-  background: transparent;
+  height: 4px;
 }
 .term-quick-cmd-list::-webkit-scrollbar-track {
   background: transparent;
 }
 .term-quick-cmd-list::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--term-scrollbar-thumb, rgba(140, 165, 195, 0.28));
   border-radius: var(--radius-full);
+  transition: background 0.15s ease;
 }
 .term-quick-cmd-list::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
+  background: var(--term-scrollbar-thumb-hover, rgba(160, 190, 225, 0.55));
 }
 .term-quick-cmd-empty {
   font-size: 11px;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -120,12 +120,15 @@ svg[class*="lucide"] {
   --surface-active:    #2c384c;  /* active/选中态 */
   --surface-canvas:    #0d1117;  /* 激活标签融入内容区的底色（须与外凹反弧 SVG 填充一致） */
 
-  /* ── 边框 ── */
+  /* ── 边框与滚动条 ── */
   --overlay-scrim: rgba(0, 0, 0, 0.42);
   --border:        rgba(72, 86, 110, 0.55);
   --border-light:  rgba(72, 86, 110, 0.28);
   --border-subtle: rgba(72, 86, 110, 0.32);
   --border-focus:  #4d9eff;
+  --scrollbar-thumb:       rgba(120, 140, 165, 0.35);
+  --scrollbar-thumb-hover: rgba(140, 165, 195, 0.6);
+  --scrollbar-track:       transparent;
 
   /* ── 文本层级（primary > secondary > tertiary > muted） ── */
   --text-primary:    #eef3f9;
@@ -332,6 +335,9 @@ body.theme-light {
   --border-light:  rgba(28, 35, 45, 0.08);
   --border-subtle: rgba(28, 35, 45, 0.10);
   --border-focus:  #2563eb;
+  --scrollbar-thumb:       rgba(100, 116, 139, 0.35);
+  --scrollbar-thumb-hover: rgba(71, 85, 105, 0.6);
+  --scrollbar-track:       transparent;
 
   --text-primary:    #111827;
   --text-secondary:  #334155;

--- a/frontend/src/styles/vendor/xterm.css
+++ b/frontend/src/styles/vendor/xterm.css
@@ -1,3 +1,5 @@
+@import "@xterm/xterm/css/xterm.css";
+
 /* ============================================================
    xterm.js Overrides & Terminal Variables
    ============================================================ */
@@ -26,6 +28,45 @@
   --term-context-bg: #131922;
   --term-context-border: 1px solid rgba(56,68,90,0.8);
   --term-context-shadow: 0 8px 32px rgba(0,5,20,0.6), 0 2px 8px rgba(0,5,20,0.4);
+  --term-scrollbar-thumb: rgba(140, 165, 195, 0.28);
+  --term-scrollbar-thumb-hover: rgba(160, 190, 225, 0.55);
+}
+
+/* ── 彻底消除 xterm-viewport 的原生浏览器滚动条，避免空视口常驻滚动条槽位 ── */
+.xterm .xterm-viewport,
+.xterm-viewport {
+  overflow-y: auto !important;
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
+}
+
+.xterm .xterm-viewport::-webkit-scrollbar,
+.xterm-viewport::-webkit-scrollbar {
+  width: 0 !important;
+  height: 0 !important;
+  display: none !important;
+  background: transparent !important;
+}
+
+/* ── xterm 5 自带平滑滚动条（仅在有溢出内容时由 xterm 控制显示） ── */
+.xterm .xterm-scrollable-element > .scrollbar.vertical {
+  width: 6px !important;
+  right: 2px !important;
+  background: transparent !important;
+  z-index: 12 !important;
+}
+
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 6px !important;
+  left: 0 !important;
+  border-radius: var(--radius-full) !important;
+  background: var(--term-scrollbar-thumb, rgba(140, 165, 195, 0.28)) !important;
+  transition: background 0.15s ease, opacity 0.2s ease !important;
+}
+
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider:hover,
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider.active {
+  background: var(--term-scrollbar-thumb-hover, rgba(160, 190, 225, 0.55)) !important;
 }
 
 .terminal-output-default-mouse-cursor,


### PR DESCRIPTION
## 📝 概述
本 PR 主要修复终端相关的多项 UI/UX 体验问题，包括多标签切换自适应、侧边栏/AI面板展开导致的视口跳变、缩放导致文字折行错位、假滚动条消除以及滚动条视觉美化。

---

## 🛠️ 主要修复内容

1. **终端视口自适应与多阶段重对齐（Multi-Stage Re-fit）**：
   - 解决多服务器标签切换、窗口最大化后终端出现假滚动条或尺寸未自适应的问题；
   - 在 \safeFit\ 中主动解除 xterm 5 \RenderService\ 的后台 pause 状态并 flush 任务队列，调用 \core._viewport.queueSync()\ 强制重新比对真实尺寸。

2. **侧边栏 / AI 面板展开时的视口底部锚定与平滑滚动修复**：
   - 修复当点击 AI 助手图标导致终端单帧突变收窄时，视口意外跳回历史顶行、最新输入行消失的问题；
   - 确立「底部锚定优先」原则：用户未手动向上翻阅时，视口始终严格锚定在 \uf.baseY\（最底部的 Shell 提示符与最新输出）；
   - 在 \safeFit\ 中加入 RAF 阶段二次确认与同步，彻底防止 xterm 内部异步 refresh 回调覆盖底部位置；
   - 确保 \_scrollableElement\ 滚动条与画面 100% 贴合，用户滚动鼠标滚轮时从底部平滑往上翻阅，消除内容跳变。

3. **键盘键入时自动重置底部锁定**：
   - 用户在终端键入任何字符或执行命令时，自动解除向上翻阅锁定并回归最新行，保证输入流体验。

4. **窗口缩放（宽 -> 极窄 -> 恢复）提示符错位修复**：
   - 开启 \eflowCursorLine: true\，窗口变宽时平滑展开折行的提示符；
   - 增加最小列数保护（\MIN_COLS = 20\、\MIN_ROWS = 2\），防止极端窄列宽粉碎 Shell 提示符；
   - 对向后端发送的 \AppGo.ResizeTerminal\（PTY \WindowChange\）加入 80ms 防抖与比对去重，避免拖拽时高频 \SIGWINCH\ 异步重绘冲突。

5. **现代滚动条样式美化**：
   - 全局定义 6px 精致半透明圆角胶囊滚动条（深浅主题自适应）；
   - 隐藏底层 \.xterm-viewport\ 的 Windows 原生空白槽位，并将 xterm 5 自带的平滑滚动条定制为统一的高颜值样式（仅在真正需要翻页时显示）。

---

## 🧪 验证
- [x] 多服务器标签切换并调整窗口/最大化，确认无多余假滚动条。
- [x] 快速拉窄窗口再拉宽，提示符无断裂、重复与错位。
- [x] 打开/收起 AI 助手面板，终端严格锚定在最下方最新输入行，滚轮上下滑动平滑无跳变。
- [x] \
pm run build\ 前端构建通过，0 错误。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 改善终端窗口自适应与尺寸调整，减少内容溢出、布局抖动和显示异常。
  * 优化终端滚动与底部定位，提升终端切换、窗口调整及 AI 面板变化后的稳定性。
  * 改进终端光标行显示与内容排版。

* **样式优化**
  * 统一终端及全局滚动条样式，支持明暗主题与跨浏览器显示。
  * 优化终端视口裁剪、布局空间利用和快捷命令列表的滚动体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->