### PR TITLE
fix(ui): 优化顶栏元素水平对齐、调整会话标签高度与顶部留白比

### DIFF
--- a/docs/superpowers/plans/2026-08-28-topbar-tab-alignment.md
+++ b/docs/superpowers/plans/2026-08-28-topbar-tab-alignment.md
@@ -1,0 +1,39 @@
+# Topbar & Tab Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the topbar logo and tab bar alignment, standardize tab height to 34px, and reduce the top gap to 6px following Chrome's design ratio.
+
+**Architecture:** Update CSS variables, align topbar items to a shared 34px height container along the bottom edge of the 40px topbar, eliminating the 4px vertical offset between logo/title and session tabs.
+
+**Tech Stack:** React, Tailwind CSS, Vanilla CSS (tokens.css, topbar.css, tabs.css).
+
+## Global Constraints
+- Maintain existing draggable behavior for `--wails-draggable: drag` and `--wails-draggable: no-drag`.
+- Support both dark mode and light mode seamlessly.
+- Preserve active tab SVG inverse corner curves.
+
+---
+
+### Task 1: Tokens & Height Variables
+**Files:**
+- Modify: `frontend/src/styles/tokens.css`
+
+- [ ] **Step 1: Check token variables for topbar and tab heights**
+- [ ] **Step 2: Commit token variable updates**
+
+### Task 2: Topbar Container & Logo Alignment
+**Files:**
+- Modify: `frontend/src/styles/components/topbar.css`
+- Modify: `frontend/src/components/AppTopbar.tsx`
+
+- [ ] **Step 1: Update `.topbar-content` and `.topbar-logo` styles to align with tab bar height**
+- [ ] **Step 2: Verify logo and title vertical alignment**
+
+### Task 3: Tab Proportions & Control Button Polish
+**Files:**
+- Modify: `frontend/src/styles/components/tabs.css`
+
+- [ ] **Step 1: Update `.tab-item`, `.tab-home-item`, and `.tab-search-item` to 34px height**
+- [ ] **Step 2: Verify active tab SVG curves and hover styles**
+- [ ] **Step 3: Run frontend build and verification**

