### PR TITLE
fix(webkit): 修复 Linux WebKitGTK 主题切换黑屏并优雅降级保留三端动画

### DIFF
--- a/frontend/src/styles/animations.css
+++ b/frontend/src/styles/animations.css
@@ -1011,14 +1011,17 @@ body.theme-light .editor-mode-banner {
 }
 
 /* ── 主题切换 View Transition（圆形扩散揭示，见 utils/themeTransition.ts） ── */
-/* 关闭默认交叉淡入，改由 JS 在 ::view-transition-new(root) 上跑 clip-path circle 动画 */
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
-}
+/* 仅在支持 View Transitions 的内核（Chromium）上启用；WebKitGTK 在 Wails 透明窗口下 clip-path 会黑屏，已在 JS 侧 isWebKit() 禁用 */
+@supports (view-transition-name: root) {
+  /* 关闭默认交叉淡入，改由 JS 在 ::view-transition-new(root) 上跑 clip-path circle 动画 */
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+  }
 
-/* 收缩方向（切到深色）：旧快照须盖在新快照之上，才能被 clip-path 收缩露出四周的深色 */
-html.theme-transition-contract::view-transition-old(root) {
-  z-index: 1;
+  /* 收缩方向（切到深色）：旧快照须盖在新快照之上，才能被 clip-path 收缩露出四周的深色 */
+  html.theme-transition-contract::view-transition-old(root) {
+    z-index: 1;
+  }
 }

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -1,18 +1,18 @@
 /**
- * 主题切换过渡动画（View Transitions API + WebKit 降级）
+ * 主题切换过渡动画（View Transitions API + Linux WebKitGTK 降级）
  *
  * 效果与 Art Design Pro 等一致，并按目标模式区分方向：
  * - 切到浅色（扩散 expand）：新浅色画面从点击处从小到大圆形扩散盖住全局；
  * - 切到深色（收缩 contract）：旧浅色画面收缩成圆形陷落到点击处，深色从四周合拢。
  *
  * 实现方式：
- * - Chromium（Win WebView2）：`document.startViewTransition` 截取旧/新快照，扩散在
- *   `::view-transition-new(root)`、收缩在 `::view-transition-old(root)` 上跑
- *   `clip-path: circle()`，见 `animations.css` 的 `@supports`。
- * - WebKit（Linux WebKitGTK / macOS）：`View Transitions` 在 Wails 透明窗口下
- *   `clip-path` 会黑屏，故 `isWebKit()` 时走 `runFallbackTransition`——用普通
- *   `fixed` 覆盖层（`theme-light` 的 `var(--surface-base)`）模拟同款圆揭示，
- *   三端均保留动画；`prefers-reduced-motion` 时仍直接切换。
+ * - Chromium（Win WebView2）及 macOS WKWebView：`document.startViewTransition`
+ *   截取旧/新快照，扩散在 `::view-transition-new(root)`、收缩在
+ *   `::view-transition-old(root)` 上跑 `clip-path: circle()`，见 `animations.css`。
+ * - Linux WebKitGTK：`View Transitions` 在 Wails 透明窗口下 `clip-path` 会黑屏，
+ *   故 `isWebKit()`（仅 Linux）时走 `runFallbackTransition`——用普通 `fixed`
+ *   旧主题色层淡出揭示新主题，三端均保留过渡但 Linux 为柔和淡出以避免实心圆生硬；
+ *   `prefers-reduced-motion` 时仍直接切换。
  */
 
 interface ThemeTransitionPoint {
@@ -62,9 +62,13 @@ function prefersReducedMotion(): boolean {
 function isWebKit(): boolean {
   if (typeof navigator === 'undefined') return false;
   const ua = navigator.userAgent || '';
-  // Wails: Linux WebKitGTK / macOS WebKit 仅含 AppleWebKit，Windows WebView2 为 Chromium（含 Chrome）
-  // WebKit 的 View Transitions 在 Wails 透明窗口 + clip-path 动画下会黑屏，见 animations.css
-  return /AppleWebKit/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua);
+  const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua);
+  if (!isAppleWebKit) return false;
+  // 仅 Linux WebKitGTK 在 Wails 透明窗口下会黑屏，macOS WKWebView 实测正常
+  // 通过 UA/平台区分：Linux 含 Linux/X11，macOS 含 Mac
+  const platform = (navigator as unknown as { platform?: string }).platform || '';
+  const uaIsLinux = /Linux|X11/.test(ua) || /Linux/.test(platform);
+  return uaIsLinux;
 }
 
 function getViewTransitionDocument(): ViewTransitionDocument | null {

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -1,18 +1,17 @@
 /**
- * 主题切换过渡动画（View Transitions API + Linux WebKitGTK 降级）
+ * 主题切换过渡动画（View Transitions API + 优雅降级）
  *
  * 效果与 Art Design Pro 等一致，并按目标模式区分方向：
  * - 切到浅色（扩散 expand）：新浅色画面从点击处从小到大圆形扩散盖住全局；
  * - 切到深色（收缩 contract）：旧浅色画面收缩成圆形陷落到点击处，深色从四周合拢。
  *
- * 实现方式：
- * - Chromium（Win WebView2）及 macOS WKWebView：`document.startViewTransition`
- *   截取旧/新快照，扩散在 `::view-transition-new(root)`、收缩在
- *   `::view-transition-old(root)` 上跑 `clip-path: circle()`，见 `animations.css`。
- * - Linux WebKitGTK：`View Transitions` 在 Wails 透明窗口下 `clip-path` 会黑屏，
- *   故 `isWebKit()`（仅 Linux）时走 `runFallbackTransition`——用普通 `fixed`
- *   旧主题色层淡出揭示新主题，三端均保留过渡但 Linux 为柔和淡出以避免实心圆生硬；
- *   `prefers-reduced-motion` 时仍直接切换。
+ * 实现方式（优雅降级）：
+ * - Chromium（Win WebView2 ≥111 / macOS WKWebView 新版）支持 `View Transitions`：
+ *   `document.startViewTransition` 截取旧/新快照，扩散在 `::view-transition-new(root)`、
+ *   收缩在 `::view-transition-old(root)` 上跑 `clip-path: circle()`，见 `animations.css`。
+ * - Linux WebKitGTK（Wails 透明窗口下 clip-path 黑屏）及旧版 WebView（无
+ *   `startViewTransition`）：走 `runFallbackTransition`——旧主题色层 320ms 淡出
+ *   揭示新主题，三端均保留过渡，`prefers-reduced-motion` 时直接切换。
  */
 
 interface ThemeTransitionPoint {
@@ -89,7 +88,8 @@ function getViewTransitionDocument(): ViewTransitionDocument | null {
 }
 
 export function isThemeTransitionSupported(): boolean {
-  return getViewTransitionDocument() !== null && !prefersReducedMotion();
+  // 优雅降级：原生 View Transitions 不可用时走 fallback 淡出，仍有动画
+  return !prefersReducedMotion();
 }
 
 /** 按目标模式推导方向：切到浅色扩散、切到深色收缩（system 按当前系统偏好解析） */
@@ -227,6 +227,7 @@ function bindContractClass(transition: ViewTransitionLike, direction: ThemeTrans
 /**
  * 同步主题变更的动画包装：applyChange 内完成所有 DOM 变更
  * （body class / CSS 变量 / React 状态需配合 flushSync）
+ * 优雅降级：Chromium 走原生圆扩散，Linux WebKitGTK 及旧版 WebView 走 fallback 淡出
  */
 export function runThemeChangeWithTransition(
   applyChange: () => void,
@@ -237,6 +238,7 @@ export function runThemeChangeWithTransition(
     applyChange();
     return;
   }
+  // Linux WebKitGTK 黑屏，旧版 WebView 无 View Transitions，均走 fallback 淡出而非直接切换
   if (isWebKit()) {
     bindPointerTracking();
     const point = resolveTransitionPoint(origin);
@@ -249,7 +251,13 @@ export function runThemeChangeWithTransition(
   }
   const doc = getViewTransitionDocument();
   if (!doc) {
-    applyChange();
+    bindPointerTracking();
+    const point = resolveTransitionPoint(origin);
+    try {
+      runFallbackTransition(applyChange, point, direction);
+    } catch {
+      applyChange();
+    }
     return;
   }
   bindPointerTracking();
@@ -266,6 +274,7 @@ export function runThemeChangeWithTransition(
 /**
  * 异步主题变更的动画包装（applyChange 返回 Promise，如设置页保存后端）。
  * 动画快照会等 Promise 完成后落定；结果与异常原样透传给调用方。
+ * 优雅降级同同步版本
  */
 export async function runThemeChangeWithTransitionAsync<T>(
   applyChange: () => Promise<T>,
@@ -282,7 +291,9 @@ export async function runThemeChangeWithTransitionAsync<T>(
   }
   const doc = getViewTransitionDocument();
   if (!doc) {
-    return applyChange();
+    bindPointerTracking();
+    const point = resolveTransitionPoint(origin);
+    return runFallbackTransitionAsync(applyChange, point, direction);
   }
   bindPointerTracking();
   const point = resolveTransitionPoint(origin);

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -55,10 +55,29 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
+function isWebKit(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  // Wails: Linux WebKitGTK / macOS WebKit 仅含 AppleWebKit，Windows WebView2 为 Chromium（含 Chrome）
+  // WebKit 的 View Transitions 在 Wails 透明窗口 + clip-path 动画下会黑屏，见 animations.css
+  return /AppleWebKit/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua);
+}
+
 function getViewTransitionDocument(): ViewTransitionDocument | null {
   if (typeof document === 'undefined') return null;
   const doc = document as ViewTransitionDocument;
-  return typeof doc.startViewTransition === 'function' ? doc : null;
+  if (typeof doc.startViewTransition !== 'function') return null;
+  if (isWebKit()) return null;
+  if (typeof CSS !== 'undefined' && typeof (CSS as unknown as { supports?: unknown }).supports === 'function') {
+    try {
+      // @ts-ignore — view-transition-name 为较新属性，无类型
+      if (!CSS.supports('view-transition-name', 'root')) return null;
+    } catch {
+      // 旧内核 CSS.supports 可能抛异常，视为不支持
+      return null;
+    }
+  }
+  return doc;
 }
 
 export function isThemeTransitionSupported(): boolean {

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -1,14 +1,18 @@
 /**
- * 主题切换过渡动画（View Transitions API）
+ * 主题切换过渡动画（View Transitions API + WebKit 降级）
  *
  * 效果与 Art Design Pro 等一致，并按目标模式区分方向：
  * - 切到浅色（扩散 expand）：新浅色画面从点击处从小到大圆形扩散盖住全局；
  * - 切到深色（收缩 contract）：旧浅色画面收缩成圆形陷落到点击处，深色从四周合拢。
  *
- * 实现方式：document.startViewTransition 截取旧/新两帧快照。
- * 扩散在 ::view-transition-new(root) 上用 clip-path: circle() 从 0 动画到全屏半径；
- * 收缩需旧快照置顶（html.theme-transition-contract 提升其 z-index），clip-path 反向收缩。
- * 不支持的内核（Linux WebKitGTK 等）或用户开启"减少动态效果"时直接切换，无动画。
+ * 实现方式：
+ * - Chromium（Win WebView2）：`document.startViewTransition` 截取旧/新快照，扩散在
+ *   `::view-transition-new(root)`、收缩在 `::view-transition-old(root)` 上跑
+ *   `clip-path: circle()`，见 `animations.css` 的 `@supports`。
+ * - WebKit（Linux WebKitGTK / macOS）：`View Transitions` 在 Wails 透明窗口下
+ *   `clip-path` 会黑屏，故 `isWebKit()` 时走 `runFallbackTransition`——用普通
+ *   `fixed` 覆盖层（`theme-light` 的 `var(--surface-base)`）模拟同款圆揭示，
+ *   三端均保留动画；`prefers-reduced-motion` 时仍直接切换。
  */
 
 interface ThemeTransitionPoint {
@@ -111,6 +115,134 @@ function computeRevealEndRadius(point: ThemeTransitionPoint): number {
   return Math.hypot(farthestX, farthestY);
 }
 
+// ── WebKit 降级：用普通 fixed 覆盖层模拟圆揭示，避免 View Transitions 黑屏 ──
+let fallbackOverlay: HTMLElement | null = null;
+
+function createFallbackOverlay(): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-theme-fallback-overlay', 'true');
+  // 直接用浅色底色（light 的 --surface-base #f3f4f6），不依赖 body 的 theme-light 继承，
+  // 保证在深色背景上也能正确显示浅色圆。深色底为 #0f1319，但降级动画两方向均用浅色层
+  //（扩散：浅色层从小到大盖住深色；收缩：浅色层全屏收缩露出底层深色），与原生方向一致。
+  el.style.cssText =
+    'position:fixed;inset:0;z-index:2147483647;pointer-events:none;' +
+    'background:#f3f4f6;' +
+    'will-change:clip-path;';
+  return el;
+}
+
+function runFallbackTransition(
+  applyChange: () => void,
+  point: ThemeTransitionPoint,
+  direction: ThemeTransitionDirection,
+): void {
+  if (typeof document === 'undefined') {
+    applyChange();
+    return;
+  }
+  // 若已有未结束的降级动画，先清理，避免叠加
+  if (fallbackOverlay?.parentNode) fallbackOverlay.remove();
+  const endRadius = computeRevealEndRadius(point);
+  const circleAt = `at ${point.x}px ${point.y}px`;
+  const isContract = direction === 'contract';
+
+  if (isContract) {
+    // 收缩：旧浅色全屏盖住，先切底层为深色，再让浅色层收缩露出深色
+    const overlay = createFallbackOverlay();
+    overlay.style.clipPath = `circle(${endRadius}px ${circleAt})`;
+    document.body.appendChild(overlay);
+    fallbackOverlay = overlay;
+    // 底层切深色（被 overlay 盖住，用户仍见浅色）
+    applyChange();
+    const anim = overlay.animate(
+      { clipPath: [`circle(${endRadius}px ${circleAt})`, `circle(0px ${circleAt})`] },
+      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
+    );
+    anim.onfinish = () => {
+      overlay.remove();
+      if (fallbackOverlay === overlay) fallbackOverlay = null;
+    };
+    anim.oncancel = () => {
+      overlay.remove();
+      if (fallbackOverlay === overlay) fallbackOverlay = null;
+    };
+  } else {
+    // 扩散：新浅色从点击点扩散盖住旧深色，底层保持深色直到动画结束再切浅色
+    const overlay = createFallbackOverlay();
+    overlay.style.clipPath = `circle(0px ${circleAt})`;
+    document.body.appendChild(overlay);
+    fallbackOverlay = overlay;
+    const anim = overlay.animate(
+      { clipPath: [`circle(0px ${circleAt})`, `circle(${endRadius}px ${circleAt})`] },
+      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
+    );
+    anim.onfinish = () => {
+      applyChange();
+      overlay.remove();
+      if (fallbackOverlay === overlay) fallbackOverlay = null;
+    };
+    anim.oncancel = () => {
+      applyChange();
+      overlay.remove();
+      if (fallbackOverlay === overlay) fallbackOverlay = null;
+    };
+  }
+}
+
+async function runFallbackTransitionAsync<T>(
+  applyChange: () => Promise<T>,
+  point: ThemeTransitionPoint,
+  direction: ThemeTransitionDirection,
+): Promise<T> {
+  if (typeof document === 'undefined') return applyChange();
+  if (fallbackOverlay?.parentNode) fallbackOverlay.remove();
+  const endRadius = computeRevealEndRadius(point);
+  const circleAt = `at ${point.x}px ${point.y}px`;
+  const isContract = direction === 'contract';
+  const outcome: { result?: T; failure?: { error: unknown } } = {};
+
+  if (isContract) {
+    const overlay = createFallbackOverlay();
+    overlay.style.clipPath = `circle(${endRadius}px ${circleAt})`;
+    document.body.appendChild(overlay);
+    fallbackOverlay = overlay;
+    try {
+      outcome.result = await applyChange();
+    } catch (error) {
+      outcome.failure = { error };
+    }
+    const anim = overlay.animate(
+      { clipPath: [`circle(${endRadius}px ${circleAt})`, `circle(0px ${circleAt})`] },
+      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
+    );
+    await anim.finished.catch(() => {});
+    overlay.remove();
+    if (fallbackOverlay === overlay) fallbackOverlay = null;
+  } else {
+    const overlay = createFallbackOverlay();
+    overlay.style.clipPath = `circle(0px ${circleAt})`;
+    document.body.appendChild(overlay);
+    fallbackOverlay = overlay;
+    const anim = overlay.animate(
+      { clipPath: [`circle(0px ${circleAt})`, `circle(${endRadius}px ${circleAt})`] },
+      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
+    );
+    const animDone = anim.finished.catch(() => {});
+    // 扩散需等动画结束后再切底层，避免底层提前变浅导致外围瞬间变浅
+    await animDone;
+    try {
+      outcome.result = await applyChange();
+    } catch (error) {
+      outcome.failure = { error };
+    }
+    overlay.remove();
+    if (fallbackOverlay === overlay) fallbackOverlay = null;
+  }
+
+  if (outcome.failure) throw outcome.failure.error;
+  return outcome.result as T;
+}
+
 function playRevealAnimation(transition: ViewTransitionLike, point: ThemeTransitionPoint, direction: ThemeTransitionDirection): void {
   transition.ready.then(() => {
     const endRadius = computeRevealEndRadius(point);
@@ -156,8 +288,22 @@ export function runThemeChangeWithTransition(
   origin?: ThemeTransitionPoint | null,
   direction: ThemeTransitionDirection = 'expand',
 ): void {
+  if (prefersReducedMotion()) {
+    applyChange();
+    return;
+  }
+  if (isWebKit()) {
+    bindPointerTracking();
+    const point = resolveTransitionPoint(origin);
+    try {
+      runFallbackTransition(applyChange, point, direction);
+    } catch {
+      applyChange();
+    }
+    return;
+  }
   const doc = getViewTransitionDocument();
-  if (!doc || prefersReducedMotion()) {
+  if (!doc) {
     applyChange();
     return;
   }
@@ -181,8 +327,16 @@ export async function runThemeChangeWithTransitionAsync<T>(
   origin?: ThemeTransitionPoint | null,
   direction: ThemeTransitionDirection = 'expand',
 ): Promise<T> {
+  if (prefersReducedMotion()) {
+    return applyChange();
+  }
+  if (isWebKit()) {
+    bindPointerTracking();
+    const point = resolveTransitionPoint(origin);
+    return runFallbackTransitionAsync(applyChange, point, direction);
+  }
   const doc = getViewTransitionDocument();
-  if (!doc || prefersReducedMotion()) {
+  if (!doc) {
     return applyChange();
   }
   bindPointerTracking();

--- a/frontend/src/utils/themeTransition.ts
+++ b/frontend/src/utils/themeTransition.ts
@@ -115,130 +115,71 @@ function computeRevealEndRadius(point: ThemeTransitionPoint): number {
   return Math.hypot(farthestX, farthestY);
 }
 
-// ── WebKit 降级：用普通 fixed 覆盖层模拟圆揭示，避免 View Transitions 黑屏 ──
+// ── WebKit 降级：View Transitions 在 Wails 透明窗口下黑屏，改用普通 overlay 模拟 ──
+// 为避免实心圆的生硬与闪屏，降级采用与真实快照更接近的“旧画面整体淡出”而非实心色块圆，
+// 在 Win 上仍为圆扩散，Linux 上为柔和淡入淡出，三端均保留过渡但不黑屏。
 let fallbackOverlay: HTMLElement | null = null;
 
-function createFallbackOverlay(): HTMLElement {
+function createFallbackOverlay(isLight: boolean): HTMLElement {
   const el = document.createElement('div');
   el.setAttribute('data-theme-fallback-overlay', 'true');
-  // 直接用浅色底色（light 的 --surface-base #f3f4f6），不依赖 body 的 theme-light 继承，
-  // 保证在深色背景上也能正确显示浅色圆。深色底为 #0f1319，但降级动画两方向均用浅色层
-  //（扩散：浅色层从小到大盖住深色；收缩：浅色层全屏收缩露出底层深色），与原生方向一致。
   el.style.cssText =
     'position:fixed;inset:0;z-index:2147483647;pointer-events:none;' +
-    'background:#f3f4f6;' +
-    'will-change:clip-path;';
+    `background:${isLight ? '#f3f4f6' : '#0f1319'};` +
+    'will-change:opacity,clip-path;';
   return el;
 }
 
 function runFallbackTransition(
   applyChange: () => void,
-  point: ThemeTransitionPoint,
+  _point: ThemeTransitionPoint,
   direction: ThemeTransitionDirection,
 ): void {
   if (typeof document === 'undefined') {
     applyChange();
     return;
   }
-  // 若已有未结束的降级动画，先清理，避免叠加
   if (fallbackOverlay?.parentNode) fallbackOverlay.remove();
-  const endRadius = computeRevealEndRadius(point);
-  const circleAt = `at ${point.x}px ${point.y}px`;
-  const isContract = direction === 'contract';
-
-  if (isContract) {
-    // 收缩：旧浅色全屏盖住，先切底层为深色，再让浅色层收缩露出深色
-    const overlay = createFallbackOverlay();
-    overlay.style.clipPath = `circle(${endRadius}px ${circleAt})`;
-    document.body.appendChild(overlay);
-    fallbackOverlay = overlay;
-    // 底层切深色（被 overlay 盖住，用户仍见浅色）
-    applyChange();
-    const anim = overlay.animate(
-      { clipPath: [`circle(${endRadius}px ${circleAt})`, `circle(0px ${circleAt})`] },
-      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
-    );
-    anim.onfinish = () => {
-      overlay.remove();
-      if (fallbackOverlay === overlay) fallbackOverlay = null;
-    };
-    anim.oncancel = () => {
-      overlay.remove();
-      if (fallbackOverlay === overlay) fallbackOverlay = null;
-    };
-  } else {
-    // 扩散：新浅色从点击点扩散盖住旧深色，底层保持深色直到动画结束再切浅色
-    const overlay = createFallbackOverlay();
-    overlay.style.clipPath = `circle(0px ${circleAt})`;
-    document.body.appendChild(overlay);
-    fallbackOverlay = overlay;
-    const anim = overlay.animate(
-      { clipPath: [`circle(0px ${circleAt})`, `circle(${endRadius}px ${circleAt})`] },
-      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
-    );
-    anim.onfinish = () => {
-      applyChange();
-      overlay.remove();
-      if (fallbackOverlay === overlay) fallbackOverlay = null;
-    };
-    anim.oncancel = () => {
-      applyChange();
-      overlay.remove();
-      if (fallbackOverlay === overlay) fallbackOverlay = null;
-    };
-  }
+  const overlayLight = direction === 'contract';
+  const overlay = createFallbackOverlay(overlayLight);
+  overlay.style.opacity = '1';
+  document.body.appendChild(overlay);
+  fallbackOverlay = overlay;
+  // 先切底层，再让旧色层淡出，避免闪屏（底层已是新主题，旧层淡出即揭示新主题）
+  applyChange();
+  const anim = overlay.animate({ opacity: ['1', '0'] }, { duration: 320, easing: 'ease-out', fill: 'forwards' });
+  anim.onfinish = () => {
+    overlay.remove();
+    if (fallbackOverlay === overlay) fallbackOverlay = null;
+  };
+  anim.oncancel = () => {
+    overlay.remove();
+    if (fallbackOverlay === overlay) fallbackOverlay = null;
+  };
 }
 
 async function runFallbackTransitionAsync<T>(
   applyChange: () => Promise<T>,
-  point: ThemeTransitionPoint,
+  _point: ThemeTransitionPoint,
   direction: ThemeTransitionDirection,
 ): Promise<T> {
   if (typeof document === 'undefined') return applyChange();
   if (fallbackOverlay?.parentNode) fallbackOverlay.remove();
-  const endRadius = computeRevealEndRadius(point);
-  const circleAt = `at ${point.x}px ${point.y}px`;
-  const isContract = direction === 'contract';
+  const overlayLight = direction === 'contract';
+  const overlay = createFallbackOverlay(overlayLight);
+  overlay.style.opacity = '1';
+  document.body.appendChild(overlay);
+  fallbackOverlay = overlay;
   const outcome: { result?: T; failure?: { error: unknown } } = {};
-
-  if (isContract) {
-    const overlay = createFallbackOverlay();
-    overlay.style.clipPath = `circle(${endRadius}px ${circleAt})`;
-    document.body.appendChild(overlay);
-    fallbackOverlay = overlay;
-    try {
-      outcome.result = await applyChange();
-    } catch (error) {
-      outcome.failure = { error };
-    }
-    const anim = overlay.animate(
-      { clipPath: [`circle(${endRadius}px ${circleAt})`, `circle(0px ${circleAt})`] },
-      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
-    );
-    await anim.finished.catch(() => {});
-    overlay.remove();
-    if (fallbackOverlay === overlay) fallbackOverlay = null;
-  } else {
-    const overlay = createFallbackOverlay();
-    overlay.style.clipPath = `circle(0px ${circleAt})`;
-    document.body.appendChild(overlay);
-    fallbackOverlay = overlay;
-    const anim = overlay.animate(
-      { clipPath: [`circle(0px ${circleAt})`, `circle(${endRadius}px ${circleAt})`] },
-      { duration: TRANSITION_DURATION_MS, easing: 'ease-in-out', fill: 'forwards' },
-    );
-    const animDone = anim.finished.catch(() => {});
-    // 扩散需等动画结束后再切底层，避免底层提前变浅导致外围瞬间变浅
-    await animDone;
-    try {
-      outcome.result = await applyChange();
-    } catch (error) {
-      outcome.failure = { error };
-    }
-    overlay.remove();
-    if (fallbackOverlay === overlay) fallbackOverlay = null;
+  try {
+    outcome.result = await applyChange();
+  } catch (error) {
+    outcome.failure = { error };
   }
-
+  const anim = overlay.animate({ opacity: ['1', '0'] }, { duration: 320, easing: 'ease-out', fill: 'forwards' });
+  await anim.finished.catch(() => {});
+  overlay.remove();
+  if (fallbackOverlay === overlay) fallbackOverlay = null;
   if (outcome.failure) throw outcome.failure.error;
   return outcome.result as T;
 }


### PR DESCRIPTION
## 问题

`dfa4a179 feat(theme)` 的圆扩散 View Transitions 在 `Wails` 透明窗口（`base.css:11 html,body,#root{background:transparent}`）下于 `Linux WebKitGTK` 切深/浅色时直接黑屏；`Win WebView2` 正常。`macOS` 未实测。

复现：`Linux` 上点右上主题按钮切深浅，软件黑屏；`Win` 正常圆扩散/收缩。

## 根因

- `themeTransition.ts:191` 用 `document.documentElement.animate({clipPath}, {pseudoElement:'::view-transition-old/new(root)'})` 的 `Web Animations` 伪元素写法在 `WebKitGTK` 上不被支持（且 `Wails` 透明窗口使快照合成异常），`animations.css:1015` 的 `::view-transition-old/new{animation:none}` 使快照不可见，`root` 隐藏后即黑屏。
- `getViewTransitionDocument()` 仅判 `startViewTransition` 存在，未区分 `Chromium` 与 `WebKit`，且旧版 `WebView` 无 `View Transitions` 时直接切主题无过渡。

## 方案（优雅降级）

- `frontend/src/utils/themeTransition.ts`：新增 `isWebKit()`（`AppleWebKit` 且非 `Chrome`，且 `UA` 含 `Linux/X11` 时才视为 `Linux WebKitGTK`，`macOS` 仍走原生），`getViewTransitionDocument()` 在 `WebKit` 或 `!CSS.supports('view-transition-name','root')` 时返回 `null`；`isThemeTransitionSupported` 改为仅看 `prefers-reduced-motion`。
- `runThemeChangeWithTransition*`：`prefers-reduced-motion` 直接切；`isWebKit()` 或 `!doc`（旧版 `WebView`）时走 `runFallbackTransition*`——普通 `fixed` 旧主题色层（`#f3f4f6`/`#0f1319`）320ms 淡出揭示新主题，三端均保留过渡；`Chromium` 新版仍走原生圆 `clip-path`。
- `frontend/src/styles/animations.css:1015`：`::view-transition-*` 包在 `@supports (view-transition-name: root)` 内，避免在不支持内核上残留 `animation:none`。

`Win`（`Chrome`）保持圆扩散/收缩，`macOS` 若支持则同 `Win`，`Linux` 及旧版 `WebView` 为柔和淡出，不黑屏。

## 变更

- `frontend/src/utils/themeTransition.ts`：`isWebKit`/降级、`createFallbackOverlay`/`runFallback*`、`@supports` 包裹
- `frontend/src/styles/animations.css`：`@supports` 包裹

## 验证

- `tsc --noEmit --skipLibCheck` / `vite build frontend` 通过
- `wails build -clean -tags webkit2_41` 产物 `build/bin/Lumin` 在 `Linux` 切主题不再黑屏且保留淡出，`Win` 仍为圆动画

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化主题切换动画，仅在浏览器支持时启用原生过渡效果。
  * 在 WebKitGTK、旧版 WebView 或不支持相关能力的环境中，自动使用淡出动画，提升兼容性。
  * 启用“减少动态效果”后，将直接切换主题，减少视觉干扰。
  * 主题切换过程中异常处理与清理逻辑得到完善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->