### PR TITLE
fix(ui): 修复对话框遮罩打开时窗口无法从顶栏拖动

### DIFF
--- a/frontend/src/components/GlobalDialog.tsx
+++ b/frontend/src/components/GlobalDialog.tsx
@@ -10,6 +10,7 @@ import {
   type QueuedDialog,
 } from './globalDialog/globalDialogTypes.ts';
 import { DialogContent } from './globalDialog/DialogContent.tsx';
+import { ModalDragStrip } from './ui';
 
 interface GlobalDialogProps {
   suspendDefault?: boolean;
@@ -130,6 +131,7 @@ export default function GlobalDialog({ suspendDefault = false }: GlobalDialogPro
       data-global-dialog-active={currentSuspended ? undefined : 'true'}
       style={{ zIndex: dialogZIndex, display: currentSuspended ? 'none' : 'flex', isolation: 'isolate' as const }}
     >
+      <ModalDragStrip />
       {dialogs.map((dialog, index) => {
         const dialogActive = index === 0 && !(suspendDefault && dialog.priority === DIALOG_PRIORITY.default);
         const handleClose = () => {

--- a/frontend/src/components/SerialConfigModal.tsx
+++ b/frontend/src/components/SerialConfigModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { X, Cpu } from 'lucide-react';
 import * as AppGo from '../../wailsjs/go/wailsapp/App.js';
 import { useTranslation } from '../i18n.ts';
-import { Button, Select } from './ui';
+import { Button, Select, ModalDragStrip } from './ui';
 import { useOverlayScrollLock } from '../hooks/useOverlayScrollLock.ts';
 
 /** 串口连接配置（与 App.ConnectSerial 的参数对应） */
@@ -74,6 +74,7 @@ export default function SerialConfigModal({ onClose, onConnect }: SerialConfigMo
         if (e.target === e.currentTarget) onClose();
       }}
     >
+      <ModalDragStrip />
       <div className="modal modal-sm" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 className="modal-title">

--- a/frontend/src/components/ai/AIProviderQuickEditOverlay.tsx
+++ b/frontend/src/components/ai/AIProviderQuickEditOverlay.tsx
@@ -108,6 +108,8 @@ export default function AIProviderQuickEditOverlay({
     <div
       onClick={onClose}
       data-modal-overlay="true"
+      // zIndex 必须低于 Z.TOPBAR(1000)：本遮罩可能盖住顶栏却无 ModalDragStrip，
+      // 一旦压过顶栏，遮罩打开时窗口将无法从顶栏拖动（Wails 按 mousedown 目标判定）
       style={{
         top: panelBounds?.top ?? 0,
         left: panelBounds?.left ?? 0,

--- a/frontend/src/components/filemanager/ChmodDialog.tsx
+++ b/frontend/src/components/filemanager/ChmodDialog.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { Lock } from 'lucide-react';
 import { Z } from '../../constants/zIndex.ts';
 import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
-import { Button } from '../ui';
+import { Button, ModalDragStrip } from '../ui';
 import {
   buildIdentityOptionList,
   calcChmodOctal,
@@ -110,6 +110,7 @@ export default function ChmodDialog({ path, permission, mode, rememberedMode = '
   }
   return createPortal(
     <div className="modal-overlay" data-modal-overlay="true" style={{ zIndex: Z.MODAL, isolation: 'isolate' as const }}>
+      <ModalDragStrip />
       <div className="modal modal-sm">
         <div className="modal-header">
           <div className="modal-title"><Lock size={14} /> {t('修改权限')}</div>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react';
 import { t } from '../../i18n.ts';
 import { Z } from '../../constants/zIndex.ts';
 import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
+import { ModalDragStrip } from './ModalDragStrip.tsx';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
 
@@ -79,6 +80,7 @@ export function Modal({
         if (closeOnOverlay && e.target === e.currentTarget) onClose();
       }}
     >
+      <ModalDragStrip />
       <div
         className={`relative w-full overflow-y-auto bg-raised border border-line rounded-[var(--radius-lg)] shadow-xl animate-[slideUp_0.12s_ease] ${align === 'top' ? '' : 'max-h-[90vh]'} ${SIZE_CLASS[size]} ${panelClassName}`}
         style={panelStyle}

--- a/frontend/src/components/ui/ModalDragStrip.tsx
+++ b/frontend/src/components/ui/ModalDragStrip.tsx
@@ -1,0 +1,16 @@
+import type { MouseEvent } from 'react';
+import { toggleWindowMaximise } from '../../hooks/useWindowState.ts';
+
+// 模态遮罩会盖住顶栏，Wails 的拖动判定取 mousedown 目标元素（即遮罩）的
+// 计算样式，导致遮罩打开时窗口无法从顶栏拖动；这条透明热区把拖动能力
+// 还给顶栏同高区域。必须是真实 DOM 元素——伪元素不会成为事件 target。
+// 双击行为与顶栏一致（切换最大化），保持遮罩打开前后手感相同。
+const handleDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
+  try { window.getSelection?.()?.removeAllRanges?.(); } catch { }
+  event.preventDefault();
+  void toggleWindowMaximise();
+};
+
+export function ModalDragStrip() {
+  return <div className="modal-drag-strip" aria-hidden="true" onDoubleClick={handleDoubleClick} />;
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from './Button.tsx';
 export { Modal, type ModalProps, type ModalSize } from './Modal.tsx';
+export { ModalDragStrip } from './ModalDragStrip.tsx';
 export { EmptyState, type EmptyStateProps } from './EmptyState.tsx';
 export {
   ContextMenu,

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -52,6 +52,9 @@ import { useLayoutEffect } from 'react';
  *
  * @rules
  * - 已使用 `ui/Modal` 的组件无需再调用，`Modal.tsx:65` 已内置。
+ * - 全屏遮罩会盖住顶栏导致窗口无法拖动：新的全屏弹层（`.modal-overlay` 或
+ *   `fixed inset-0` 的模态类遮罩）首个子节点需放 `<ModalDragStrip />`
+ *   （见 `ui/ModalDragStrip.tsx`），恢复遮罩打开时的顶栏拖动/双击最大化。
  * - 任何新写的 `fixed/inset-0` 覆盖层（即使很小如 `Select` 下拉、`ContextMenu`）
  *   若可能盖在可滚动内容（文件管理器的 Virtuoso、首页主机列表、探针面板等）之上，
  *   均应调用 `useOverlayScrollLock(open)` 并 `portal` 到 `body`。

--- a/frontend/src/hooks/useWindowState.ts
+++ b/frontend/src/hooks/useWindowState.ts
@@ -69,6 +69,21 @@ function isOverNativeScrollbar(e: MouseEvent, el: HTMLElement): boolean {
   return el.clientLeft > 1 && e.clientX <= rect.left + el.clientLeft;
 }
 
+/** 双击顶栏/遮罩拖动条切换最大化：记住还原尺寸 → 切换 → 刷新共享最大化状态 */
+export async function toggleWindowMaximise(): Promise<void> {
+  try {
+    if (shouldRememberWindowSize()) {
+      const [size, maximized] = await Promise.all([WindowGetSize(), WindowIsMaximised()]);
+      if (!maximized && size?.w > 100 && size?.h > 100) {
+        localStorage.setItem('windowSize', JSON.stringify({ w: size.w, h: size.h, maximized: true }));
+      }
+    }
+  } catch { }
+  WindowToggleMaximise();
+  // 切换后稍候刷新共享最大化状态，驱动 enableResize 同步与热区层显隐
+  setTimeout(() => refreshWindowMaximized(), 100);
+}
+
 export default function useWindowState(): () => Promise<void> {
   // 最大化状态来自共享单例轮询，避免多处各自 setInterval 调 Wails IPC
   const maximized = useIsWindowMaximized();
@@ -207,19 +222,7 @@ export default function useWindowState(): () => Promise<void> {
     };
   }, []);
 
-  return useCallback(async () => {
-    try {
-      if (shouldRememberWindowSize()) {
-        const [size, maximized] = await Promise.all([WindowGetSize(), WindowIsMaximised()]);
-        if (!maximized && size?.w > 100 && size?.h > 100) {
-          localStorage.setItem('windowSize', JSON.stringify({ w: size.w, h: size.h, maximized: true }));
-        }
-      }
-    } catch { }
-    WindowToggleMaximise();
-    // 切换后稍候刷新共享最大化状态，驱动 enableResize 同步与热区层显隐
-    setTimeout(() => refreshWindowMaximized(), 100);
-  }, []);
+  return useCallback(() => toggleWindowMaximise(), []);
 }
 
 function shouldRememberWindowSize(): boolean {

--- a/frontend/src/styles/components/common.css
+++ b/frontend/src/styles/components/common.css
@@ -101,6 +101,18 @@ select option {
   animation: fadeIn 0.12s ease;
 }
 
+/* 模态遮罩会盖住顶栏，而 Wails 按 mousedown 目标元素上的 --wails-draggable
+   判定能否拖动窗口；在遮罩顶部放一条与顶栏同高的透明热区，让遮罩打开时
+   仍能从顶栏区域拖动窗口。必须是真实元素——伪元素不会成为事件 target。 */
+.modal-drag-strip {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--topbar-h, 40px);
+  --wails-draggable: drag;
+}
+
 .modal {
   background: var(--surface-raised);
   border: 1px solid var(--border);


### PR DESCRIPTION
## 问题

设置、关闭确认等对话框打开后，全屏遮罩会盖住顶栏，此时无法再通过按住顶栏区域拖动窗口（以前可以）。

## 根因

Wails 在 `mousedown` 时取**鼠标下最顶层元素**的计算样式判断 `--wails-draggable === "drag"`（见 Wails runtime `desktop/main.js` 的 `dragTest`）：

- 顶栏 `.topbar`（z-index 1000）带有 `--wails-draggable: drag`；
- 模态遮罩是 `fixed inset-0`、z-index 35000+ 且 portal 到 `body` 的元素，打开后成为鼠标下的目标元素，而它没有 drag 属性，导致拖动失效。

## 修复方案

在遮罩顶部放置一条与顶栏同高（`var(--topbar-h)`）的透明「拖动热区」`.modal-drag-strip`，带 `--wails-draggable: drag`：

- **必须是真实 DOM 元素**——Wails 的 `e.target` 永远不会是伪元素；
- 遮罩点击关闭不受影响（scrim 关闭逻辑判断 `e.target === e.currentTarget`，热区不会命中）；
- 对话框面板是后续的定位兄弟节点，任何重叠区域事件仍落在面板上，面板内交互、文字选择不受影响；
- 热区双击切换最大化，与顶栏行为保持一致；
- 纯视觉零变化（热区全透明），遮罩样式不变。

## 改动范围

| 文件 | 改动 |
|---|---|
| `ui/ModalDragStrip.tsx`（新增） | 共享拖动热区组件，双击复用 `toggleWindowMaximise` |
| `styles/components/common.css` | `.modal-drag-strip` 样式 |
| `ui/Modal.tsx` | 接入（覆盖设置等 12+ 个模态） |
| `GlobalDialog.tsx` | 接入（关闭确认 / alert / confirm / prompt / choice） |
| `SerialConfigModal.tsx`、`ChmodDialog.tsx` | 接入 |
| `hooks/useWindowState.ts` | 抽出 `toggleWindowMaximise()` 供顶栏与拖动条复用，行为不变 |
| `hooks/useOverlayScrollLock.ts` | 约定文档补充：新增全屏遮罩需放置拖动条 |
| `ai/AIProviderQuickEditOverlay.tsx` | 防御性注释：其 zIndex 需保持低于 `Z.TOPBAR` |

已排查其余弹层（SessionListOverlay、AIProviderQuickEditOverlay、FileEditor popup、各类右键菜单等）均为面板内或 z-index 低于顶栏的浮层，不受影响，无需接入。

## 验证

- `vite build` 通过；`oxlint` 0 错误；`check-styles` 未超基线；`tsc --noEmit` 改动文件无错误
- 手动验证建议：打开设置/退出确认弹窗后按住顶栏区域可拖动窗口、双击可最大化/还原、点击遮罩仍可关闭（`closeOnOverlay` 的弹窗）、弹窗内按钮输入不受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增模态窗口顶部拖动区域，打开弹窗时仍可拖动窗口。
  * 支持双击模态窗口顶部区域切换窗口最大化状态。
  * 统一为多个弹窗提供窗口拖动与最大化交互。

* **改进**
  * 优化弹层与顶部栏的交互，避免弹窗遮挡窗口拖动操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->