### PR TITLE
fix(tray): 修复 Windows 托盘右键菜单多次点击或切换其它托盘后不再弹出的问题

### DIFF
--- a/internal/platformruntime/runtime_unix.go
+++ b/internal/platformruntime/runtime_unix.go
@@ -156,5 +156,8 @@ func RemoveTrayIconSync() {}
 // PrepareTrayMenu 是 Windows 专用前台解锁的 Unix 空实现。
 func PrepareTrayMenu() {}
 
+// AfterTrayMenu 是 Windows 专用托盘菜单状态清理的 Unix 空实现。
+func AfterTrayMenu() {}
+
 // AttachFramelessWindowFix 是 Windows 专用窗口边缘光标修复的 Unix 空实现。
 func AttachFramelessWindowFix() {}

--- a/internal/platformruntime/runtime_windows.go
+++ b/internal/platformruntime/runtime_windows.go
@@ -3,6 +3,7 @@
 package platformruntime
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -25,6 +26,7 @@ var (
 	procIsWindowVisible          = user32.NewProc("IsWindowVisible")
 	procShowWindow               = user32.NewProc("ShowWindow")
 	procShowWindowAsync          = user32.NewProc("ShowWindowAsync")
+	procPostMessage              = user32.NewProc("PostMessageW")
 	procSetForegroundWindow      = user32.NewProc("SetForegroundWindow")
 	procBringWindowToTop         = user32.NewProc("BringWindowToTop")
 	procSetFocus                 = user32.NewProc("SetFocus")
@@ -108,25 +110,63 @@ type trayNotifyIconData struct {
 	BalloonIcon     uintptr
 }
 
-// findSystrayHWND 找本进程 energye 托盘隐藏窗（class=SystrayClass）
-func findSystrayHWND(matchPID uint32) syscall.Handle {
-	var found syscall.Handle
-	callback := syscall.NewCallback(func(hwnd syscall.Handle, lParam uintptr) uintptr {
-		if windowClass(hwnd) != systrayClass {
+var (
+	cachedSystrayHWND     syscall.Handle
+	cachedSystrayHWNDLock sync.Mutex
+)
+
+// systraySearchCtx 携带 SystrayClass 窗口搜索状态，经 EnumWindows 的 lParam 传入回调。
+type systraySearchCtx struct {
+	matchPID uint32
+	found    syscall.Handle
+}
+
+// systrayEnumCallback 必须是包级唯一实例：syscall.NewCallback 在 Windows 上有
+// 进程级数量上限（约 2000），在函数体内每次调用都新建，长期运行会触发
+// "too many callbacks" panic。回调无闭包状态，搜索数据经 lParam 传递。
+var systrayEnumCallback = syscall.NewCallback(func(hwnd syscall.Handle, lParam uintptr) uintptr {
+	// uintptr 不能直接还原 unsafe.Pointer（go vet 禁止）；经 lParam 自身地址
+	// 间接转译。EnumWindows 同步执行，ctx 在调用方栈上存活，生命周期安全。
+	ctx := (*systraySearchCtx)(*(*unsafe.Pointer)(unsafe.Pointer(&lParam)))
+	if windowClass(hwnd) != systrayClass {
+		return 1
+	}
+	if ctx.matchPID != 0 {
+		var pid uint32
+		procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&pid)))
+		if pid != ctx.matchPID {
 			return 1
 		}
-		if matchPID != 0 {
+	}
+	ctx.found = hwnd
+	return 0
+})
+
+// findSystrayHWND 找本进程 energye 托盘隐藏窗（class=SystrayClass）
+func findSystrayHWND(matchPID uint32) syscall.Handle {
+	cachedSystrayHWNDLock.Lock()
+	defer cachedSystrayHWNDLock.Unlock()
+
+	// 优先检查缓存的句柄。句柄销毁后数值可能被系统复用（可能落到本进程的
+	// 其它窗口上），仅校验 PID 不够，必须 PID + 窗口类双重校验；
+	// 任一不符说明缓存已失效，清掉回退全量枚举。
+	if matchPID == 0 || matchPID == uint32(os.Getpid()) {
+		if cachedSystrayHWND != 0 {
 			var pid uint32
-			procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&pid)))
-			if pid != matchPID {
-				return 1
+			procGetWindowThreadProcessId.Call(uintptr(cachedSystrayHWND), uintptr(unsafe.Pointer(&pid)))
+			if pid == uint32(os.Getpid()) && windowClass(cachedSystrayHWND) == systrayClass {
+				return cachedSystrayHWND
 			}
+			cachedSystrayHWND = 0
 		}
-		found = hwnd
-		return 0
-	})
-	procEnumWindows.Call(callback, 0)
-	return found
+	}
+
+	ctx := systraySearchCtx{matchPID: matchPID}
+	procEnumWindows.Call(systrayEnumCallback, uintptr(unsafe.Pointer(&ctx)))
+	if (matchPID == 0 || matchPID == uint32(os.Getpid())) && ctx.found != 0 {
+		cachedSystrayHWND = ctx.found
+	}
+	return ctx.found
 }
 
 // removeTrayIconSync 退出前同步删托盘图标。
