### PR TITLE
feat(filemanager): 支持批量复制文件路径

### DIFF
--- a/frontend/src/components/filemanager/ContextMenu.tsx
+++ b/frontend/src/components/filemanager/ContextMenu.tsx
@@ -32,7 +32,11 @@ export default function ContextMenu({ pos, item, mode = 'item', isPinned = false
         entries.push({ label: t('关闭标签'), icon: icon(X), onSelect: onCloseTab });
       }
       if (item) {
-        entries.push({ label: t('复制路径'), icon: icon(Copy), onSelect: onCopyPath });
+        entries.push({
+          label: `${t('复制路径')}${clipboardItemCount > 1 ? ` (${clipboardItemCount}${t('项')})` : ''}`,
+          icon: icon(Copy),
+          onSelect: onCopyPath,
+        });
       }
       if (item && !isTabMenu) {
         entries.push({

--- a/frontend/src/components/filemanager/FileManagerOverlays.tsx
+++ b/frontend/src/components/filemanager/FileManagerOverlays.tsx
@@ -96,7 +96,11 @@ export function renderFileManagerOverlays(fm: FileManagerController, uploadPanel
           }}
           onCopyPath={() => {
             if (contextMenu.item) {
-              handleCopyPath(contextMenu.item, contextMenu.itemBasePath || currentPath);
+              handleCopyPath(
+                contextMenu.item,
+                contextMenu.itemBasePath || currentPath,
+                contextMenu.clipboardUsesSelectedPaths ? [...selectedPathsRef.current] : [],
+              );
             }
             closeContextMenu();
           }}

--- a/frontend/src/components/filemanager/useFileManagerItemOps.ts
+++ b/frontend/src/components/filemanager/useFileManagerItemOps.ts
@@ -45,11 +45,19 @@ export function useFileManagerItemOps(deps: ReturnType<typeof useFileManagerCore
   } = deps;
 
   // Download file via Wails native file dialog
-  const handleCopyPath = (item: FileManagerFileItem, basePath = currentPath) => {
-    let fullPath = joinPath(basePath, item.name);
-    if (item.isDirectory && !fullPath.endsWith('/')) fullPath += '/';
-    navigator.clipboard?.writeText(fullPath).then(() => {
-      addToast?.(`${t('已复制')}: ${fullPath}`, 'success');
+  const handleCopyPath = (item: FileManagerFileItem, basePath = currentPath, selectedItemPaths: unknown[] = []) => {
+    const normalizedSelectedPaths = Array.isArray(selectedItemPaths)
+      ? selectedItemPaths.map((path) => String(path || '').trim()).filter(Boolean)
+      : [];
+    let paths = normalizedSelectedPaths;
+    if (paths.length === 0) {
+      let fullPath = joinPath(basePath, item.name);
+      if (item.isDirectory && !fullPath.endsWith('/')) fullPath += '/';
+      paths = [fullPath];
+    }
+    const clipboardText = paths.join('\n');
+    navigator.clipboard?.writeText(clipboardText).then(() => {
+      addToast?.(`${t('已复制')}: ${paths.length > 1 ? `${paths.length}${t('项')}` : clipboardText}`, 'success');
     }).catch(() => {
       addToast?.(t('复制失败'), 'error');
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持同时复制多个选中项目的路径。
  * 选中多个项目时，菜单项会显示项目数量。
* **改进**
  * 单个项目复制路径时保留原有操作和提示。
  * 复制成功提示会根据复制项目数量显示对应信息。
  * 目录路径复制将保留末尾的 `/`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->