--- a/docs/superpowers/specs/2026-08-28-topbar-tab-alignment-design.md
+++ b/docs/superpowers/specs/2026-08-28-topbar-tab-alignment-design.md
@@ -1,0 +1,20 @@
+# Topbar & Tab Alignment Design
+
+## Goal
+Fix the vertical alignment mismatch between the topbar Logo ("Lumin") and the tab bar, and optimize the active tab height and top margin to match standard modern browser proportions (Chrome style).
+
+## Background & Problem Analysis
+1. **Vertical Offset**: The topbar has a height of 40px with `align-items: center` for the logo container (centerline at Y=20px), while the tab bar has `align-items: flex-end` with 32px height (centerline at Y=24px), causing a 4px vertical stagger.
+2. **Top Spacing**: 32px tabs inside 40px topbar leave 8px (20%) top gap, making the active tab appear sunken.
+3. **Control Items Alignment**: The Home button and Search button next to the logo currently have slight style and height discrepancies with the rest of the tab strip.
+
+## Proposed Solution (Approach A - Chrome Style)
+- **Top Margin & Proportions**:
+  - Keep `--topbar-h: 40px`.
+  - Increase tab height to `34px`, reducing top gap from 8px to 6px (matching Chrome's standard proportions).
+- **Centerline Alignment**:
+  - Align `.topbar-logo` height to `34px` (bottom aligned in the 40px topbar), so that the logo icon (20px) and "Lumin" text (12px) share the exact same optical centerline at Y=23px as the tab text and icons.
+- **Controls & Search**:
+  - Standardize `.tab-home-item` and `.tab-search-item` to 34px height, ensuring uniform visual rhythm.
+- **Window Controls**:
+  - Keep window action buttons properly aligned with the topbar layout.

--- a/frontend/src/components/AppTopbar.tsx
+++ b/frontend/src/components/AppTopbar.tsx
@@ -137,7 +137,7 @@ export default function AppTopbar({
                   type="button"
                   className={cn(
                     'tab-search-item no-drag shrink-0',
-                    showSessionList && 'text-accent bg-hover shadow-sm',
+                    showSessionList && 'active',
                   )}
                   onClick={(e) => { e.stopPropagation(); toggleSessionList(); }}
                   aria-label={t('搜索服务器')}

--- a/frontend/src/components/AppTopbar.tsx
+++ b/frontend/src/components/AppTopbar.tsx
@@ -136,8 +136,8 @@ export default function AppTopbar({
                   ref={sessionListBtnRef}
                   type="button"
                   className={cn(
-                    'tab-search-item no-drag shrink-0 transition-colors duration-[80ms] hover:bg-hover',
-                    showSessionList ? 'text-accent hover:text-accent' : 'text-secondary hover:text-primary',
+                    'tab-search-item no-drag shrink-0',
+                    showSessionList && 'text-accent bg-hover shadow-sm',
                   )}
                   onClick={(e) => { e.stopPropagation(); toggleSessionList(); }}
                   aria-label={t('搜索服务器')}

--- a/frontend/src/styles/components/tabs.css
+++ b/frontend/src/styles/components/tabs.css
@@ -101,7 +101,7 @@
   min-width: 28px;
   max-width: 28px;
   padding: 0;
-  border: 1px solid transparent;
+  border: none;
   background: transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -111,7 +111,7 @@
   margin-right: 4px;
   margin-left: 2px;
   color: var(--text-secondary);
-  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
 }
 
 .tab-search-item:hover {
@@ -125,19 +125,18 @@
   transform: scale(0.96);
 }
 
-/* 面板打开/激活态：箭头上主题强调色 (accent)，背景与边框呈现清晰激活高亮 */
+/* 面板打开态：保持自然的灰底与微阴影，箭头翻转 180° */
 .tab-search-item.active,
 .tab-search-item[aria-expanded="true"] {
-  background: color-mix(in srgb, var(--accent) 14%, var(--surface-hover));
-  color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent), var(--shadow-sm);
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
 }
 
 .tab-search-item.active:hover,
 .tab-search-item[aria-expanded="true"]:hover {
-  background: color-mix(in srgb, var(--accent) 20%, var(--surface-hover));
-  color: var(--accent);
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .tab-search-item svg {

--- a/frontend/src/styles/components/tabs.css
+++ b/frontend/src/styles/components/tabs.css
@@ -101,7 +101,7 @@
   min-width: 28px;
   max-width: 28px;
   padding: 0;
-  border: none;
+  border: 1px solid transparent;
   background: transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -111,7 +111,7 @@
   margin-right: 4px;
   margin-left: 2px;
   color: var(--text-secondary);
-  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
 }
 
 .tab-search-item:hover {
@@ -123,6 +123,30 @@
 .tab-search-item:active {
   background: var(--surface-active);
   transform: scale(0.96);
+}
+
+/* 面板打开/激活态：箭头上主题强调色 (accent)，背景与边框呈现清晰激活高亮 */
+.tab-search-item.active,
+.tab-search-item[aria-expanded="true"] {
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface-hover));
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent), var(--shadow-sm);
+}
+
+.tab-search-item.active:hover,
+.tab-search-item[aria-expanded="true"]:hover {
+  background: color-mix(in srgb, var(--accent) 20%, var(--surface-hover));
+  color: var(--accent);
+}
+
+.tab-search-item svg {
+  transition: transform var(--transition-fast);
+}
+
+.tab-search-item.active svg,
+.tab-search-item[aria-expanded="true"] svg {
+  transform: rotate(180deg);
 }
 
 /* 标签行内「新建」圆钮：静默无底，悬停浮现圆形灰底（对齐浏览器范式） */

--- a/frontend/src/styles/components/tabs.css
+++ b/frontend/src/styles/components/tabs.css
@@ -43,11 +43,11 @@
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
-  height: 18px;
+  height: 34px;
   margin-left: 4px;
   padding-left: 6px;
   border-left: 1px solid var(--border);
-  align-self: center;
+  align-self: flex-end;
 }
 
 .tab-actions:empty {
@@ -61,8 +61,8 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  height: 32px;
-  min-height: 32px;
+  height: 34px;
+  min-height: 34px;
   padding: 0 10px 0 12px;
   font-size: var(--text-sm);
   border-radius: 10px 10px 0 0;
@@ -96,8 +96,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 32px;
-  min-height: 32px;
+  height: 34px;
+  min-height: 34px;
   width: 36px;
   min-width: 36px;
   max-width: 36px;
@@ -235,7 +235,7 @@ body.theme-light.has-global-wallpaper .tab-item.active::after {
 .topbar-home-btn {
   width: 36px;
   min-width: 36px;
-  height: 32px;
+  height: 34px;
   padding: 0;
   display: inline-flex;
   align-items: center;

--- a/frontend/src/styles/components/tabs.css
+++ b/frontend/src/styles/components/tabs.css
@@ -91,22 +91,38 @@
   color: var(--accent);
 }
 
-/* 搜索服务器入口：与主页按钮同尺寸/位置，但配色走工具类（点击上色同 AI 按钮） */
+/* 搜索服务器入口：与设置等快捷按钮统一规格，带圆角与 hover 悬浮阴影 */
 .tab-search-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 34px;
-  min-height: 34px;
-  width: 36px;
-  min-width: 36px;
-  max-width: 36px;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  max-width: 28px;
   padding: 0;
   border: none;
   background: transparent;
-  border-radius: 10px 10px 0 0;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   user-select: none;
+  align-self: flex-end;
+  margin-bottom: 3px;
+  margin-right: 4px;
+  margin-left: 2px;
+  color: var(--text-secondary);
+  transition: background var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+}
+
+.tab-search-item:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.tab-search-item:active {
+  background: var(--surface-active);
+  transform: scale(0.96);
 }
 
 /* 标签行内「新建」圆钮：静默无底，悬停浮现圆形灰底（对齐浏览器范式） */

--- a/frontend/src/styles/components/topbar.css
+++ b/frontend/src/styles/components/topbar.css
@@ -54,7 +54,7 @@ body.theme-light.has-global-wallpaper .topbar-home-btn.active {
 
 .topbar-content {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   width: 100%;
   height: 100%;
   gap: var(--space-1);
@@ -76,6 +76,10 @@ body.theme-light.has-global-wallpaper .topbar-home-btn.active {
   cursor: pointer;
   user-select: none;
   min-width: 0;
+  height: 34px;
+  padding: 0 4px;
+  border-radius: var(--radius-xs);
+  align-self: flex-end;
 }
 
 .topbar-logo img {
@@ -89,6 +93,7 @@ body.theme-light.has-global-wallpaper .topbar-home-btn.active {
   font-weight: 600;
   color: var(--topbar-title-color, var(--text-primary));
   letter-spacing: -0.1px;
+  line-height: 1;
 }
 
 .window-controls {
@@ -96,6 +101,8 @@ body.theme-light.has-global-wallpaper .topbar-home-btn.active {
   align-items: center;
   gap: 2px;
   margin-left: auto;
+  height: 34px;
+  align-self: flex-end;
 }
 
 .window-controls button {


### PR DESCRIPTION
### 📝 问题描述
1. **顶栏元素垂直中轴线错位**：左侧 Logo 与项目名称（Lumin）在 40px 容器中居中（中心线 Y=20px），而标签栏（32px）为底部对齐（中心线 Y=24px），导致 Logo 和标签存在 4px 的高低错位。
2. **标签比例与顶部留白偏大**：40px 顶栏搭配 32px 标签导致顶部留白达到 8px（20%），在视觉上选中的标签显下沉且顶部空荡。
3. **搜索服务器按钮交互与造型**：此前为标签块造型，与设置按钮及现代浏览器标签搜索控件规格不一致。

### 🛠️ 改动内容
1. **统一水平基准中轴线**：
   - 顶栏内容容器（\.topbar-content\）底部贴齐，Logo 区域（\.topbar-logo\）统一为 34px 高度并内部居中。
   - Logo 图标、项目名、主页按钮、搜索按钮、标签内容、通道占用徽章与右侧窗口控制按钮全部共享同一水平参考线（\Y = 23px\）。
2. **对齐现代浏览器（Chrome）标签黄金比例**：
   - 标签高度由 \32px\ 增加到 \34px\，顶部留白由 \8px\ 收窄至 \6px\，视觉更饱满紧凑。
   - 保持激活标签底部的平滑无缝外凹反弧（SVG 反弧与内容区相接）。
3. **搜索服务器按钮（ChevronDown）规范化与交互增强**：
   - 改为 28px × 28px 四周圆角小方钮（\ounded-[var(--radius-sm)]\），与设置按钮规格统一。
   - 增加 Hover 悬浮微阴影（\shadow-sm\）与背景色。
   - 面板展开时箭头自带 180° 平滑翻转动效（由 \\ 变为 \^\）。

### 🧪 验证
- 本地前端 \
pm run build\ 打包构建通过。
- 深色模式、浅色模式下对齐与阴影显示正常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **界面优化**
  - 统一顶部栏与标签页的视觉高度和底部对齐方式，改善整体垂直居中与间距。
  - 优化 Logo、主页、搜索入口及窗口控制区域的尺寸和布局。
  - 改进服务器搜索入口的悬停、按下、展开状态及箭头动效。
  - 保持拖拽操作、明暗主题和活动标签视觉效果不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->