@@ -272,47 +312,63 @@ func activateHWND(hwnd syscall.Handle) {
 	}
 }
 
+// mainWindowSearchCtx 携带主窗候选搜索状态，经 EnumWindows 的 lParam 传入回调。
+type mainWindowSearchCtx struct {
+	matchPID uint32
+	seen     map[syscall.Handle]struct{}
+	found    []syscall.Handle
+}
+
+// mainWindowEnumCallback 与 systrayEnumCallback 同理必须是包级唯一实例：
+// 每次托盘左键/菜单唤起窗口都会走到这里（forceShowWindow 每次触发两次
+// ForceShowWindow），函数内每次新建 syscall.NewCallback 会在约千次唤起后
+// 耗尽进程级上限（约 2000）并 panic。
+var mainWindowEnumCallback = syscall.NewCallback(func(hwnd syscall.Handle, lParam uintptr) uintptr {
+	ctx := (*mainWindowSearchCtx)(*(*unsafe.Pointer)(unsafe.Pointer(&lParam)))
+	if !isTopLevelWindow(hwnd) {
+		return 1
+	}
+	class := windowClass(hwnd)
+	if class == systrayClass {
+		return 1
+	}
+	if ctx.matchPID != 0 {
+		var pid uint32
+		procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&pid)))
+		if pid != ctx.matchPID {
+			return 1
+		}
+	}
+	// 当前进程已按 Wails 窗口类识别，无需读取标题；GetWindowTextW
+	// 可能向卡死的目标窗口线程同步取值，反而阻塞托盘消息线程。
+	hit := false
+	if ctx.matchPID != 0 {
+		hit = class == wailsFormClass
+	} else {
+		// 跨进程二次启动：只认标题，避免误激活其他 Wails 应用。
+		hit = windowText(hwnd) == mainWindowTitle
+	}
+	if !hit {
+		return 1
+	}
+	if _, ok := ctx.seen[hwnd]; ok {
+		return 1
+	}
+	ctx.seen[hwnd] = struct{}{}
+	ctx.found = append(ctx.found, hwnd)
+	return 1
+})
+
 // findMainWindowCandidates 枚举本进程/跨进程可能的 Lumin 主窗。
 // 久置+多次点击时任务栏可能出现多个条目，唤醒时优先可见/未最小化的 winc_Form。
 func findMainWindowCandidates(matchPID uint32) []syscall.Handle {
-	found := make([]syscall.Handle, 0, 4)
-	seen := map[syscall.Handle]struct{}{}
-	callback := syscall.NewCallback(func(hwnd syscall.Handle, lParam uintptr) uintptr {
-		if !isTopLevelWindow(hwnd) {
-			return 1
-		}
-		class := windowClass(hwnd)
-		if class == systrayClass {
-			return 1
-		}
-		if matchPID != 0 {
-			var pid uint32
-			procGetWindowThreadProcessId.Call(uintptr(hwnd), uintptr(unsafe.Pointer(&pid)))
-			if pid != matchPID {
-				return 1
-			}
-		}
-		// 当前进程已按 Wails 窗口类识别，无需读取标题；GetWindowTextW
-		// 可能向卡死的目标窗口线程同步取值，反而阻塞托盘消息线程。
-		hit := false
-		if matchPID != 0 {
-			hit = class == wailsFormClass
-		} else {
-			// 跨进程二次启动：只认标题，避免误激活其他 Wails 应用。
-			hit = windowText(hwnd) == mainWindowTitle
-		}
-		if !hit {
-			return 1
-		}
-		if _, ok := seen[hwnd]; ok {
-			return 1
-		}
-		seen[hwnd] = struct{}{}
-		found = append(found, hwnd)
-		return 1
-	})
-	procEnumWindows.Call(callback, 0)
-	return found
+	ctx := mainWindowSearchCtx{
+		matchPID: matchPID,
+		seen:     map[syscall.Handle]struct{}{},
+		found:    make([]syscall.Handle, 0, 4),
+	}
+	procEnumWindows.Call(mainWindowEnumCallback, uintptr(unsafe.Pointer(&ctx)))
+	return ctx.found
 }
 
 type windowCandidate struct {
@@ -369,7 +425,7 @@ func findAndShowWindow() {
 	}
 }
 
