### PR TITLE
fix(linux): 修复设置/文件管理器等弹层在 Linux WebKitGTK 上的滚动条穿透

### DIFF
--- a/frontend/src/components/FileEditor.tsx
+++ b/frontend/src/components/FileEditor.tsx
@@ -3,6 +3,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { SquarePen, Upload } from 'lucide-react';
 import { Z } from '../constants/zIndex.ts';
+import { useOverlayScrollLock } from '../hooks/useOverlayScrollLock.ts';
 import { formatShortcut } from '../utils/platform.ts';
 import { ContextMenu, Modal } from './ui';
 import { BASIC_SETUP } from './fileEditor/fileEditorLanguages.ts';
@@ -63,6 +64,8 @@ export default function FileEditor(props: FileEditorProps) {
     ext,
     handleWorkbenchTabChange,
   } = useFileEditor(props);
+
+  useOverlayScrollLock(mode === 'popup' && isActive && !minimized);
 
   const editorContent = (
     <>

--- a/frontend/src/components/GlobalDialog.tsx
+++ b/frontend/src/components/GlobalDialog.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { t } from '../i18n.ts';
 import { Z } from '../constants/zIndex';
+import { useOverlayScrollLock } from '../hooks/useOverlayScrollLock.ts';
 import {
   DIALOG_PRIORITY,
   getDialogPriority,
@@ -107,21 +109,26 @@ export default function GlobalDialog({ suspendDefault = false }: GlobalDialogPro
     };
   }, [pushDialog]);
 
+  const current = dialogs[0] as QueuedDialog | undefined;
+  const currentSuspended = !!current && suspendDefault && current.priority === DIALOG_PRIORITY.default;
+  const shouldLock = dialogs.length > 0 && !currentSuspended;
+  useOverlayScrollLock(shouldLock);
+
   if (dialogs.length === 0) return null;
 
-  const current = dialogs[0];
-  const currentSuspended = suspendDefault && current.priority === DIALOG_PRIORITY.default;
-  const dialogZIndex = current.priority === DIALOG_PRIORITY.system
+  const activeCurrent = dialogs[0];
+  const dialogZIndex = activeCurrent.priority === DIALOG_PRIORITY.system
     ? Z.SYSTEM_DIALOG
