### PR TITLE
fix(window): 修复边缘无法拖动缩放（滚动条/折叠条遮挡）并优化缩放指针一致性

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import AppTopbar from './components/AppTopbar.tsx';
 import AppOverlays from './components/AppOverlays.tsx';
 import AppMCPFloatingOverlay from './components/app/AppMCPFloatingOverlay.tsx';
 import AppWorkspaceView from './components/app/AppWorkspaceView.tsx';
+import WindowResizeBorders from './components/app/WindowResizeBorders.tsx';
 import useAppOrchestrator from './hooks/useAppOrchestrator.ts';
 
 export default function App() {
@@ -16,6 +17,7 @@ export default function App() {
       <AppWorkspaceView orchestrator={orchestrator} />
       <AppOverlays {...orchestrator.overlaysProps} />
       <AppMCPFloatingOverlay {...orchestrator.mcpProps} />
+      <WindowResizeBorders />
     </div>
   );
 }

--- a/frontend/src/components/ai/chat/AIChatConversation.tsx
+++ b/frontend/src/components/ai/chat/AIChatConversation.tsx
@@ -205,7 +205,9 @@ export default function AIChatConversation({
             element.style.direction = isLeftSide ? 'rtl' : 'ltr';
           }
         }}
-        style={{ height: '100%', overflowX: 'hidden' }}
+        // 滚动条内缩 8px（rtl 时在左、ltr 时在右，均为窗口边缘侧），与窗口缩放抓握带完全错开：
+        // 抓握带 [0,8) 可缩放，滚动条 [8,14) 可拖拽，互不抢占
+        style={{ height: '100%', overflowX: 'hidden', marginInlineEnd: 8 }}
         data={groupedMessages}
         alignToBottom={false}
         increaseViewportBy={{ top: 1200, bottom: 800 }}

