### PR TITLE
feat(theme): 主题切换增加 View Transition 圆形过渡动画（浅色扩散 / 深色收缩）

### DIFF
--- a/frontend/src/components/settings/appearance/useThemePackages.ts
+++ b/frontend/src/components/settings/appearance/useThemePackages.ts
@@ -10,6 +10,7 @@ import {
   type ThemePackage,
 } from '../../../utils/theme.ts';
 import { settingsConfirm } from '../settingsDialogs.ts';
+import { runThemeChangeWithTransitionAsync, themeTransitionDirectionFor } from '../../../utils/themeTransition.ts';
 
 type AddToast = (message: string | Error, type?: string, duration?: number, actions?: unknown[]) => number;
 
@@ -40,10 +41,12 @@ export function useThemePackages({ addToast, forceDarkTheme, handleClose }: UseT
     }
     setThemePackageBusy(true);
     try {
-      const nextSettings = await saveThemePackageSettings({
-        ...themePackageSettings,
-        themeMode: mode,
-      });
+      // 浅/深/系统模式切换包一层 View Transition：切浅色扩散、切深色收缩（不支持的内核直接切换）
+      const nextSettings = await runThemeChangeWithTransitionAsync(() =>
+        saveThemePackageSettings({
+          ...themePackageSettings,
+          themeMode: mode,
+        }), null, themeTransitionDirectionFor(mode));
       setThemePackageSettings(nextSettings);
       setThemePackages(listThemePackages());
       setThemeMode(nextSettings.themeMode || 'dark');

--- a/frontend/src/hooks/useAppGlobalEvents.ts
+++ b/frontend/src/hooks/useAppGlobalEvents.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { flushSync } from 'react-dom';
 import { EventsOn } from '../../wailsjs/runtime/runtime.js';
 import { getAIGlobalSettings } from '../components/ai/aiGlobalSettingsBridge.ts';
+import { runThemeChangeWithTransition, themeTransitionDirectionFor } from '../utils/themeTransition.ts';
 import { formatAIQuotedSelection, type SessionLike, type WorkspaceContentTab } from '../utils/sessionWorkspace.ts';
 import type { TerminalPaneLayout } from '../utils/terminalPaneLayout.ts';
 
@@ -151,11 +153,16 @@ export default function useAppGlobalEvents({
       return;
     }
     const nextMode = resolvedQuickThemeMode === 'light' ? 'dark' : 'light';
-    localStorage.setItem('themeMode', nextMode);
-    setQuickThemeMode(nextMode);
-    if (nextMode === 'light') document.body.classList.add('theme-light');
-    else document.body.classList.remove('theme-light');
-    window.dispatchEvent(new CustomEvent('theme-mode-changed'));
+    // 包一层 View Transition：切浅色=白圈从点击处扩散，切深色=旧画面收缩进点击点（不支持的内核直接切换）
+    runThemeChangeWithTransition(() => {
+      flushSync(() => {
+        localStorage.setItem('themeMode', nextMode);
+        setQuickThemeMode(nextMode);
+        if (nextMode === 'light') document.body.classList.add('theme-light');
+        else document.body.classList.remove('theme-light');
+        window.dispatchEvent(new CustomEvent('theme-mode-changed'));
+      });
+    }, null, themeTransitionDirectionFor(nextMode));
   }, [activeAIDevilMode, resolvedQuickThemeMode]);
 
   useEffect(() => {

--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1009,3 +1009,16 @@ body.theme-light .editor-mode-banner {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
 }
+
+/* ── 主题切换 View Transition（圆形扩散揭示，见 utils/themeTransition.ts） ── */
+/* 关闭默认交叉淡入，改由 JS 在 ::view-transition-new(root) 上跑 clip-path circle 动画 */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+/* 收缩方向（切到深色）：旧快照须盖在新快照之上，才能被 clip-path 收缩露出四周的深色 */
+html.theme-transition-contract::view-transition-old(root) {
+  z-index: 1;
+}

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -1,0 +1,193 @@
+/**
+ * 主题切换过渡动画（View Transitions API）
+ *
+ * 效果与 Art Design Pro 等一致，并按目标模式区分方向：
+ * - 切到浅色（扩散 expand）：新浅色画面从点击处从小到大圆形扩散盖住全局；
+ * - 切到深色（收缩 contract）：旧浅色画面收缩成圆形陷落到点击处，深色从四周合拢。
+ *
+ * 实现方式：document.startViewTransition 截取旧/新两帧快照。
+ * 扩散在 ::view-transition-new(root) 上用 clip-path: circle() 从 0 动画到全屏半径；
+ * 收缩需旧快照置顶（html.theme-transition-contract 提升其 z-index），clip-path 反向收缩。
+ * 不支持的内核（Linux WebKitGTK 等）或用户开启"减少动态效果"时直接切换，无动画。
+ */
+
+interface ThemeTransitionPoint {
+  x: number;
+  y: number;
+}
+
+/** 扩散：新快照从小到大揭示；收缩：旧快照从全屏收缩到点击点 */
+export type ThemeTransitionDirection = 'expand' | 'contract';
+
+type ViewTransitionLike = {
+  ready: Promise<void>;
+  finished: Promise<void>;
+  updateCallbackDone: Promise<void>;
+};
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (callback: () => void | Promise<void>) => ViewTransitionLike;
+};
+
+/** 收缩方向期间挂在 <html> 上的标记类，配合 CSS 把旧快照提到新快照之上 */
+const CONTRACT_CLASS = 'theme-transition-contract';
+
+const TRANSITION_DURATION_MS = 500;
+
+/** 全局记录最后一次指针按下位置，作为圆形扩散的圆心（键盘触发时用最近一次点击位置） */
+let lastPointerPoint: ThemeTransitionPoint | null = null;
+let pointerTrackingBound = false;
+
+const DEFAULT_TRANSITION_POINT: ThemeTransitionPoint = { x: -1, y: -1 };
+
+function bindPointerTracking(): void {
+  if (pointerTrackingBound || typeof window === 'undefined') return;
+  pointerTrackingBound = true;
+  // capture + passive：只读坐标，不影响任何交互
+  window.addEventListener('pointerdown', (event) => {
+    if (typeof event.clientX !== 'number' || typeof event.clientY !== 'number') return;
+    lastPointerPoint = { x: event.clientX, y: event.clientY };
+  }, { capture: true, passive: true });
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function getViewTransitionDocument(): ViewTransitionDocument | null {
+  if (typeof document === 'undefined') return null;
+  const doc = document as ViewTransitionDocument;
+  return typeof doc.startViewTransition === 'function' ? doc : null;
+}
+
+export function isThemeTransitionSupported(): boolean {
+  return getViewTransitionDocument() !== null && !prefersReducedMotion();
+}
+
+/** 按目标模式推导方向：切到浅色扩散、切到深色收缩（system 按当前系统偏好解析） */
+export function themeTransitionDirectionFor(nextMode: string): ThemeTransitionDirection {
+  let resolved = String(nextMode || '');
+  if (resolved === 'system' && typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    resolved = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+  }
+  return resolved === 'light' ? 'expand' : 'contract';
+}
+
+function resolveTransitionPoint(origin?: ThemeTransitionPoint | null): ThemeTransitionPoint {
+  if (origin && Number.isFinite(origin.x) && Number.isFinite(origin.y)) return origin;
+  if (lastPointerPoint) return lastPointerPoint;
+  // 无任何指针记录（如快捷键首次触发）：退化为顶栏主题按钮的大致位置
+  if (DEFAULT_TRANSITION_POINT.x < 0 && typeof window !== 'undefined') {
+    DEFAULT_TRANSITION_POINT.x = Math.max(window.innerWidth - 48, 0);
+    DEFAULT_TRANSITION_POINT.y = 40;
+  }
+  return DEFAULT_TRANSITION_POINT;
+}
+
+/** 圆心到屏幕最远角的距离，即覆盖全屏所需的圆半径 */
+function computeRevealEndRadius(point: ThemeTransitionPoint): number {
+  const farthestX = Math.max(point.x, window.innerWidth - point.x);
+  const farthestY = Math.max(point.y, window.innerHeight - point.y);
+  return Math.hypot(farthestX, farthestY);
+}
+
+function playRevealAnimation(transition: ViewTransitionLike, point: ThemeTransitionPoint, direction: ThemeTransitionDirection): void {
+  transition.ready.then(() => {
+    const endRadius = computeRevealEndRadius(point);
+    const circleAt = `at ${point.x}px ${point.y}px`;
+    const isContract = direction === 'contract';
+    const animation = document.documentElement.animate(
+      {
+        clipPath: isContract
+          // 旧画面从全屏圆收缩到点击点，四周露出新（深色）画面
+          ? [`circle(${endRadius}px ${circleAt})`, `circle(0px ${circleAt})`]
+          // 新画面从点击点扩散到全屏
+          : [`circle(0px ${circleAt})`, `circle(${endRadius}px ${circleAt})`],
+      },
+      {
+        duration: TRANSITION_DURATION_MS,
+        easing: 'ease-in-out',
+        pseudoElement: isContract ? '::view-transition-old(root)' : '::view-transition-new(root)',
+        // 动画结束时保持末帧：否则裁剪立即失效，置顶的旧浅色快照会整屏弹回一帧（白闪）
+        fill: 'forwards',
+      },
+    );
+    // fill: forwards 的残留 effect 会在伪元素拆除后附着到下一次过渡的同名伪元素上，过渡结束时显式取消
+    transition.finished.then(() => animation.cancel(), () => animation.cancel());
+  }).catch(() => {});
+}
+
+/** 收缩方向需要旧快照置顶，动画结束后摘掉标记类 */
+function bindContractClass(transition: ViewTransitionLike, direction: ThemeTransitionDirection): void {
+  if (direction !== 'contract' || typeof document === 'undefined') return;
+  document.documentElement.classList.add(CONTRACT_CLASS);
+  transition.finished.then(
+    () => document.documentElement.classList.remove(CONTRACT_CLASS),
+    () => document.documentElement.classList.remove(CONTRACT_CLASS),
+  );
+}
+
+/**
+ * 同步主题变更的动画包装：applyChange 内完成所有 DOM 变更
+ * （body class / CSS 变量 / React 状态需配合 flushSync）
+ */
+export function runThemeChangeWithTransition(
+  applyChange: () => void,
+  origin?: ThemeTransitionPoint | null,
+  direction: ThemeTransitionDirection = 'expand',
+): void {
+  const doc = getViewTransitionDocument();
+  if (!doc || prefersReducedMotion()) {
+    applyChange();
+    return;
+  }
+  bindPointerTracking();
+  const point = resolveTransitionPoint(origin);
+  try {
+    const transition = doc.startViewTransition!(applyChange);
+    bindContractClass(transition, direction);
+    playRevealAnimation(transition, point, direction);
+  } catch (_) {
+    applyChange();
+  }
+}
+
+/**
+ * 异步主题变更的动画包装（applyChange 返回 Promise，如设置页保存后端）。
+ * 动画快照会等 Promise 完成后落定；结果与异常原样透传给调用方。
+ */
+export async function runThemeChangeWithTransitionAsync<T>(
+  applyChange: () => Promise<T>,
+  origin?: ThemeTransitionPoint | null,
+  direction: ThemeTransitionDirection = 'expand',
+): Promise<T> {
+  const doc = getViewTransitionDocument();
+  if (!doc || prefersReducedMotion()) {
+    return applyChange();
+  }
+  bindPointerTracking();
+  const point = resolveTransitionPoint(origin);
+  const outcome: { result?: T; failure?: { error: unknown } } = {};
+  try {
+    const transition = doc.startViewTransition!(async () => {
+      try {
+        outcome.result = await applyChange();
+      } catch (error) {
+        outcome.failure = { error };
+      }
+    });
+    bindContractClass(transition, direction);
+    playRevealAnimation(transition, point, direction);
+    await transition.updateCallbackDone.catch(() => {});
+    await transition.finished.catch(() => {});
+  } catch (_) {
+    return applyChange();
+  }
+  if (outcome.failure) {
+    throw outcome.failure.error;
+  }
+  return outcome.result as T;
+}
+
+bindPointerTracking();


### PR DESCRIPTION
## 功能说明

为浅色/深色主题切换增加圆形过渡动画（View Transitions API），方向随目标模式区分：

- **切到浅色（扩散）**：白色圆从点击位置从小到大扩散，铺满全局
- **切到深色（收缩）**：旧画面从大到小收缩、陷落回点击的主题图标，深色从四周合拢

圆心自动取最后一次指针按下位置，键盘触发时退化为最近一次点击位置。顶栏主题按钮与设置页外观模式切换（浅色/深色/系统）两条路径均已接入。

## 实现要点

- 新增 `frontend/src/utils/themeTransition.ts`：用 `document.startViewTransition` 截取新旧两帧快照，在伪元素上以 `clip-path: circle()` 实现扩散/收缩
- 收缩方向通过 `html.theme-transition-contract::view-transition-old(root) { z-index: 1 }` 将旧快照置顶后收缩，深色从四周合拢
- `fill: 'forwards'` 保持收缩动画末帧，修复动画结尾旧快照弹回导致的整屏白闪；过渡结束时显式 `cancel()`，避免 fill 残留效果附着到下一次过渡的同名伪元素
- 不支持 View Transitions 的内核（如 Linux WebKitGTK）或系统开启"减少动态效果"时直接切换，行为与现状完全一致

## 测试

- `tsc --noEmit`、`oxlint`、`vite build` 全部通过
- headless Chrome 实测：双向切换动画帧、主题状态（body class / localStorage / CSS 变量）均正确，无控制台报错；已基于最新 upstream/main 变基（仅 1 处 import 行冲突，已解决）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增主题切换动画：浅色模式以扩散效果显示，深色模式以收缩效果显示。
  * 动画起点根据指针位置确定，并支持系统主题模式。
  * 支持减少动态效果设置，兼容不支持相关功能的浏览器。

* **体验优化**
  * 快速切换主题时，界面状态、样式和设置可保持同步更新。
  * 主题切换异常处理流程保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->