-    : (current.priority === DIALOG_PRIORITY.settings
+    : (activeCurrent.priority === DIALOG_PRIORITY.settings
       ? Z.SETTINGS_DIALOG
       : Z.GLOBAL_DIALOG);
 
-  return (
+  const overlayNode = (
     <div
       className="modal-overlay"
+      data-modal-overlay="true"
       data-global-dialog-active={currentSuspended ? undefined : 'true'}
-      style={{ zIndex: dialogZIndex, display: currentSuspended ? 'none' : 'flex' }}
+      style={{ zIndex: dialogZIndex, display: currentSuspended ? 'none' : 'flex', isolation: 'isolate' as const }}
     >
       {dialogs.map((dialog, index) => {
         const dialogActive = index === 0 && !(suspendDefault && dialog.priority === DIALOG_PRIORITY.default);
@@ -152,4 +159,9 @@ export default function GlobalDialog({ suspendDefault = false }: GlobalDialogPro
       })}
     </div>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(overlayNode, document.body);
+  }
+  return overlayNode;
 }

--- a/frontend/src/components/SerialConfigModal.tsx
+++ b/frontend/src/components/SerialConfigModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { X, Cpu } from 'lucide-react';
 import * as AppGo from '../../wailsjs/go/wailsapp/App.js';
 import { useTranslation } from '../i18n.ts';
 import { Button, Select } from './ui';
+import { useOverlayScrollLock } from '../hooks/useOverlayScrollLock.ts';
 
 /** 串口连接配置（与 App.ConnectSerial 的参数对应） */
 export interface SerialFormConfig {
@@ -59,8 +61,19 @@ export default function SerialConfigModal({ onClose, onConnect }: SerialConfigMo
     onConnect(form);
   };
 
-  return (
-    <div className="modal-overlay">
+  useOverlayScrollLock(true);
+
+  if (typeof document === 'undefined') return null;
+
+  const overlayNode = (
+    <div
+      className="modal-overlay"
+      data-modal-overlay="true"
+      style={{ isolation: 'isolate' as const }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
       <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 className="modal-title">
@@ -180,4 +193,6 @@ export default function SerialConfigModal({ onClose, onConnect }: SerialConfigMo
       </div>
     </div>
   );
+
+  return createPortal(overlayNode, document.body);
 }

--- a/frontend/src/components/ai/AIProviderQuickEditOverlay.tsx
+++ b/frontend/src/components/ai/AIProviderQuickEditOverlay.tsx
@@ -1,6 +1,8 @@
+import { createPortal } from 'react-dom';
 import { ArrowLeft, Save, Trash2 } from 'lucide-react';
 import { Z } from '../../constants/zIndex.ts';
 import { useTranslation } from '../../i18n.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import type { AIProviderLike } from './AIProviderSelector.tsx';
 import { useAIProviderQuickEdit } from './quickEdit/useAIProviderQuickEdit.ts';
 import QuickEditBasicTab from './quickEdit/QuickEditBasicTab.tsx';
@@ -91,22 +93,28 @@ export default function AIProviderQuickEditOverlay({
     onSave,
   });
 
+  useOverlayScrollLock(open);
+
   if (!open) {
     return null;
   }
 
+  if (typeof document === 'undefined') return null;
+
   const title = draft.name || (mode === 'create' ? t('新增供应商') : t('编辑供应商'));
   const subtitle = mode === 'create' ? t('创建供应商配置...') : t('编辑...');
 
-  return (
+  const overlayNode = (
     <div
       onClick={onClose}
+      data-modal-overlay="true"
       style={{
         top: panelBounds?.top ?? 0,
         left: panelBounds?.left ?? 0,
         width: panelBounds?.width ?? '100vw',
         height: panelBounds?.height ?? '100vh',
         zIndex: Z.DIALOG,
+        isolation: 'isolate' as const,
       }}
       className="fixed max-w-screen max-h-screen overflow-hidden flex justify-center items-stretch bg-scrim/90 backdrop-blur-[4px]">
       <div
@@ -222,4 +230,6 @@ export default function AIProviderQuickEditOverlay({
       </div>
     </div>
   );
+
+  return createPortal(overlayNode, document.body);
 }

--- a/frontend/src/components/filemanager/ChmodDialog.tsx
+++ b/frontend/src/components/filemanager/ChmodDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Lock } from 'lucide-react';
 import { Z } from '../../constants/zIndex.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import { Button } from '../ui';
 import {
   buildIdentityOptionList,
@@ -102,11 +103,13 @@ export default function ChmodDialog({ path, permission, mode, rememberedMode = '
     setIncludeChildren(Boolean(includeSubdirectories));
   };
 
+  useOverlayScrollLock(true);
+
   if (typeof document === 'undefined') {
     return null;
   }
   return createPortal(
-    <div className="modal-overlay" style={{ zIndex: Z.MODAL }}>
+    <div className="modal-overlay" data-modal-overlay="true" style={{ zIndex: Z.MODAL, isolation: 'isolate' as const }}>
       <div className="modal modal-sm">
         <div className="modal-header">
           <div className="modal-title"><Lock size={14} /> {t('修改权限')}</div>

--- a/frontend/src/components/overlays/SessionListOverlay.tsx
+++ b/frontend/src/components/overlays/SessionListOverlay.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Search, X } from 'lucide-react';
 import Tiptop from '../Tiptop.tsx';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import type { config } from '../../../wailsjs/go/models.ts';
 import type { TopbarSession } from '../AppTopbar.tsx';
 import type { SessionAuthPrompt } from '../../hooks/useSessionConnections.ts';
@@ -45,6 +47,7 @@ export default function SessionListOverlay({
   setShowSessionList,
   closeSession,
 }: SessionListOverlayProps) {
+  useOverlayScrollLock(true);
   const [activeIdx, setActiveIdx] = useState(0);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
@@ -107,10 +110,11 @@ export default function SessionListOverlay({
     }
   };
 
-  return (
+  const content = (
     <div
       ref={sessionListRef}
       className="tab-context-menu max-h-[400px] flex flex-col"
+      data-session-list-overlay="true"
       style={{
         left: Math.min(Math.max(8, sessionListPos.x - PANEL_WIDTH), Math.max(8, (window.innerWidth || 1280) - PANEL_WIDTH - 8)),
         top: sessionListPos.y,
@@ -189,4 +193,9 @@ export default function SessionListOverlay({
       </div>
     </div>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(content, document.body);
+  }
+  return content;
 }

--- a/frontend/src/components/overlays/TabContextMenuOverlay.tsx
+++ b/frontend/src/components/overlays/TabContextMenuOverlay.tsx
@@ -1,4 +1,6 @@
+import { createPortal } from 'react-dom';
 import { Copy, X } from 'lucide-react';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import type { TopbarSession } from '../AppTopbar.tsx';
 import type { TabContextMenuState } from './overlayTypes.ts';
 
@@ -24,9 +26,10 @@ export default function TabContextMenuOverlay({
   forceCloseSession,
   closeAllSessions,
 }: TabContextMenuOverlayProps) {
+  useOverlayScrollLock(true);
   const showCopySessionPassword = canCopySessionPassword(tabContextMenu.sessionId);
-  return (
-    <div className="tab-context-menu" style={{ left: tabContextMenu.x, top: tabContextMenu.y }}>
+  const content = (
+    <div className="tab-context-menu" data-tab-context-menu="true" style={{ left: tabContextMenu.x, top: tabContextMenu.y }}>
       {showCopySessionPassword && (
         <>
           <div
@@ -68,4 +71,9 @@ export default function TabContextMenuOverlay({
       )}
     </div>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(content, document.body);
+  }
+  return content;
 }

--- a/frontend/src/components/overlays/TerminalTabContextMenuOverlay.tsx
+++ b/frontend/src/components/overlays/TerminalTabContextMenuOverlay.tsx
@@ -1,5 +1,7 @@
+import { createPortal } from 'react-dom';
 import { PenLine, X } from 'lucide-react';
 import { cn } from '../../utils/cn.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import type { SessionLike } from '../../utils/sessionWorkspace.ts';
 import type { TopbarSession } from '../AppTopbar.tsx';
 import type { TerminalTabContextMenuState } from './overlayTypes.ts';
@@ -30,6 +32,7 @@ export default function TerminalTabContextMenuOverlay({
   closeTerminalGroup,
   closeTerminal,
 }: TerminalTabContextMenuOverlayProps) {
+  useOverlayScrollLock(true);
   const session = sessions.find((item) => item.id === terminalTabContextMenu.sessionId);
   const moveTargets = [
     { target: 'top-left', label: t('移至左上面板') },
@@ -37,8 +40,8 @@ export default function TerminalTabContextMenuOverlay({
     { target: 'bottom-left', label: t('移至左下面板') },
     { target: 'bottom-right', label: t('移至右下面板') },
   ];
-  return (
-    <div className="tab-context-menu" style={{ left: terminalTabContextMenu.x, top: terminalTabContextMenu.y }}>
+  const content = (
+    <div className="tab-context-menu" data-tab-context-menu="true" style={{ left: terminalTabContextMenu.x, top: terminalTabContextMenu.y }}>
       {terminalTabContextMenu.type === 'terminal' && moveTargets.map((item) => {
         const occupied = !!session && isTerminalDockTargetOccupied(session, terminalTabContextMenu.terminalId, item.target);
         const enabled = !!session && canMoveTerminalToDockTarget(session, terminalTabContextMenu.terminalId, item.target);
@@ -88,4 +91,9 @@ export default function TerminalTabContextMenuOverlay({
       </div>
     </div>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(content, document.body);
+  }
+  return content;
 }

--- a/frontend/src/components/serverList/ServerContextMenu.tsx
+++ b/frontend/src/components/serverList/ServerContextMenu.tsx
@@ -1,9 +1,11 @@
+import { createPortal } from 'react-dom';
 import { Copy, Folder, Link, PenLine, SquarePen, Trash2, X } from 'lucide-react';
 import type React from 'react';
 import type { config } from '../../../wailsjs/go/models.ts';
 import { Z } from '../../constants/zIndex.ts';
 import { useTranslation } from '../../i18n.ts';
 import { ContextMenu, MenuList, MenuPanel } from '../ui';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import type { MenuItem } from '../ui';
 import { MENU_ESTIMATED_WIDTH } from './serverListTypes.ts';
 
@@ -47,6 +49,92 @@ export function ServerContextMenu({
   existingGroups,
 }: ServerContextMenuProps) {
   const { t } = useTranslation();
+  useOverlayScrollLock(!!groupHeaderMenu || !!menuServer);
+
+  const menuServerNode = menuServer ? (
+    <>
+      <div
+        className="fixed inset-0"
+        style={{ zIndex: Z.MENU_BACKDROP }}
+        onMouseDown={() => closeServerMenu()}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          closeServerMenu();
+        }}
+      />
+      <MenuPanel
+        minWidth={MENU_ESTIMATED_WIDTH}
+        data-context-menu="true"
+        className="fixed overflow-visible animate-[fadeIn_0.12s_ease]"
+        style={{ left: menuPos.x, top: menuPos.y, zIndex: Z.MENU }}
+      >
+        <div className="relative">
+          <MenuList
+            items={[
+              { label: t('连接'), icon: <Link size={14} />, onSelect: () => { onConnect(menuServer); } },
+              { label: t('编辑配置'), icon: <SquarePen size={14} />, onSelect: () => { triggerEdit(menuServer, menuSourceRef.current); } },
+              { label: t('克隆'), icon: <Copy size={14} />, onSelect: () => { onClone(menuServer, getEditAnimationPayload(menuServer, menuSourceRef.current)); } },
+              ...(onMoveGroup ? [{
+                label: t('移动到分组'),
+                icon: <Folder size={14} />,
+                onSelect: () => {
+                  submenuToggleRef.current = true;
+                  setGroupMenu((prev) => !prev);
+                },
+              } as MenuItem] : []),
+              'separator',
+              {
+                label: t('删除'),
+                icon: <Trash2 size={14} />,
+                danger: true,
+                onSelect: () => {
+                  void (async () => {
+                    if (await window.luminDialog?.confirm(`${t('确定删除服务器')}「${menuServer.name || menuServer.host}」？`)) {
+                      onDelete(menuServer.id);
+                    }
+                  })();
+                },
+              },
+            ] as MenuItem[]}
+            onClose={() => {
+              if (submenuToggleRef.current) {
+                submenuToggleRef.current = false;
+                return;
+              }
+              closeServerMenu();
+            }}
+          />
+          {groupMenu && onMoveGroup && (
+            <MenuPanel
+              minWidth={MENU_ESTIMATED_WIDTH}
+              className="absolute left-full top-0 animate-[fadeIn_0.12s_ease]"
+              style={{ zIndex: Z.SUBMENU }}
+            >
+              <MenuList
+                items={[
+                  ...existingGroups.filter((g) => g !== (menuServer.group || '')).map((g): MenuItem => ({
+                    label: g,
+                    icon: <Folder size={13} />,
+                    onSelect: () => { onMoveGroup(menuServer.id, g); },
+                  })),
+                  ...(menuServer.group ? [{
+                    label: t('移出分组'),
+                    icon: <X size={13} />,
+                    onSelect: () => { onMoveGroup(menuServer.id, ''); },
+                  } as MenuItem] : []),
+                ] as MenuItem[]}
+                onClose={closeServerMenu}
+              />
+            </MenuPanel>
+          )}
+        </div>
+      </MenuPanel>
+    </>
+  ) : null;
+
+  const menuServerPortal = menuServerNode
+    ? (typeof document !== 'undefined' && document.body ? createPortal(menuServerNode, document.body) : menuServerNode)
+    : null;
 
   return (
     <>
@@ -61,86 +149,7 @@ export function ServerContextMenu({
           onClose={() => setGroupHeaderMenu(null)}
         />
       )}
-
-      {menuServer && (
-        <>
-          <div
-            className="fixed inset-0"
-            style={{ zIndex: Z.MENU_BACKDROP }}
-            onMouseDown={() => closeServerMenu()}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              closeServerMenu();
-            }}
-          />
-          <MenuPanel
-            minWidth={MENU_ESTIMATED_WIDTH}
-            className="fixed overflow-visible animate-[fadeIn_0.12s_ease]"
-            style={{ left: menuPos.x, top: menuPos.y, zIndex: Z.MENU }}
-          >
-            <div className="relative">
-              <MenuList
-                items={[
-                  { label: t('连接'), icon: <Link size={14} />, onSelect: () => { onConnect(menuServer); } },
-                  { label: t('编辑配置'), icon: <SquarePen size={14} />, onSelect: () => { triggerEdit(menuServer, menuSourceRef.current); } },
-                  { label: t('克隆'), icon: <Copy size={14} />, onSelect: () => { onClone(menuServer, getEditAnimationPayload(menuServer, menuSourceRef.current)); } },
-                  ...(onMoveGroup ? [{
-                    label: t('移动到分组'),
-                    icon: <Folder size={14} />,
-                    onSelect: () => {
-                      submenuToggleRef.current = true;
-                      setGroupMenu((prev) => !prev);
-                    },
-                  } as MenuItem] : []),
-                  'separator',
-                  {
-                    label: t('删除'),
-                    icon: <Trash2 size={14} />,
-                    danger: true,
-                    onSelect: () => {
-                      void (async () => {
-                        if (await window.luminDialog?.confirm(`${t('确定删除服务器')}「${menuServer.name || menuServer.host}」？`)) {
-                          onDelete(menuServer.id);
-                        }
-                      })();
-                    },
-                  },
-                ] as MenuItem[]}
-                onClose={() => {
-                  if (submenuToggleRef.current) {
-                    submenuToggleRef.current = false;
-                    return;
-                  }
-                  closeServerMenu();
-                }}
-              />
-              {groupMenu && onMoveGroup && (
-                <MenuPanel
-                  minWidth={MENU_ESTIMATED_WIDTH}
-                  className="absolute left-full top-0 animate-[fadeIn_0.12s_ease]"
-                  style={{ zIndex: Z.SUBMENU }}
-                >
-                  <MenuList
-                    items={[
-                      ...existingGroups.filter((g) => g !== (menuServer.group || '')).map((g): MenuItem => ({
-                        label: g,
-                        icon: <Folder size={13} />,
-                        onSelect: () => { onMoveGroup(menuServer.id, g); },
-                      })),
-                      ...(menuServer.group ? [{
-                        label: t('移出分组'),
-                        icon: <X size={13} />,
-                        onSelect: () => { onMoveGroup(menuServer.id, ''); },
-                      } as MenuItem] : []),
-                    ] as MenuItem[]}
-                    onClose={closeServerMenu}
-                  />
-                </MenuPanel>
-              )}
-            </div>
-          </MenuPanel>
-        </>
-      )}
+      {menuServerPortal}
     </>
   );
 }

--- a/frontend/src/components/ui/ContextMenu.tsx
+++ b/frontend/src/components/ui/ContextMenu.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { Z } from '../../constants/zIndex.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 
 export interface MenuEntry {
   label: ReactNode;
@@ -126,18 +128,21 @@ export function MenuPanel({
   className = '',
   style,
   onContextMenu,
+  ...rest
 }: {
   children: ReactNode;
   minWidth?: number;
   className?: string;
   style?: React.CSSProperties;
   onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
+  [key: string]: unknown;
 }) {
   return (
     <div
       className={`bg-overlay border border-line rounded-md shadow-md py-1 overflow-y-auto ${className}`}
       style={{ minWidth, ...style }}
       onContextMenu={onContextMenu}
+      {...(rest as Record<string, unknown>)}
     >
       {children}
     </div>
@@ -154,6 +159,7 @@ export interface ContextMenuProps {
 }
 
 export function ContextMenu({ x, y, items, onClose, zIndex = Z.MENU, minWidth }: ContextMenuProps) {
+  useOverlayScrollLock(true);
   const panelRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ left: number; top: number }>({ left: x, top: y });
 
@@ -182,7 +188,7 @@ export function ContextMenu({ x, y, items, onClose, zIndex = Z.MENU, minWidth }:
     return () => window.removeEventListener('keydown', onKey, true);
   }, [onClose]);
 
-  return (
+  const content = (
     <>
       <div
         className="fixed inset-0"
@@ -200,6 +206,7 @@ export function ContextMenu({ x, y, items, onClose, zIndex = Z.MENU, minWidth }:
       />
       <MenuPanel
         minWidth={minWidth}
+        data-context-menu="true"
         className="fixed animate-[fadeIn_0.08s_ease]"
         style={{ zIndex, left: pos.left, top: pos.top }}
         onContextMenu={(e) => {
@@ -214,4 +221,9 @@ export function ContextMenu({ x, y, items, onClose, zIndex = Z.MENU, minWidth }:
       </MenuPanel>
     </>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(content, document.body);
+  }
+  return content;
 }

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { t } from '../../i18n.ts';
 import { Z } from '../../constants/zIndex.ts';
@@ -61,15 +62,43 @@ export function Modal({
     return () => window.removeEventListener('keydown', onKey, true);
   }, [open, closeOnEscape, onClose]);
 
+  // 关键：用 useLayoutEffect 同步在 paint 前加上 modal-open，避免首帧穿透。
+  // Linux WebKitGTK 的 overlay scrollbar 在滚动后 1s 内处于可见态（自动淡出），
+  // 若用 useEffect（paint 后才加类），首帧会把仍在淡出动画中的 thumb 画到 fixed 弹层之上，
+  // 表现为“滚动后立马开设置才穿透、等一会就消失”。
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+
+    const docEl = document.documentElement;
+    const body = document.body;
+    const previousCount = Number(body.dataset.modalCount || '0');
+    const nextCount = previousCount + 1;
+
+    body.dataset.modalCount = String(nextCount);
+    body.classList.add('modal-open');
+    docEl.classList.add('modal-open');
+
+    return () => {
+      const remaining = Math.max(0, Number(body.dataset.modalCount || '1') - 1);
+      if (remaining === 0) {
+        body.classList.remove('modal-open');
+        docEl.classList.remove('modal-open');
+        delete body.dataset.modalCount;
+      } else {
+        body.dataset.modalCount = String(remaining);
+      }
+    };
+  }, [open]);
+
   if (!open) return null;
 
   const hasHeader = title != null || !hideClose;
 
-  return (
+  const overlayNode = (
     <div
       data-modal-overlay="true"
       className={`fixed inset-0 flex ${align === 'top' ? 'items-start pt-[52px]' : 'items-center'} justify-center bg-scrim animate-[fadeIn_0.12s_ease]`}
-      style={{ zIndex }}
+      style={{ zIndex, isolation: 'isolate' }}
       {...overlayProps}
       onMouseDown={(e) => {
         if (closeOnOverlay && e.target === e.currentTarget) onClose();
@@ -104,4 +133,9 @@ export function Modal({
       </div>
     </div>
   );
+
+  if (typeof document !== 'undefined' && document.body) {
+    return createPortal(overlayNode, document.body);
+  }
+  return overlayNode;
 }

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useLayoutEffect, type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { t } from '../../i18n.ts';
 import { Z } from '../../constants/zIndex.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
 
@@ -62,33 +63,7 @@ export function Modal({
     return () => window.removeEventListener('keydown', onKey, true);
   }, [open, closeOnEscape, onClose]);
 
-  // 关键：用 useLayoutEffect 同步在 paint 前加上 modal-open，避免首帧穿透。
-  // Linux WebKitGTK 的 overlay scrollbar 在滚动后 1s 内处于可见态（自动淡出），
-  // 若用 useEffect（paint 后才加类），首帧会把仍在淡出动画中的 thumb 画到 fixed 弹层之上，
-  // 表现为“滚动后立马开设置才穿透、等一会就消失”。
-  useLayoutEffect(() => {
-    if (!open) return undefined;
-
-    const docEl = document.documentElement;
-    const body = document.body;
-    const previousCount = Number(body.dataset.modalCount || '0');
-    const nextCount = previousCount + 1;
-
-    body.dataset.modalCount = String(nextCount);
-    body.classList.add('modal-open');
-    docEl.classList.add('modal-open');
-
-    return () => {
-      const remaining = Math.max(0, Number(body.dataset.modalCount || '1') - 1);
-      if (remaining === 0) {
-        body.classList.remove('modal-open');
-        docEl.classList.remove('modal-open');
-        delete body.dataset.modalCount;
-      } else {
-        body.dataset.modalCount = String(remaining);
-      }
-    };
-  }, [open]);
+  useOverlayScrollLock(open);
 
   if (!open) return null;
 

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 
 import { Z } from '../../constants/zIndex.ts';
 import { cn } from '../../utils/cn.ts';
 import { clampMenuPosition } from '../../utils/menuPosition.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 
 export interface SelectOption {
   value: string;
@@ -52,6 +53,8 @@ export function Select({
     () => options.find((opt) => opt.value === value),
     [options, value],
   );
+
+  useOverlayScrollLock(open);
 
   const displayLabel = currentOption ? currentOption.label : (placeholder || value);
 
@@ -194,6 +197,7 @@ export function Select({
           role="listbox"
           aria-labelledby={selectId}
           tabIndex={-1}
+          data-select-dropdown="true"
           style={{
             position: 'fixed',
             left: menuPos.x,

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -1,0 +1,32 @@
+import { useLayoutEffect } from 'react';
+
+/**
+ * Linux WebKitGTK overlay scrollbar 会在滚动后 1s 内处于淡出动画中，
+ * 若背景容器仍为 overflow:auto，thumb 会以独立合成层画到 fixed 弹层之上。
+ * 复用 Modal 的 modalCount 计数，保证多层弹层嵌套时仅在最后一层关闭时解锁。
+ */
+export function useOverlayScrollLock(open: boolean) {
+  useLayoutEffect(() => {
+    if (!open) return undefined;
+
+    const docEl = document.documentElement;
+    const body = document.body;
+    const previousCount = Number(body.dataset.modalCount || '0');
+    const nextCount = previousCount + 1;
+
+    body.dataset.modalCount = String(nextCount);
+    body.classList.add('modal-open');
+    docEl.classList.add('modal-open');
+
+    return () => {
+      const remaining = Math.max(0, Number(body.dataset.modalCount || '1') - 1);
+      if (remaining === 0) {
+        body.classList.remove('modal-open');
+        docEl.classList.remove('modal-open');
+        delete body.dataset.modalCount;
+      } else {
+        body.dataset.modalCount = String(remaining);
+      }
+    };
+  }, [open]);
+}

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -1,9 +1,68 @@
 import { useLayoutEffect } from 'react';
 
 /**
- * Linux WebKitGTK overlay scrollbar 会在滚动后 1s 内处于淡出动画中，
- * 若背景容器仍为 overflow:auto，thumb 会以独立合成层画到 fixed 弹层之上。
- * 复用 Modal 的 modalCount 计数，保证多层弹层嵌套时仅在最后一层关闭时解锁。
+ * useOverlayScrollLock — Linux WebKitGTK 滚动条穿透的统一加锁
+ *
+ * @description
+ * Wails Linux 使用 WebKitGTK，其原生 overlay scrollbar 在滚动后 1s 内处于
+ * 淡出动画中，thumb 以独立合成层（GTK GtkOverlay）绘制在所有 `position:fixed`
+ * 之上，`z-index`/`isolation` 无法压制。若弹层打开时背景容器仍为
+ * `overflow:auto`，thumb 会穿透到弹层上（表现为一条 6px 细线，滚动后立即
+ * 开弹层必现，静置 1s 后自动消失）。`base.css` 结合 `html.modal-open` 在
+ * `paint` 前将背景 `overflow` 切为 `hidden` 才能瞬间隐藏。
+ *
+ * 本 hook 与 `frontend/src/styles/base.css:124-210` 配套：
+ * - `base.css` 将 `*` 的滚动条样式收敛到 `.app-layout/[data-modal-overlay]/.modal-overlay`
+ *   并在 `html.modal-open .app-layout *{scrollbar-width:none; overflow:hidden}` 隐藏背景；
+ *   弹层自身通过 `[data-modal-overlay]`/`.modal-overlay`/`[data-select-dropdown]` 等
+ *   恢复为 `thin`，`portaled` 到 `body` 的弹层天然在 `.app-layout` 外不受影响。
+ * - 本 hook 负责在 `paint` 前同步给 `html/body` 加 `modal-open`，并通过
+ *   `body.dataset.modalCount` 计数保证多层嵌套（例：设置弹层内再开二次确认）时
+ *   仅在最后一层关闭才解锁。
+ *
+ * @param open - 弹层/菜单/下拉是否可见，`true` 时加锁，`false` 或卸载时解锁
+ *
+ * @usage
+ * ```tsx
+ * // 1) 全屏弹层 / Dialog / Drawer（必须 portal 到 body，并加 data-modal-overlay）
+ * import { createPortal } from 'react-dom'
+ * import { useOverlayScrollLock } from '@/hooks/useOverlayScrollLock'
+ * function MyDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+ *   useOverlayScrollLock(open)
+ *   if (!open || typeof document === 'undefined') return null
+ *   return createPortal(
+ *     <div data-modal-overlay="true" className="modal-overlay" style={{ isolation: 'isolate' }}>
+ *       <div className="modal">...</div>
+ *     </div>,
+ *     document.body
+ *   )
+ * }
+ *
+ * // 2) 右键菜单 / 下拉（同样 portal，菜单自身可滚动时加 data 属性以便 base.css 恢复）
+ * function MyMenu({ open, x, y }: { open: boolean; x: number; y: number }) {
+ *   useOverlayScrollLock(open)
+ *   if (!open) return null
+ *   return createPortal(
+ *     <div data-context-menu="true" style={{ position:'fixed', left:x, top:y }}>...</div>,
+ *     document.body
+ *   )
+ * }
+ * // Select 下拉已在 ui/Select.tsx 内置此逻辑，无需外层重复加锁
+ * ```
+ *
+ * @rules
+ * - 已使用 `ui/Modal` 的组件无需再调用，`Modal.tsx:65` 已内置。
+ * - 任何新写的 `fixed/inset-0` 覆盖层（即使很小如 `Select` 下拉、`ContextMenu`）
+ *   若可能盖在可滚动内容（文件管理器的 Virtuoso、首页主机列表、探针面板等）之上，
+ *   均应调用 `useOverlayScrollLock(open)` 并 `portal` 到 `body`。
+ * - 弹层自身若有滚动（`max-h-64 overflow-y-auto`），需加 `data-modal-overlay` /
+ *   `data-select-dropdown` / `data-context-menu` 等，使 `base.css` 的恢复规则
+ *   不会将其误隐藏；`portaled` 的弹层已在 `.app-layout` 外，天然不受背景隐藏影响。
+ * - `.app-layout` 内新增可滚动容器（`overflow-y:auto`）无需在 `base.css` 登记，
+ *   通用 `html.modal-open .app-layout *` 会自动在任意弹层打开时隐藏，无需特例化。
+ * - 统一修复入口：若后续仍出现穿透，优先检查弹层是否调用本 hook 且已 `portal`，
+ *   而非为每个滚动条写特例。详见分支 `fix/linux-modal-scrollbar-bleed` 及
+ *   `base.css:124` 注释。
  */
 export function useOverlayScrollLock(open: boolean) {
   useLayoutEffect(() => {

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -62,7 +62,17 @@
 [data-modal-overlay],
 [data-modal-overlay] *,
 .modal-overlay,
-.modal-overlay * {
+.modal-overlay *,
+[data-select-dropdown],
+[data-select-dropdown] *,
+.tab-context-menu,
+.tab-context-menu *,
+[data-session-list-overlay],
+[data-session-list-overlay] *,
+[data-tab-context-menu],
+[data-tab-context-menu] *,
+[data-context-menu],
+[data-context-menu] * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent;
 }
@@ -72,7 +82,17 @@
 [data-modal-overlay]::-webkit-scrollbar,
 [data-modal-overlay] *::-webkit-scrollbar,
 .modal-overlay::-webkit-scrollbar,
-.modal-overlay *::-webkit-scrollbar {
+.modal-overlay *::-webkit-scrollbar,
+[data-select-dropdown]::-webkit-scrollbar,
+[data-select-dropdown] *::-webkit-scrollbar,
+.tab-context-menu::-webkit-scrollbar,
+.tab-context-menu *::-webkit-scrollbar,
+[data-session-list-overlay]::-webkit-scrollbar,
+[data-session-list-overlay] *::-webkit-scrollbar,
+[data-tab-context-menu]::-webkit-scrollbar,
+[data-tab-context-menu] *::-webkit-scrollbar,
+[data-context-menu]::-webkit-scrollbar,
+[data-context-menu] *::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
@@ -81,7 +101,17 @@
 [data-modal-overlay]::-webkit-scrollbar-button,
 [data-modal-overlay] *::-webkit-scrollbar-button,
 .modal-overlay::-webkit-scrollbar-button,
-.modal-overlay *::-webkit-scrollbar-button {
+.modal-overlay *::-webkit-scrollbar-button,
+[data-select-dropdown]::-webkit-scrollbar-button,
+[data-select-dropdown] *::-webkit-scrollbar-button,
+.tab-context-menu::-webkit-scrollbar-button,
+.tab-context-menu *::-webkit-scrollbar-button,
+[data-session-list-overlay]::-webkit-scrollbar-button,
+[data-session-list-overlay] *::-webkit-scrollbar-button,
+[data-tab-context-menu]::-webkit-scrollbar-button,
+[data-tab-context-menu] *::-webkit-scrollbar-button,
+[data-context-menu]::-webkit-scrollbar-button,
+[data-context-menu] *::-webkit-scrollbar-button {
   display: none !important;
   width: 0 !important;
   height: 0 !important;
@@ -91,7 +121,17 @@
 [data-modal-overlay]::-webkit-scrollbar-track,
 [data-modal-overlay] *::-webkit-scrollbar-track,
 .modal-overlay::-webkit-scrollbar-track,
-.modal-overlay *::-webkit-scrollbar-track {
+.modal-overlay *::-webkit-scrollbar-track,
+[data-select-dropdown]::-webkit-scrollbar-track,
+[data-select-dropdown] *::-webkit-scrollbar-track,
+.tab-context-menu::-webkit-scrollbar-track,
+.tab-context-menu *::-webkit-scrollbar-track,
+[data-session-list-overlay]::-webkit-scrollbar-track,
+[data-session-list-overlay] *::-webkit-scrollbar-track,
+[data-tab-context-menu]::-webkit-scrollbar-track,
+[data-tab-context-menu] *::-webkit-scrollbar-track,
+[data-context-menu]::-webkit-scrollbar-track,
+[data-context-menu] *::-webkit-scrollbar-track {
   background: transparent;
 }
 .app-layout::-webkit-scrollbar-thumb,
@@ -99,7 +139,17 @@
 [data-modal-overlay]::-webkit-scrollbar-thumb,
 [data-modal-overlay] *::-webkit-scrollbar-thumb,
 .modal-overlay::-webkit-scrollbar-thumb,
-.modal-overlay *::-webkit-scrollbar-thumb {
+.modal-overlay *::-webkit-scrollbar-thumb,
+[data-select-dropdown]::-webkit-scrollbar-thumb,
+[data-select-dropdown] *::-webkit-scrollbar-thumb,
+.tab-context-menu::-webkit-scrollbar-thumb,
+.tab-context-menu *::-webkit-scrollbar-thumb,
+[data-session-list-overlay]::-webkit-scrollbar-thumb,
+[data-session-list-overlay] *::-webkit-scrollbar-thumb,
+[data-tab-context-menu]::-webkit-scrollbar-thumb,
+[data-tab-context-menu] *::-webkit-scrollbar-thumb,
+[data-context-menu]::-webkit-scrollbar-thumb,
+[data-context-menu] *::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35));
   border-radius: var(--radius-full);
   transition: background 0.15s ease;
@@ -109,7 +159,17 @@
 [data-modal-overlay]::-webkit-scrollbar-thumb:hover,
 [data-modal-overlay] *::-webkit-scrollbar-thumb:hover,
 .modal-overlay::-webkit-scrollbar-thumb:hover,
-.modal-overlay *::-webkit-scrollbar-thumb:hover {
+.modal-overlay *::-webkit-scrollbar-thumb:hover,
+[data-select-dropdown]::-webkit-scrollbar-thumb:hover,
+[data-select-dropdown] *::-webkit-scrollbar-thumb:hover,
+.tab-context-menu::-webkit-scrollbar-thumb:hover,
+.tab-context-menu *::-webkit-scrollbar-thumb:hover,
+[data-session-list-overlay]::-webkit-scrollbar-thumb:hover,
+[data-session-list-overlay] *::-webkit-scrollbar-thumb:hover,
+[data-tab-context-menu]::-webkit-scrollbar-thumb:hover,
+[data-tab-context-menu] *::-webkit-scrollbar-thumb:hover,
+[data-context-menu]::-webkit-scrollbar-thumb:hover,
+[data-context-menu] *::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover, rgba(140, 165, 195, 0.6));
 }
 .app-layout::-webkit-scrollbar-corner,
@@ -117,7 +177,17 @@
 [data-modal-overlay]::-webkit-scrollbar-corner,
 [data-modal-overlay] *::-webkit-scrollbar-corner,
 .modal-overlay::-webkit-scrollbar-corner,
-.modal-overlay *::-webkit-scrollbar-corner {
+.modal-overlay *::-webkit-scrollbar-corner,
+[data-select-dropdown]::-webkit-scrollbar-corner,
+[data-select-dropdown] *::-webkit-scrollbar-corner,
+.tab-context-menu::-webkit-scrollbar-corner,
+.tab-context-menu *::-webkit-scrollbar-corner,
+[data-session-list-overlay]::-webkit-scrollbar-corner,
+[data-session-list-overlay] *::-webkit-scrollbar-corner,
+[data-tab-context-menu]::-webkit-scrollbar-corner,
+[data-tab-context-menu] *::-webkit-scrollbar-corner,
+[data-context-menu]::-webkit-scrollbar-corner,
+[data-context-menu] *::-webkit-scrollbar-corner {
   background: transparent;
 }
 
@@ -195,6 +265,26 @@ body.modal-open [data-modal-overlay]::-webkit-scrollbar,
 body.modal-open [data-modal-overlay] *::-webkit-scrollbar,
 body.modal-open .modal-overlay::-webkit-scrollbar,
 body.modal-open .modal-overlay *::-webkit-scrollbar {
+  display: block !important;
+  width: 6px !important;
+  height: 6px !important;
+}
+
+/* Select 下拉在 .app-layout 内时（仪表盘/文件管理器等），其自身滚动需保留
+   （Select 的 useOverlayScrollLock 会在下拉打开时触发 modal-open） */
+html.modal-open [data-select-dropdown],
+html.modal-open [data-select-dropdown] *,
+body.modal-open [data-select-dropdown],
+body.modal-open [data-select-dropdown] * {
+  scrollbar-width: thin !important;
+  scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+}
+html.modal-open [data-select-dropdown]::-webkit-scrollbar,
+html.modal-open [data-select-dropdown] *::-webkit-scrollbar,
+body.modal-open [data-select-dropdown]::-webkit-scrollbar,
+body.modal-open [data-select-dropdown] *::-webkit-scrollbar {
   display: block !important;
   width: 6px !important;
   height: 6px !important;

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -54,34 +54,146 @@
   }
 }
 
-/* ── 全局滚动条样式（统一现代精致半透明胶囊风格） ── */
-* {
+/* ── 应用内容区滚动条样式（仅作用于真实应用滚动容器，避免原生滚动条穿透到浮层上）
+   Linux WebKitGTK 会把 ::-webkit-scrollbar 当作独立层绘制在 fixed 弹层之上，而 Win/Chromium 会正确裁剪；
+   因此将全局 * 作用域收敛到 .app-layout，并将弹层 portal 到 body，使两者在合成层上隔离。 ── */
+.app-layout,
+.app-layout *,
+[data-modal-overlay],
+[data-modal-overlay] *,
+.modal-overlay,
+.modal-overlay * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent;
 }
 
-::-webkit-scrollbar {
+.app-layout::-webkit-scrollbar,
+.app-layout *::-webkit-scrollbar,
+[data-modal-overlay]::-webkit-scrollbar,
+[data-modal-overlay] *::-webkit-scrollbar,
+.modal-overlay::-webkit-scrollbar,
+.modal-overlay *::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
-::-webkit-scrollbar-button {
+.app-layout::-webkit-scrollbar-button,
+.app-layout *::-webkit-scrollbar-button,
+[data-modal-overlay]::-webkit-scrollbar-button,
+[data-modal-overlay] *::-webkit-scrollbar-button,
+.modal-overlay::-webkit-scrollbar-button,
+.modal-overlay *::-webkit-scrollbar-button {
   display: none !important;
   width: 0 !important;
   height: 0 !important;
 }
-::-webkit-scrollbar-track {
+.app-layout::-webkit-scrollbar-track,
+.app-layout *::-webkit-scrollbar-track,
+[data-modal-overlay]::-webkit-scrollbar-track,
+[data-modal-overlay] *::-webkit-scrollbar-track,
+.modal-overlay::-webkit-scrollbar-track,
+.modal-overlay *::-webkit-scrollbar-track {
   background: transparent;
 }
-::-webkit-scrollbar-thumb {
+.app-layout::-webkit-scrollbar-thumb,
+.app-layout *::-webkit-scrollbar-thumb,
+[data-modal-overlay]::-webkit-scrollbar-thumb,
+[data-modal-overlay] *::-webkit-scrollbar-thumb,
+.modal-overlay::-webkit-scrollbar-thumb,
+.modal-overlay *::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35));
   border-radius: var(--radius-full);
   transition: background 0.15s ease;
 }
-::-webkit-scrollbar-thumb:hover {
+.app-layout::-webkit-scrollbar-thumb:hover,
+.app-layout *::-webkit-scrollbar-thumb:hover,
+[data-modal-overlay]::-webkit-scrollbar-thumb:hover,
+[data-modal-overlay] *::-webkit-scrollbar-thumb:hover,
+.modal-overlay::-webkit-scrollbar-thumb:hover,
+.modal-overlay *::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover, rgba(140, 165, 195, 0.6));
 }
-::-webkit-scrollbar-corner {
+.app-layout::-webkit-scrollbar-corner,
+.app-layout *::-webkit-scrollbar-corner,
+[data-modal-overlay]::-webkit-scrollbar-corner,
+[data-modal-overlay] *::-webkit-scrollbar-corner,
+.modal-overlay::-webkit-scrollbar-corner,
+.modal-overlay *::-webkit-scrollbar-corner {
   background: transparent;
+}
+
+/* 弹层打开时，仅隐藏背景 .app-layout 的滚动条；portal 到 body 的弹层不受影响。
+   Linux WebKitGTK 的 overlay scrollbar 是独立合成层：滚动后 1s 内处于淡出动画中，
+   若仅用 scrollbar-width:none 且用 useEffect（paint 后才加类），首帧会把动画中的 thumb 画到 fixed 层之上。
+   因此：① Modal 改用 useLayoutEffect 同步加类（paint 前生效）；② 这里同时把背景滚动容器的 overflow 设为 hidden，
+   使 GTK 的 overlay indicator 立即失去可滚动依据而瞬间隐藏，而非等淡出超时。 */
+html.modal-open .app-layout,
+html.modal-open .app-layout *,
+body.modal-open .app-layout,
+body.modal-open .app-layout * {
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
+}
+html.modal-open .app-layout::-webkit-scrollbar,
+html.modal-open .app-layout *::-webkit-scrollbar,
+body.modal-open .app-layout::-webkit-scrollbar,
+body.modal-open .app-layout *::-webkit-scrollbar {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+/* 背景中两个真实可滚动容器：左侧添加服务器表单、右侧主机列表。overflow:hidden 能让 GTK 立即隐藏 overlay */
+html.modal-open .app-layout .dashboard-server-editor-body,
+html.modal-open .app-layout .hosts-scroll-area,
+body.modal-open .app-layout .dashboard-server-editor-body,
+body.modal-open .app-layout .hosts-scroll-area {
+  overflow: hidden !important;
+}
+html.modal-open,
+body.modal-open {
+  overflow: hidden !important;
+}
+
+/* 弹层自身始终保持 isolate 合成层，确保在 Linux 上盖过背景滚动条层 */
+[data-modal-overlay],
+.modal-overlay {
+  isolation: isolate;
+}
+
+/* 若弹层仍在 .app-layout 内（如 GlobalDialog 未 portal），上面 .app-layout 隐藏会误伤弹层自身；显式恢复弹层滚动条 */
+html.modal-open [data-modal-overlay],
+html.modal-open [data-modal-overlay] *,
+html.modal-open .modal-overlay,
+html.modal-open .modal-overlay *,
+body.modal-open [data-modal-overlay],
+body.modal-open [data-modal-overlay] *,
+body.modal-open .modal-overlay,
+body.modal-open .modal-overlay * {
+  scrollbar-width: thin !important;
+  scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent !important;
+}
+html.modal-open [data-modal-overlay]::-webkit-scrollbar,
+html.modal-open [data-modal-overlay] *::-webkit-scrollbar,
+html.modal-open .modal-overlay::-webkit-scrollbar,
+html.modal-open .modal-overlay *::-webkit-scrollbar,
+body.modal-open [data-modal-overlay]::-webkit-scrollbar,
+body.modal-open [data-modal-overlay] *::-webkit-scrollbar,
+body.modal-open .modal-overlay::-webkit-scrollbar,
+body.modal-open .modal-overlay *::-webkit-scrollbar {
+  display: block !important;
+  width: 6px !important;
+  height: 6px !important;
+}
+
+/* 根节点在 Linux/WebKit 下可能单独绘制原生滚动条槽，始终隐藏（应用内滚动由 .app-layout 子容器承担） */
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+}
+html, body {
+  scrollbar-width: none !important;
+  -ms-overflow-style: none !important;
 }
 
 /* ── 终端视口原生滚动条消除（避免空行显示空白滚动槽） ── */

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -141,10 +141,10 @@ body.modal-open .app-layout *::-webkit-scrollbar {
   width: 0 !important;
   height: 0 !important;
 }
-/* 背景中真实可滚动容器：滚动后立即开弹层时 GTK 的 overlay indicator 仍在 1s 淡出期内，
-   仅 scrollbar-width:none 无法瞬间隐藏已在动画中的 native thumb，需同时 overflow:hidden。
-   覆盖所有在 .app-layout 内可能成为背景的可滚动容器（首页/文件/探针/终端等），
-   portaled 到 body 的弹层不受影响（.app-layout 外），若未来新增滚动容器只需在此追加。 */
+/* 背景滚动锁定：文件管理器(Virtuoso)、探针、首页等任意在 .app-layout 内的可滚动容器
+   在 Linux WebKitGTK 上滚动后 1s 内 overlay indicator 仍在淡出，scrollbar-width:none 无法瞬间隐藏
+   动画中的 native thumb，需 overflow:hidden。采用通用选择器而非枚举，避免遗漏 Virtuoso 等动态
+   生成的滚动容器（文件管理器截图即为此类）。portaled 弹层在 body 外不受影响，.modal-overlay 例外保留。 */
 html.modal-open .app-layout .dashboard-server-editor-body,
 html.modal-open .app-layout .hosts-scroll-area,
 html.modal-open .app-layout .data-page-scroll,
@@ -152,13 +152,16 @@ html.modal-open .app-layout .probe-panel,
 html.modal-open .app-layout .terminal-tab-list-items,
 html.modal-open .app-layout .context-menu,
 html.modal-open .app-layout .term-quick-cmd-preview,
+/* 通用兜底：任意 .app-layout 内元素（排除仍在 .app-layout 内的 GlobalDialog） */
+html.modal-open .app-layout *:not(.modal-overlay):not(.modal-overlay *):not([data-modal-overlay]):not([data-modal-overlay] *),
 body.modal-open .app-layout .dashboard-server-editor-body,
 body.modal-open .app-layout .hosts-scroll-area,
 body.modal-open .app-layout .data-page-scroll,
 body.modal-open .app-layout .probe-panel,
 body.modal-open .app-layout .terminal-tab-list-items,
 body.modal-open .app-layout .context-menu,
-body.modal-open .app-layout .term-quick-cmd-preview {
+body.modal-open .app-layout .term-quick-cmd-preview,
+body.modal-open .app-layout *:not(.modal-overlay):not(.modal-overlay *):not([data-modal-overlay]):not([data-modal-overlay] *) {
   overflow: hidden !important;
 }
 html.modal-open,

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -141,11 +141,24 @@ body.modal-open .app-layout *::-webkit-scrollbar {
   width: 0 !important;
   height: 0 !important;
 }
-/* 背景中两个真实可滚动容器：左侧添加服务器表单、右侧主机列表。overflow:hidden 能让 GTK 立即隐藏 overlay */
+/* 背景中真实可滚动容器：滚动后立即开弹层时 GTK 的 overlay indicator 仍在 1s 淡出期内，
+   仅 scrollbar-width:none 无法瞬间隐藏已在动画中的 native thumb，需同时 overflow:hidden。
+   覆盖所有在 .app-layout 内可能成为背景的可滚动容器（首页/文件/探针/终端等），
+   portaled 到 body 的弹层不受影响（.app-layout 外），若未来新增滚动容器只需在此追加。 */
 html.modal-open .app-layout .dashboard-server-editor-body,
 html.modal-open .app-layout .hosts-scroll-area,
+html.modal-open .app-layout .data-page-scroll,
+html.modal-open .app-layout .probe-panel,
+html.modal-open .app-layout .terminal-tab-list-items,
+html.modal-open .app-layout .context-menu,
+html.modal-open .app-layout .term-quick-cmd-preview,
 body.modal-open .app-layout .dashboard-server-editor-body,
-body.modal-open .app-layout .hosts-scroll-area {
+body.modal-open .app-layout .hosts-scroll-area,
+body.modal-open .app-layout .data-page-scroll,
+body.modal-open .app-layout .probe-panel,
+body.modal-open .app-layout .terminal-tab-list-items,
+body.modal-open .app-layout .context-menu,
+body.modal-open .app-layout .term-quick-cmd-preview {
   overflow: hidden !important;
 }
 html.modal-open,


### PR DESCRIPTION
## 问题

Linux（WSL/Wayland，Wails WebKitGTK）上滚动任意可滚动容器（首页主机列表/添加服务器表单、文件管理器 Virtuoso、探针面板等）后立即打开设置等弹层，背景的 6px 细滚动条会以独立合成层穿透到 `fixed` 弹层之上；静置约 1s 后随 GTK 淡出动画自动消失。Windows WebView2 正常裁剪。

复现：滚动 → 立即点右上齿轮打开“设置”，可见细线切过弹层；等 1s 再开则无。文件管理器场景同样复现（见截图，Virtuoso 动态 scroller）。

## 根因

1. `base.css` 曾用 `*`/`::-webkit-scrollbar` 全局定义，WebKitGTK 的 overlay scrollbar 为 GTK `GtkOverlay` 独立层，不受 `z-index`/`isolation` 压制。
2. `Modal` 用 `useEffect` 在 `paint` 后才加 `html.modal-open`，首帧把仍在 1s 淡出动画中的 thumb 画到弹层上；仅 `scrollbar-width:none` 无法瞬间隐藏已在动画中的 native thumb，需同时 `overflow:hidden`。
3. 仅 `Modal` 加锁，`GlobalDialog`/`ChmodDialog`/`SerialConfigModal`/`FileEditor popup`/`AIProviderQuickEditOverlay` 等全屏弹层及 `ContextMenu`/`Select`/`TabContextMenu` 等未加锁；且 `Virtuoso` 的 scroller 为动态生成，枚举式 `overflow:hidden` 遗漏。

## 方案

- **统一样式收敛** `frontend/src/styles/base.css`：`*` → `.app-layout/[data-modal-overlay]/.modal-overlay` 及 `[data-select-dropdown]/.tab-context-menu` 等，`html.modal-open .app-layout *{scrollbar-width:none}` + 通用 `html.modal-open .app-layout *:not(.modal-overlay):not([data-modal-overlay]){overflow:hidden}` 兜底，portaled 弹层在 `body` 外不受影响，弹层自身通过 `[data-*]` 恢复 `thin`。
- **同步加锁** `frontend/src/hooks/useOverlayScrollLock.ts`（新，`useLayoutEffect+modalCount`）：在 `paint` 前同步加 `html/body.modal-open`，多层嵌套计数仅最后一层关闭解锁。`Modal` 已内置，其余全屏弹层复用。
- **弹层 portal 化**：`Modal`/`GlobalDialog`/`SerialConfigModal`/`AIProviderQuickEditOverlay`/`FileEditor popup`/`Tab/TerminalTab/SessionList`/`ServerContextMenu`/`ContextMenu` 统一 `createPortal(document.body)` + `data-modal-overlay`/`isolation:isolate`。
- **Select** 下拉 `data-select-dropdown` + `useOverlayScrollLock(open)` 并在 `base.css` 恢复自身滚动。

后续 `.app-layout` 内新增 `overflow:auto` 容器无需在 `base.css` 登记，通用 `*` 会自动在任意弹层打开时隐藏；新 `fixed` 覆盖层只需 `useOverlayScrollLock(open)` 并 `portal` 即可，详见 `useOverlayScrollLock.ts` 注释。

## 变更

- `frontend/src/styles/base.css`：通用滚动条/背景锁定、portaled 弹层恢复、根槽隐藏
- `frontend/src/hooks/useOverlayScrollLock.ts`：新增统一 hook
- `frontend/src/components/ui/Modal.tsx`：复用 hook + portal
- `frontend/src/components/GlobalDialog.tsx`、`filemanager/ChmodDialog.tsx`、`SerialConfigModal.tsx`、`FileEditor.tsx`、`ai/AIProviderQuickEditOverlay.tsx`：portal + hook
- `frontend/src/components/ui/ContextMenu.tsx`、`ui/Select.tsx`、`overlays/*`、`serverList/ServerContextMenu.tsx`：中风险菜单/下拉 portal + hook

## 验证

- `tsc --noEmit --skipLibCheck` / `vite build frontend` 通过
- 手动：文件管理器/首页滚动后立即打开设置、GlobalDialog、Chmod、Select 下拉、右键菜单，均无细线穿透；嵌套弹层（设置内再开确认）解锁正常；Win 未回归

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 弹窗、下拉菜单及右键菜单打开时自动锁定背景滚动，避免页面位置意外变化。
  - 弹层统一显示在页面顶层，减少被其他内容遮挡的情况。
  - 支持多个嵌套弹层同时使用，关闭其中一层不会提前恢复背景滚动。
- **体验优化**
  - 优化应用容器、弹层、下拉框和菜单的滚动条样式与显示范围。
  - 改善弹层隔离效果及菜单点击关闭行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->