--- a/frontend/src/components/app/WindowResizeBorders.tsx
+++ b/frontend/src/components/app/WindowResizeBorders.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import { WindowIsMaximised } from '../../../wailsjs/runtime/runtime.js';
+
+/**
+ * WindowResizeBorders
+ * 在非最大化窗口边缘与四角提供顶层无边框调整热区，
+ * 解决原生滚动条（AI 面板 / 监控面板 / 文件管理器）以及边缘折叠条遮挡/阻断窗口拖动缩放的问题。
+ */
+export default function WindowResizeBorders() {
+  const [isMax, setIsMax] = useState(false);
+
+  useEffect(() => {
+    let unmounted = false;
+    const syncState = async () => {
+      try {
+        const max = await WindowIsMaximised();
+        if (!unmounted) setIsMax(max);
+      } catch {}
+    };
+
+    syncState();
+    window.addEventListener('resize', syncState);
+    const interval = window.setInterval(syncState, 400);
+
+    return () => {
+      unmounted = true;
+      window.removeEventListener('resize', syncState);
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  if (isMax) return null;
+
+  const startResize = (e: React.MouseEvent, edge: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const w = window as unknown as {
+      wails?: { flags?: { resizeEdge?: string } };
+      WailsInvoke?: (cmd: string) => void;
+    };
+    if (w.wails?.flags) {
+      w.wails.flags.resizeEdge = edge;
+    }
+    if (w.WailsInvoke) {
+      w.WailsInvoke('resize:' + edge);
+    }
+  };
+
+  const handleMouseEnter = (edge: string) => {
+    const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
+    if (wailsFlags) {
+      wailsFlags.resizeEdge = edge;
+    }
+  };
+
+  const handleMouseLeave = () => {
+    const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
+    if (wailsFlags?.resizeEdge) {
+      delete wailsFlags.resizeEdge;
+    }
+  };
+
+  const borderThickness = 5;
+  const cornerSize = 10;
+
+  return (
+    <>
+      {/* 边缘缩放热区 */}
+      <div
+        className="window-resize-border window-resize-border-right"
+        style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: `${borderThickness}px`,
+          zIndex: 99999,
+          cursor: 'e-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'e-resize')}
+        onMouseEnter={() => handleMouseEnter('e-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-border window-resize-border-left"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: `${borderThickness}px`,
+          zIndex: 99999,
+          cursor: 'w-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'w-resize')}
+        onMouseEnter={() => handleMouseEnter('w-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-border window-resize-border-bottom"
+        style={{
+          position: 'fixed',
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: `${borderThickness}px`,
+          zIndex: 99999,
+          cursor: 's-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 's-resize')}
+        onMouseEnter={() => handleMouseEnter('s-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-border window-resize-border-top"
+        style={{
+          position: 'fixed',
+          left: 0,
+          right: 0,
+          top: 0,
+          height: `${borderThickness}px`,
+          zIndex: 99999,
+          cursor: 'n-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'n-resize')}
+        onMouseEnter={() => handleMouseEnter('n-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+
+      {/* 四角缩放热区 */}
+      <div
+        className="window-resize-corner window-resize-corner-tl"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: `${cornerSize}px`,
+          height: `${cornerSize}px`,
+          zIndex: 100000,
+          cursor: 'nw-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'nw-resize')}
+        onMouseEnter={() => handleMouseEnter('nw-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-corner window-resize-corner-tr"
+        style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          width: `${cornerSize}px`,
+          height: `${cornerSize}px`,
+          zIndex: 100000,
+          cursor: 'ne-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'ne-resize')}
+        onMouseEnter={() => handleMouseEnter('ne-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-corner window-resize-corner-bl"
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          width: `${cornerSize}px`,
+          height: `${cornerSize}px`,
+          zIndex: 100000,
+          cursor: 'sw-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'sw-resize')}
+        onMouseEnter={() => handleMouseEnter('sw-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+      <div
+        className="window-resize-corner window-resize-corner-br"
+        style={{
+          position: 'fixed',
+          bottom: 0,
+          right: 0,
+          width: `${cornerSize}px`,
+          height: `${cornerSize}px`,
+          zIndex: 100000,
+          cursor: 'se-resize',
+          pointerEvents: 'auto',
+        }}
+        onMouseDown={(e) => startResize(e, 'se-resize')}
+        onMouseEnter={() => handleMouseEnter('se-resize')}
+        onMouseLeave={handleMouseLeave}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/app/WindowResizeBorders.tsx
+++ b/frontend/src/components/app/WindowResizeBorders.tsx
@@ -1,36 +1,74 @@
-import { useEffect, useState } from 'react';
-import { WindowIsMaximised } from '../../../wailsjs/runtime/runtime.js';
+import type React from 'react';
+import useIsWindowMaximized from '../../hooks/useIsWindowMaximized.ts';
+import { Z } from '../../constants/zIndex.ts';
 
 /**
  * WindowResizeBorders
  * 在非最大化窗口边缘与四角提供顶层无边框调整热区，
  * 解决原生滚动条（AI 面板 / 监控面板 / 文件管理器）以及边缘折叠条遮挡/阻断窗口拖动缩放的问题。
+ * 指针悬停原生滚动条时热区会整体让位（让位逻辑见 useWindowState）。
  */
+
+const EDGE_THICKNESS = 5;
+const CORNER_SIZE = 8;
+
+interface ResizeZone {
+  edge: string;
+  cursor: string;
+  className: string;
+  zIndex: number;
+  style: React.CSSProperties;
+}
+
+const RESIZE_ZONES: ResizeZone[] = [
+  {
+    edge: 'e-resize', cursor: 'e-resize', zIndex: Z.WINDOW_RESIZE_BORDER,
+    className: 'window-resize-border window-resize-border-right',
+    style: { top: 0, right: 0, bottom: 0, width: EDGE_THICKNESS },
+  },
+  {
+    edge: 'w-resize', cursor: 'w-resize', zIndex: Z.WINDOW_RESIZE_BORDER,
+    className: 'window-resize-border window-resize-border-left',
+    style: { top: 0, left: 0, bottom: 0, width: EDGE_THICKNESS },
+  },
+  {
+    edge: 's-resize', cursor: 's-resize', zIndex: Z.WINDOW_RESIZE_BORDER,
+    className: 'window-resize-border window-resize-border-bottom',
+    style: { left: 0, right: 0, bottom: 0, height: EDGE_THICKNESS },
+  },
+  {
+    edge: 'n-resize', cursor: 'n-resize', zIndex: Z.WINDOW_RESIZE_BORDER,
+    className: 'window-resize-border window-resize-border-top',
+    style: { left: 0, right: 0, top: 0, height: EDGE_THICKNESS },
+  },
+  {
+    edge: 'nw-resize', cursor: 'nw-resize', zIndex: Z.WINDOW_RESIZE_CORNER,
+    className: 'window-resize-corner window-resize-corner-tl',
+    style: { top: 0, left: 0, width: CORNER_SIZE, height: CORNER_SIZE },
+  },
+  {
+    edge: 'ne-resize', cursor: 'ne-resize', zIndex: Z.WINDOW_RESIZE_CORNER,
+    className: 'window-resize-corner window-resize-corner-tr',
+    style: { top: 0, right: 0, width: CORNER_SIZE, height: CORNER_SIZE },
+  },
+  {
+    edge: 'sw-resize', cursor: 'sw-resize', zIndex: Z.WINDOW_RESIZE_CORNER,
+    className: 'window-resize-corner window-resize-corner-bl',
+    style: { bottom: 0, left: 0, width: CORNER_SIZE, height: CORNER_SIZE },
+  },
+  {
+    edge: 'se-resize', cursor: 'se-resize', zIndex: Z.WINDOW_RESIZE_CORNER,
+    className: 'window-resize-corner window-resize-corner-br',
+    style: { bottom: 0, right: 0, width: CORNER_SIZE, height: CORNER_SIZE },
+  },
+];
+
 export default function WindowResizeBorders() {
-  const [isMax, setIsMax] = useState(false);
-
-  useEffect(() => {
-    let unmounted = false;
-    const syncState = async () => {
-      try {
-        const max = await WindowIsMaximised();
-        if (!unmounted) setIsMax(max);
-      } catch {}
-    };
-
-    syncState();
-    window.addEventListener('resize', syncState);
-    const interval = window.setInterval(syncState, 400);
-
-    return () => {
-      unmounted = true;
-      window.removeEventListener('resize', syncState);
-      window.clearInterval(interval);
-    };
-  }, []);
+  const isMax = useIsWindowMaximized();
 
   if (isMax) return null;
 
+  // 兜底：触屏/笔输入没有前置 mousemove、flags.resizeEdge 为空时，由热区自身发起缩放
   const startResize = (e: React.MouseEvent, edge: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -46,156 +84,22 @@ export default function WindowResizeBorders() {
     }
   };
 
-  const handleMouseEnter = (edge: string) => {
-    const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
-    if (wailsFlags) {
-      wailsFlags.resizeEdge = edge;
-    }
-  };
-
-  const handleMouseLeave = () => {
-    const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
-    if (wailsFlags?.resizeEdge) {
-      delete wailsFlags.resizeEdge;
-    }
-  };
-
-  const borderThickness = 5;
-  const cornerSize = 10;
-
   return (
     <>
-      {/* 边缘缩放热区 */}
-      <div
-        className="window-resize-border window-resize-border-right"
-        style={{
-          position: 'fixed',
-          top: 0,
-          right: 0,
-          bottom: 0,
-          width: `${borderThickness}px`,
-          zIndex: 99999,
-          cursor: 'e-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'e-resize')}
-        onMouseEnter={() => handleMouseEnter('e-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-border window-resize-border-left"
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          width: `${borderThickness}px`,
-          zIndex: 99999,
-          cursor: 'w-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'w-resize')}
-        onMouseEnter={() => handleMouseEnter('w-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-border window-resize-border-bottom"
-        style={{
-          position: 'fixed',
-          left: 0,
-          right: 0,
-          bottom: 0,
-          height: `${borderThickness}px`,
-          zIndex: 99999,
-          cursor: 's-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 's-resize')}
-        onMouseEnter={() => handleMouseEnter('s-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-border window-resize-border-top"
-        style={{
-          position: 'fixed',
-          left: 0,
-          right: 0,
-          top: 0,
-          height: `${borderThickness}px`,
-          zIndex: 99999,
-          cursor: 'n-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'n-resize')}
-        onMouseEnter={() => handleMouseEnter('n-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-
-      {/* 四角缩放热区 */}
-      <div
-        className="window-resize-corner window-resize-corner-tl"
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: `${cornerSize}px`,
-          height: `${cornerSize}px`,
-          zIndex: 100000,
-          cursor: 'nw-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'nw-resize')}
-        onMouseEnter={() => handleMouseEnter('nw-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-corner window-resize-corner-tr"
-        style={{
-          position: 'fixed',
-          top: 0,
-          right: 0,
-          width: `${cornerSize}px`,
-          height: `${cornerSize}px`,
-          zIndex: 100000,
-          cursor: 'ne-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'ne-resize')}
-        onMouseEnter={() => handleMouseEnter('ne-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-corner window-resize-corner-bl"
-        style={{
-          position: 'fixed',
-          bottom: 0,
-          left: 0,
-          width: `${cornerSize}px`,
-          height: `${cornerSize}px`,
-          zIndex: 100000,
-          cursor: 'sw-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'sw-resize')}
-        onMouseEnter={() => handleMouseEnter('sw-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
-      <div
-        className="window-resize-corner window-resize-corner-br"
-        style={{
-          position: 'fixed',
-          bottom: 0,
-          right: 0,
-          width: `${cornerSize}px`,
-          height: `${cornerSize}px`,
-          zIndex: 100000,
-          cursor: 'se-resize',
-          pointerEvents: 'auto',
-        }}
-        onMouseDown={(e) => startResize(e, 'se-resize')}
-        onMouseEnter={() => handleMouseEnter('se-resize')}
-        onMouseLeave={handleMouseLeave}
-      />
+      {RESIZE_ZONES.map((zone) => (
+        <div
+          key={zone.edge}
+          className={zone.className}
+          style={{
+            position: 'fixed',
+            zIndex: zone.zIndex,
+            cursor: zone.cursor,
+            pointerEvents: 'auto',
+            ...zone.style,
+          }}
+          onMouseDown={(e) => startResize(e, zone.edge)}
+        />
+      ))}
     </>
   );
 }

--- a/frontend/src/constants/zIndex.ts
+++ b/frontend/src/constants/zIndex.ts
@@ -54,5 +54,9 @@ export const Z = {
 
   // ── Absolute top (toasts / system notices) ──
   TOAST: 40000,
+
+  // ── Window frameless resize hotzones（压过所有应用层，含弹层） ──
+  WINDOW_RESIZE_BORDER: 99999,
+  WINDOW_RESIZE_CORNER: 100000,
 } as const;
 

--- a/frontend/src/hooks/useIsWindowMaximized.ts
+++ b/frontend/src/hooks/useIsWindowMaximized.ts
@@ -1,0 +1,56 @@
+import { useSyncExternalStore } from 'react';
+import { WindowIsMaximised } from '../../wailsjs/runtime/runtime.js';
+
+let maximized = false;
+let started = false;
+let refCount = 0;
+let pollTimer = 0;
+let resizeDebounce = 0;
+const listeners = new Set<() => void>();
+
+async function poll(): Promise<void> {
+  try {
+    const next = await WindowIsMaximised();
+    if (next !== maximized) {
+      maximized = next;
+      listeners.forEach((listener) => listener());
+    }
+  } catch { /* wails runtime 未就绪时静默，等待下轮轮询 */ }
+}
+
+function onWindowResize(): void {
+  // 拖拽缩放过程中 resize 高频触发，防抖后再查询
+  window.clearTimeout(resizeDebounce);
+  resizeDebounce = window.setTimeout(() => void poll(), 120);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  refCount += 1;
+  if (!started) {
+    started = true;
+    void poll();
+    pollTimer = window.setInterval(() => void poll(), 400);
+    window.addEventListener('resize', onWindowResize);
+  }
+  return () => {
+    listeners.delete(listener);
+    refCount -= 1;
+    if (refCount <= 0 && started) {
+      started = false;
+      window.clearInterval(pollTimer);
+      window.clearTimeout(resizeDebounce);
+      window.removeEventListener('resize', onWindowResize);
+    }
+  };
+}
+
+/** 窗口最大化状态（全局单例轮询，多处订阅共享同一份 Wails IPC 结果） */
+export default function useIsWindowMaximized(): boolean {
+  return useSyncExternalStore(subscribe, () => maximized);
+}
+
+/** 立即刷新一次最大化状态（如最大化/还原切换后） */
+export function refreshWindowMaximized(): void {
+  void poll();
+}

--- a/frontend/src/hooks/useWindowState.ts
+++ b/frontend/src/hooks/useWindowState.ts
@@ -29,9 +29,22 @@ function readSavedWindowSize(): SavedWindowSize | null {
 }
 
 export default function useWindowState(): () => Promise<void> {
-  // 保持 Wails 窗口边缘缩放状态与最大化状态同步，防止最大化时显示边缘缩放光标
+  // 保持 Wails 窗口边缘缩放状态与最大化状态同步，并增强无边框边缘缩放光标与拖拽判定
   useEffect(() => {
     let isMax = false;
+
+    const clearResizeState = () => {
+      const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
+      if (wailsFlags && 'resizeEdge' in wailsFlags) {
+        delete wailsFlags.resizeEdge;
+      }
+      if (document.documentElement.hasAttribute('data-wails-resize-edge')) {
+        document.documentElement.removeAttribute('data-wails-resize-edge');
+      }
+      if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
+        document.documentElement.style.cursor = '';
+      }
+    };
 
     const syncMaximizeState = async () => {
       try {
@@ -41,12 +54,7 @@ export default function useWindowState(): () => Promise<void> {
           wailsFlags.enableResize = !isMax;
         }
         if (isMax) {
-          if (wailsFlags && 'resizeEdge' in wailsFlags) {
-            delete wailsFlags.resizeEdge;
-          }
-          if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
-            document.documentElement.style.cursor = '';
-          }
+          clearResizeState();
         }
       } catch {}
     };
@@ -58,25 +66,70 @@ export default function useWindowState(): () => Promise<void> {
     window.addEventListener('resize', onResize);
     const timer = window.setInterval(syncMaximizeState, 400);
 
-    const onMouseMove = () => {
+    const onMouseMove = (e: MouseEvent) => {
+      const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string; borderThickness?: number } } })?.wails?.flags;
       if (isMax) {
-        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
         if (wailsFlags) {
           wailsFlags.enableResize = false;
-          if ('resizeEdge' in wailsFlags) {
-            delete wailsFlags.resizeEdge;
-          }
         }
-        if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
-          document.documentElement.style.cursor = '';
+        clearResizeState();
+        return;
+      }
+
+      if (!wailsFlags || wailsFlags.enableResize === false) {
+        return;
+      }
+
+      const borderThickness = Math.max(wailsFlags.borderThickness || 0, 8);
+      wailsFlags.borderThickness = borderThickness;
+      const rightBorder = (window.innerWidth - e.clientX < borderThickness) || (window.outerWidth - e.clientX < borderThickness);
+      const leftBorder = e.clientX < borderThickness;
+      const topBorder = e.clientY < borderThickness;
+      const bottomBorder = (window.innerHeight - e.clientY < borderThickness) || (window.outerHeight - e.clientY < borderThickness);
+
+      let edge: string | null = null;
+      if (rightBorder && bottomBorder) edge = 'se-resize';
+      else if (leftBorder && bottomBorder) edge = 'sw-resize';
+      else if (leftBorder && topBorder) edge = 'nw-resize';
+      else if (topBorder && rightBorder) edge = 'ne-resize';
+      else if (leftBorder) edge = 'w-resize';
+      else if (topBorder) edge = 'n-resize';
+      else if (bottomBorder) edge = 's-resize';
+      else if (rightBorder) edge = 'e-resize';
+
+      if (edge) {
+        wailsFlags.resizeEdge = edge;
+        document.documentElement.style.cursor = edge;
+        document.documentElement.setAttribute('data-wails-resize-edge', edge);
+      } else if (wailsFlags.resizeEdge !== undefined || document.documentElement.hasAttribute('data-wails-resize-edge')) {
+        clearResizeState();
+      }
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (isMax) return;
+      const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
+      if (wailsFlags?.resizeEdge) {
+        const w = window as unknown as { WailsInvoke?: (cmd: string) => void };
+        if (w.WailsInvoke) {
+          w.WailsInvoke('resize:' + wailsFlags.resizeEdge);
+          e.preventDefault();
+          e.stopPropagation();
         }
       }
     };
+
     window.addEventListener('mousemove', onMouseMove, { capture: true, passive: true });
+    window.addEventListener('mousedown', onMouseDown, { capture: true });
+    window.addEventListener('mouseleave', clearResizeState);
+    window.addEventListener('blur', clearResizeState);
 
     return () => {
       window.removeEventListener('resize', onResize);
       window.removeEventListener('mousemove', onMouseMove, { capture: true });
+      window.removeEventListener('mousedown', onMouseDown, { capture: true });
+      window.removeEventListener('mouseleave', clearResizeState);
+      window.removeEventListener('blur', clearResizeState);
       window.clearInterval(timer);
     };
   }, []);

--- a/frontend/src/hooks/useWindowState.ts
+++ b/frontend/src/hooks/useWindowState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   WindowGetSize,
   WindowIsMaximised,
@@ -6,6 +6,7 @@ import {
   WindowSetSize,
   WindowToggleMaximise,
 } from '../../wailsjs/runtime/runtime.js';
+import useIsWindowMaximized, { refreshWindowMaximized } from './useIsWindowMaximized.ts';
 
 interface SavedWindowSize {
   w: number;
@@ -13,124 +14,139 @@ interface SavedWindowSize {
   maximized: boolean;
 }
 
-function shouldRememberWindowSize(): boolean {
-  return typeof localStorage !== 'undefined'
-    && localStorage.getItem('rememberWindowSize') !== 'false';
+interface WailsFlags {
+  enableResize?: boolean;
+  resizeEdge?: string;
+  borderThickness?: number;
+  defaultCursor?: string | null;
 }
 
-function readSavedWindowSize(): SavedWindowSize | null {
-  try {
-    const parsed = JSON.parse(localStorage.getItem('windowSize') || 'null') as unknown;
-    const saved = parsed as SavedWindowSize | null;
-    return saved && saved.w > 100 && saved.h > 100 ? saved : null;
-  } catch {
-    return null;
+const RESIZE_EDGE_ATTR = 'data-wails-resize-edge';
+// 边缘缩放抓握带宽度（Wails 默认 6px），缩放优先于贴边滚动条。
+// AI 聊天/监控面板的滚动条通过等宽 gutter 内缩错开：[0,8) 缩放、[8,14) 滚动条两不误；
+// 其余贴边滚动条区域按缩放处理（滚轮滚动不受影响）
+const RESIZE_BORDER_THICKNESS = 8;
+
+function getWailsFlags(): WailsFlags | undefined {
+  return (window as unknown as { wails?: { flags?: WailsFlags } })?.wails?.flags;
+}
+
+function clearWindowResizeState(): void {
+  const flags = getWailsFlags();
+  if (flags && 'resizeEdge' in flags) {
+    delete flags.resizeEdge;
+  }
+  const doc = document.documentElement;
+  if (doc.hasAttribute(RESIZE_EDGE_ATTR)) {
+    doc.removeAttribute(RESIZE_EDGE_ATTR);
+  }
+  if (doc.style.cursor && doc.style.cursor.includes('resize')) {
+    doc.style.cursor = '';
   }
 }
 
+/** 指针是否落在元素的原生滚动条像素上（边缘缩放判定带内调用） */
+function isOverNativeScrollbar(e: MouseEvent, el: HTMLElement): boolean {
+  // 右侧竖向 / 底部横向：Chromium 中滚动条不占用 client 区，命中坐标越过 client 即滚动条
+  if (e.offsetX > el.clientWidth || e.offsetY > el.clientHeight) {
+    return true;
+  }
+  // 左侧竖向（rtl 容器，如左停靠的监控面板）：滚动条位于元素左缘
+  const rect = el.getBoundingClientRect();
+  if (e.clientX < rect.left || e.clientX > rect.right
+    || e.clientY < rect.top || e.clientY > rect.bottom) {
+    return false;
+  }
+  if (getComputedStyle(el).direction !== 'rtl') {
+    return false;
+  }
+  // clientLeft 不含左滚动条时，滚动条占位体现为左缘空隙
+  const gap = rect.width - el.clientLeft - el.clientWidth;
+  if (gap > 1 && e.clientX <= rect.left + el.clientLeft + gap) {
+    return true;
+  }
+  // clientLeft 已包含左滚动条宽度的情形
+  return el.clientLeft > 1 && e.clientX <= rect.left + el.clientLeft;
+}
+
 export default function useWindowState(): () => Promise<void> {
-  // 保持 Wails 窗口边缘缩放状态与最大化状态同步，并增强无边框边缘缩放光标与拖拽判定
+  // 最大化状态来自共享单例轮询，避免多处各自 setInterval 调 Wails IPC
+  const maximized = useIsWindowMaximized();
+  const isMaxRef = useRef(maximized);
+  isMaxRef.current = maximized;
+
+  // 保持 Wails 无边框窗口的边缘缩放开关与最大化状态同步
   useEffect(() => {
-    let isMax = false;
+    const flags = getWailsFlags();
+    if (flags) {
+      flags.enableResize = !maximized;
+      flags.borderThickness = RESIZE_BORDER_THICKNESS;
+    }
+    if (maximized) {
+      clearWindowResizeState();
+    }
+  }, [maximized]);
 
-    const clearResizeState = () => {
-      const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
-      if (wailsFlags && 'resizeEdge' in wailsFlags) {
-        delete wailsFlags.resizeEdge;
-      }
-      if (document.documentElement.hasAttribute('data-wails-resize-edge')) {
-        document.documentElement.removeAttribute('data-wails-resize-edge');
-      }
-      if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
-        document.documentElement.style.cursor = '';
-      }
-    };
-
-    const syncMaximizeState = async () => {
-      try {
-        isMax = await WindowIsMaximised();
-        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string; defaultCursor?: string | null } } })?.wails?.flags;
-        if (wailsFlags) {
-          wailsFlags.enableResize = !isMax;
-        }
-        if (isMax) {
-          clearResizeState();
-        }
-      } catch {}
-    };
-
-    syncMaximizeState();
-    const onResize = () => {
-      syncMaximizeState();
-    };
-    window.addEventListener('resize', onResize);
-    const timer = window.setInterval(syncMaximizeState, 400);
+  // 边缘缩放的坐标判定与 resize: 调用交给 Wails 自带 runtime 维护；这里只把
+  // runtime 维护的 resizeEdge 镜像到 data 属性，驱动 CSS 光标穿透（元素自身
+  // cursor 规则不得遮挡边缘缩放光标）
+  useEffect(() => {
+    const doc = document.documentElement;
 
     const onMouseMove = (e: MouseEvent) => {
-      const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string; borderThickness?: number } } })?.wails?.flags;
-      if (isMax) {
-        if (wailsFlags) {
-          wailsFlags.enableResize = false;
-        }
-        clearResizeState();
-        return;
+      if (isMaxRef.current) return;
+      const flags = getWailsFlags();
+      if (!flags || flags.enableResize === false) return;
+      if (flags.borderThickness !== RESIZE_BORDER_THICKNESS) {
+        flags.borderThickness = RESIZE_BORDER_THICKNESS;
       }
 
-      if (!wailsFlags || wailsFlags.enableResize === false) {
-        return;
-      }
-
-      const borderThickness = Math.max(wailsFlags.borderThickness || 0, 8);
-      wailsFlags.borderThickness = borderThickness;
-      const rightBorder = (window.innerWidth - e.clientX < borderThickness) || (window.outerWidth - e.clientX < borderThickness);
-      const leftBorder = e.clientX < borderThickness;
-      const topBorder = e.clientY < borderThickness;
-      const bottomBorder = (window.innerHeight - e.clientY < borderThickness) || (window.outerHeight - e.clientY < borderThickness);
-
-      let edge: string | null = null;
-      if (rightBorder && bottomBorder) edge = 'se-resize';
-      else if (leftBorder && bottomBorder) edge = 'sw-resize';
-      else if (leftBorder && topBorder) edge = 'nw-resize';
-      else if (topBorder && rightBorder) edge = 'ne-resize';
-      else if (leftBorder) edge = 'w-resize';
-      else if (topBorder) edge = 'n-resize';
-      else if (bottomBorder) edge = 's-resize';
-      else if (rightBorder) edge = 'e-resize';
-
+      const edge = flags.resizeEdge;
       if (edge) {
-        wailsFlags.resizeEdge = edge;
-        document.documentElement.style.cursor = edge;
-        document.documentElement.setAttribute('data-wails-resize-edge', edge);
-      } else if (wailsFlags.resizeEdge !== undefined || document.documentElement.hasAttribute('data-wails-resize-edge')) {
-        clearResizeState();
+        if (doc.getAttribute(RESIZE_EDGE_ATTR) !== edge) {
+          doc.setAttribute(RESIZE_EDGE_ATTR, edge);
+        }
+      } else if (doc.hasAttribute(RESIZE_EDGE_ATTR)) {
+        doc.removeAttribute(RESIZE_EDGE_ATTR);
       }
     };
 
     const onMouseDown = (e: MouseEvent) => {
-      if (isMax) return;
-      const wailsFlags = (window as unknown as { wails?: { flags?: { resizeEdge?: string } } })?.wails?.flags;
-      if (wailsFlags?.resizeEdge) {
-        const w = window as unknown as { WailsInvoke?: (cmd: string) => void };
-        if (w.WailsInvoke) {
-          w.WailsInvoke('resize:' + wailsFlags.resizeEdge);
-          e.preventDefault();
-          e.stopPropagation();
-        }
+      if (isMaxRef.current) return;
+      const flags = getWailsFlags();
+      if (!flags?.resizeEdge) return;
+      // 指针落在原生滚动条像素上时，浏览器强制显示箭头光标（CSS 改不了），
+      // 此时按住应为滚动而非缩放：命中滚动条就取消边缘状态，让滚动条接管，
+      // 保证"显示缩放光标的地方按下才会缩放"，判定与光标始终一致
+      const target = e.target;
+      if (target instanceof HTMLElement
+        && target.clientWidth > 0
+        && isOverNativeScrollbar(e, target)) {
+        delete flags.resizeEdge;
+        return;
+      }
+      const w = window as unknown as { WailsInvoke?: (cmd: string) => void };
+      if (w.WailsInvoke) {
+        w.WailsInvoke('resize:' + flags.resizeEdge);
+        e.preventDefault();
+        e.stopPropagation();
       }
     };
 
-    window.addEventListener('mousemove', onMouseMove, { capture: true, passive: true });
+    const onLeave = () => clearWindowResizeState();
+
+    // 冒泡阶段注册：晚于 wails runtime 的同名监听执行，镜像的才是当次事件的状态
+    window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mousedown', onMouseDown, { capture: true });
-    window.addEventListener('mouseleave', clearResizeState);
-    window.addEventListener('blur', clearResizeState);
+    window.addEventListener('mouseleave', onLeave);
+    window.addEventListener('blur', onLeave);
 
     return () => {
-      window.removeEventListener('resize', onResize);
-      window.removeEventListener('mousemove', onMouseMove, { capture: true });
+      window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mousedown', onMouseDown, { capture: true });
-      window.removeEventListener('mouseleave', clearResizeState);
-      window.removeEventListener('blur', clearResizeState);
-      window.clearInterval(timer);
+      window.removeEventListener('mouseleave', onLeave);
+      window.removeEventListener('blur', onLeave);
+      onLeave();
     };
   }, []);
 
@@ -201,20 +217,22 @@ export default function useWindowState(): () => Promise<void> {
       }
     } catch { }
     WindowToggleMaximise();
-    setTimeout(async () => {
-      try {
-        const isMax = await WindowIsMaximised();
-        const wailsFlags = (window as unknown as { wails?: { flags?: { enableResize?: boolean; resizeEdge?: string } } })?.wails?.flags;
-        if (wailsFlags) {
-          wailsFlags.enableResize = !isMax;
-          if (isMax) {
-            delete wailsFlags.resizeEdge;
-            if (document.documentElement.style.cursor && document.documentElement.style.cursor.includes('resize')) {
-              document.documentElement.style.cursor = '';
-            }
-          }
-        }
-      } catch {}
-    }, 100);
+    // 切换后稍候刷新共享最大化状态，驱动 enableResize 同步与热区层显隐
+    setTimeout(() => refreshWindowMaximized(), 100);
   }, []);
+}
+
+function shouldRememberWindowSize(): boolean {
+  return typeof localStorage !== 'undefined'
+    && localStorage.getItem('rememberWindowSize') !== 'false';
+}
+
+function readSavedWindowSize(): SavedWindowSize | null {
+  try {
+    const parsed = JSON.parse(localStorage.getItem('windowSize') || 'null') as unknown;
+    const saved = parsed as SavedWindowSize | null;
+    return saved && saved.w > 100 && saved.h > 100 ? saved : null;
+  } catch {
+    return null;
+  }
 }

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -48,18 +48,8 @@
     opacity: var(--app-icon-opacity, 1);
   }
 
-  /* ── 窗口边缘缩放时光标强制穿透 ───────────────────────────── */
-  html[data-wails-resize-edge] *,
-  html[style*="cursor: e-resize"] *,
-  html[style*="cursor: w-resize"] *,
-  html[style*="cursor: n-resize"] *,
-  html[style*="cursor: s-resize"] *,
-  html[style*="cursor: ne-resize"] *,
-  html[style*="cursor: nw-resize"] *,
-  html[style*="cursor: se-resize"] *,
-  html[style*="cursor: sw-resize"] *,
-  html[style*="cursor: col-resize"] *,
-  html[style*="cursor: row-resize"] * {
+  /* ── 窗口边缘缩放时光标强制穿透（边缘状态由 useWindowState 镜像到 data 属性） ── */
+  html[data-wails-resize-edge] * {
     cursor: inherit !important;
   }
 }

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -74,6 +74,11 @@
   width: 6px;
   height: 6px;
 }
+::-webkit-scrollbar-button {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+}
 ::-webkit-scrollbar-track {
   background: transparent;
 }

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -47,6 +47,21 @@
   .codicon {
     opacity: var(--app-icon-opacity, 1);
   }
+
+  /* ── 窗口边缘缩放时光标强制穿透 ───────────────────────────── */
+  html[data-wails-resize-edge] *,
+  html[style*="cursor: e-resize"] *,
+  html[style*="cursor: w-resize"] *,
+  html[style*="cursor: n-resize"] *,
+  html[style*="cursor: s-resize"] *,
+  html[style*="cursor: ne-resize"] *,
+  html[style*="cursor: nw-resize"] *,
+  html[style*="cursor: se-resize"] *,
+  html[style*="cursor: sw-resize"] *,
+  html[style*="cursor: col-resize"] *,
+  html[style*="cursor: row-resize"] * {
+    cursor: inherit !important;
+  }
 }
 
 /* ── 全局滚动条样式（统一现代精致半透明胶囊风格） ── */


### PR DESCRIPTION
## 问题
- 无边框窗口在有滚动条的区域（AI 面板 / 监控面板 / 文件管理器）无法拖动缩放窗口
- 左右两侧边缘（AI 及监控折叠条等）无法悬浮拖动调整窗口宽度

## 方案
- 顶层无边框缩放热区层（边 5px / 角 8px），保证边缘可抓握
- 边缘判定统一 8px 抓握带；AI 聊天滚动条内缩 8px 与抓握带错开，滚动与缩放互不抢占
- 按下时检测原生滚动条（覆盖右缘/下缘及 rtl 左缘滚动条），指针在滚动条上不误触缩放，光标指示与实际行为一致
- 边缘状态交由 Wails 运行时维护，前端镜像 resizeEdge 驱动光标穿透，消除双份重复实现
- 新增 useIsWindowMaximized 共享轮询，去除多处重复的 400ms 最大化状态轮询
- 杂项：z-index 收编常量、清理无效选择器、最大化时清理热区残留状态

## 测试
- AI 面板 / 文件管理器 / 监控面板滚动条拖动与滚轮正常
- 四边与四角拖动缩放正常，光标提示与实际行为一致
- 最大化 / 还原切换无残留缩放光标


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增无边框窗口的边缘和角落拖拽区域，支持调整窗口大小。
  * 窗口最大化时自动隐藏调整大小区域，并同步窗口状态。

* **界面优化**
  * 优化滚动条与窗口边缘的间距，避免遮挡缩放区域。
  * 调整缩放状态下的鼠标光标显示及滚动条按钮样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->