-// platformPrepareTrayMenu 托盘右键菜单弹出前调用。
+// PrepareTrayMenu 托盘右键菜单弹出前调用。
 // energye ShowMenu 内部会对托盘隐藏窗 SetForegroundWindow 再 TrackPopupMenu；
 // 久置后前台被拒时菜单直接不显示。这里先解锁前台并激活托盘窗。
 func PrepareTrayMenu() {
@@ -378,10 +434,24 @@ func PrepareTrayMenu() {
 	pid, _, _ := procGetCurrentProcessId.Call()
 	hwnd := findSystrayHWND(uint32(pid))
 	if hwnd == 0 {
+		log.Printf("[Systray] PrepareTrayMenu: SystrayClass HWND not found for PID %d", pid)
 		return
 	}
-	procSetForegroundWindow.Call(uintptr(hwnd))
-	procBringWindowToTop.Call(uintptr(hwnd))
+	fgRes, _, fgErr := procSetForegroundWindow.Call(uintptr(hwnd))
+	topRes, _, topErr := procBringWindowToTop.Call(uintptr(hwnd))
+	log.Printf("[Systray] PrepareTrayMenu: hwnd=0x%x, SetForegroundWindow=%v (err=%v), BringWindowToTop=%v (err=%v)",
+		hwnd, fgRes != 0, fgErr, topRes != 0, topErr)
+}
+
+// AfterTrayMenu 托盘右键菜单关闭后调用（发送 WM_NULL 确保 Windows Shell 清理菜单状态）。
+func AfterTrayMenu() {
+	pid, _, _ := procGetCurrentProcessId.Call()
+	hwnd := findSystrayHWND(uint32(pid))
+	if hwnd != 0 {
+		const wmNull = 0x0000
+		procPostMessage.Call(uintptr(hwnd), uintptr(wmNull), 0, 0)
+		log.Printf("[Systray] AfterTrayMenu: posted WM_NULL to hwnd 0x%x", hwnd)
+	}
 }
 
 // platformForceShowWindow 托盘/任务栏久置后唤醒：激活本进程主窗，并尽量恢复其它最小化副本。

--- a/internal/platformruntime/systray_other.go
+++ b/internal/platformruntime/systray_other.go
@@ -2,19 +2,33 @@
 
 package platformruntime
 
-import "github.com/energye/systray"
+import (
+	"log"
+	"runtime"
+
+	"github.com/energye/systray"
+)
 
 // PrepareSystray returns a cleanup function. The standalone systray event loop
 // is started later by StartSystray.
 func PrepareSystray(setup func()) func() {
 	return func() {
+		log.Println("[Systray] systray.Quit called from PrepareSystray cleanup")
 		systray.Quit()
 	}
 }
 
 // StartSystray runs the standalone systray event loop in a goroutine.
 func StartSystray(setup func()) {
-	go systray.Run(func() {
-		setup()
-	}, func() {})
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		log.Println("[Systray] Starting systray event loop on dedicated locked OS thread")
+		systray.Run(func() {
+			log.Println("[Systray] systray onReady triggered, invoking setup")
+			setup()
+		}, func() {
+			log.Println("[Systray] systray onExit triggered")
+		})
+	}()
 }

--- a/internal/wailsapp/run.go
+++ b/internal/wailsapp/run.go
@@ -60,6 +60,7 @@ var systrayOnce sync.Once
 
 func setupSystray(app *App) {
 	systrayOnce.Do(func() {
+		log.Println("[Systray] setupSystray initializing...")
 		systray.SetIcon(app.icon)
 		systray.SetTitle("Lumin")
 		systray.SetTooltip("Lumin SSH")
@@ -68,6 +69,7 @@ func setupSystray(app *App) {
 		mQuit := systray.AddMenuItem("完全退出", "Quit Lumin")
 
 		showMain := func() {
+			log.Println("[Systray] showMain invoked, awakening main window")
 			forceShowWindow(app.ctx)
 		}
 
@@ -77,26 +79,39 @@ func setupSystray(app *App) {
 			// 不调 SetOnClick/SetOnRClick：enableOnClick 会覆盖菜单行为，
 			// 且库注释明确 ShowMenu() 在 macOS 只支持 OnRClick 回调内调用。
 			systray.CreateMenu()
+			log.Println("[Systray] macOS CreateMenu configured")
 		} else {
 			// Windows/Linux: 左键直接显示窗口
 			systray.SetOnClick(func(menu systray.IMenu) {
+				log.Println("[Systray] Left click received, showing main window")
 				showMain()
 			})
 			// 右键弹菜单；Windows 久置后 TrackPopupMenu 常因前台锁不弹出，
 			// 先解锁再 ShowMenu。
 			systray.SetOnRClick(func(menu systray.IMenu) {
+				log.Println("[Systray] Right click received, preparing tray menu")
 				platformruntime.PrepareTrayMenu()
-				menu.ShowMenu()
+				if err := menu.ShowMenu(); err != nil {
+					log.Printf("[Systray] ShowMenu returned: %v", err)
+				} else {
+					log.Println("[Systray] ShowMenu completed successfully")
+				}
+				platformruntime.AfterTrayMenu()
 			})
+			log.Println("[Systray] Windows/Linux SetOnClick and SetOnRClick configured")
 		}
 
 		mShow.Click(func() {
+			log.Println("[Systray] Menu item 'Show Main Window' clicked")
 			showMain()
 		})
 
 		mQuit.Click(func() {
+			log.Println("[Systray] Menu item 'Quit Lumin' clicked")
 			app.DoQuit()
 		})
+
+		log.Println("[Systray] setupSystray completed successfully")
 	})
 }
 


### PR DESCRIPTION
## 问题现象

Windows 下右键托盘图标:

1. 第一次右键能正常弹出菜单,但继续多次右键后菜单不再出现;
2. 右键本程序托盘图标后,再去右键其它软件的托盘图标,再回来右键本程序托盘图标,菜单不显示;来回多点几次即可稳定复现。

## 根因分析

核对 energye/systray v1.0.3 源码(`systray_windows.go` 的 `ShowMenu`)确认:其实现为 `SetForegroundWindow` → `TrackPopupMenu`,**菜单关闭后没有补发 `WM_NULL`**。

这是 Win32 托盘编程的经典问题(MSDN Shell_NotifyIcon 备注 / KB135788 的标准写法):`TrackPopupMenu` 返回后必须向窗口 `PostMessage(WM_NULL)`,否则窗口的菜单模式状态残留,后续 `TrackPopupMenu` 调用失败、菜单不再显示——与上面两个复现路径完全吻合。上游 getlantern/systray(energye 是其 fork)原本有这个处理,energye 重构 `ShowMenu() error` 时丢失了。

## 修复内容

- **新增 `AfterTrayMenu()`**:右键菜单关闭后向托盘隐藏窗 `PostMessage(WM_NULL)`,恢复规范写法;时序与官方示例等价(均在 `wndProc` 派发线程内同步执行)。
- **`StartSystray` 增加 `runtime.LockOSThread`**:托盘窗口创建(`registerSystray`)与消息泵(`nativeLoop`)在同一 goroutine,加锁后永久绑定同一 OS 线程,消除 goroutine 被调度器迁移线程后 `GetMessage` 取不到窗口消息、托盘整体失灵的隐患(库自身 `init()` 里的 LockOSThread 只锁 main goroutine,管不到这里新起的 goroutine)。
- **`syscall.NewCallback` 耗尽隐患修复**:`findSystrayHWND` / `findMainWindowCandidates` 的 EnumWindows 回调提为包级变量。Windows 上回调有进程级约 2000 的硬上限,超限直接 panic;此前每次托盘唤起窗口会新建 2 个回调,约千次唤起后必然崩溃。
- **句柄缓存加固**:`findSystrayHWND` 的缓存 fast-path 由仅校验 PID 改为 PID + 窗口类双重校验,句柄销毁被复用后不再命中脏缓存。

## 关于日志量的说明

本次在全链路补充了 `[Systray]` 诊断日志(每次右键约 5 条),**日志量偏大是有意为之**,便于本版本在实际环境观察验证修复效果。已有 5MB 日志轮转兜底。**若本版本运行稳定无问题,下个版本将降低日志量或移除纯成功路径的日志**,保留错误路径日志。

## 平台影响

- **Linux**:库的 `SetOnRClick` 在 Linux 上是空实现,右键回调不会触发,菜单由桌面环境的 DBus/StatusNotifier 原生弹出,`PrepareTrayMenu`/`AfterTrayMenu`/`ShowMenu` 运行时不会执行,行为无变化;`LockOSThread` 对 DBus 事件循环无副作用。
- **macOS**:`StartSystray` 本就是 no-op(托盘走 `RunWithExternalLoop` 挂在 Wails 主线程),本次未触碰 macOS 相关代码;macOS 分支使用 `CreateMenu` 常驻菜单,不经过本次修改的路径。

## 验证

- 手动复现原始 bug 场景:多次连续右键、与其它软件托盘图标交替右键,菜单均能稳定弹出;
- `go vet` 干净;`go build ./...` 通过;`go test ./internal/platformruntime/ ./internal/wailsapp/ -count=1` 全部通过;`GOOS=linux` 交叉编译通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化系统托盘菜单的显示与关闭处理，提升菜单交互的稳定性。
  - 增强托盘窗口与主窗口的识别及激活表现。
  - 统一 Unix、Windows 平台的托盘菜单处理行为。
- **问题修复**
  - 修复部分情况下托盘菜单关闭后窗口状态未及时恢复的问题。
  - 改善托盘启动、初始化及右键菜单显示过程中的异常处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->