### PR TITLE
fix(terminal): 修复浅色模式下连接服务器时底部命令输入框深色闪烁的问题

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -101,7 +101,7 @@ export default function Terminal({
   const { gutterRef } = gutterApi;
 
   // ── 主题/壁纸与设置事件监听 ──
-  const { T, themeToggle, bgInfo } = useTerminalTheme({ termRef, wrapperRef });
+  const { T, themeToggle, bgInfo, terminalContainerStyle } = useTerminalTheme({ termRef, wrapperRef });
   useTerminalSettingsEvents({
     ...gutterApi,
     termRef, fitAddonRef, shortcutsRef, localEchoRef, timestampsEnabledRef, commandBlocksEnabledRef,
@@ -219,6 +219,7 @@ export default function Terminal({
       ref={wrapperRef}
       onContextMenu={handleContextMenu}
       onClick={closeContextMenu}
+      style={terminalContainerStyle}
       // 主题底色 + 色调层；壁纸半透明叠在上面
       className="relative h-full flex flex-col overflow-hidden bg-[var(--term-container-bg)]"
     >

--- a/frontend/src/components/terminal/useTerminalTheme.ts
+++ b/frontend/src/components/terminal/useTerminalTheme.ts
@@ -15,6 +15,31 @@ export function useTerminalTheme(deps: {
   // ponytail: getTerminalTheme() 每次渲染调用 30+ 次，缓存为 1 次
   const T = useMemo(() => getTerminalTheme(), [themeToggle]);
 
+  // ponytail: container 颜色同步计算为 CSS 属性对象，确保挂载首帧即生效，防止浅色模式建连时深色闪烁
+  const terminalContainerStyle = useMemo<React.CSSProperties>(() => {
+    const c = T.container || {};
+    const cssVar = (value: string | undefined) => value || '';
+    return {
+      '--term-container-bg': cssVar(c.containerBg),
+      '--term-tint': c.tint || 'transparent',
+      '--term-status-bg': cssVar(c.statusBarBg),
+      '--term-status-border': cssVar(c.statusBarBorder),
+      '--term-status-color': cssVar(c.statusBarColor),
+      '--term-server-color': cssVar(c.serverNameColor),
+      '--term-input-bar-bg': cssVar(c.inputBarBg),
+      '--term-input-bar-border': cssVar(c.inputBarBorder),
+      '--term-input-bg': cssVar(c.inputBg),
+      '--term-input-color': cssVar(c.inputColor),
+      '--term-input-placeholder': c.inputPlaceholder || c.mutedColor || '',
+      '--term-btn-border': cssVar(c.btnBorder),
+      '--term-separator': cssVar(c.separator),
+      '--term-muted': cssVar(c.mutedColor),
+      '--term-context-bg': cssVar(c.contextBg),
+      '--term-context-border': cssVar(c.contextBorder),
+      '--term-context-shadow': cssVar(c.contextShadow),
+    } as React.CSSProperties;
+  }, [T]);
+
   // ── 背景管理与刷新 ─────────────────────────────────────────────────
   const [bgInfo, setBgInfo] = useState({
     image: localStorage.getItem('termBgImage') || '',
@@ -105,5 +130,5 @@ export function useTerminalTheme(deps: {
     }
   }, [T]);
 
-  return { T, themeToggle, bgInfo };
+  return { T, themeToggle, bgInfo, terminalContainerStyle };
 }

--- a/frontend/src/styles/vendor/xterm.css
+++ b/frontend/src/styles/vendor/xterm.css
@@ -14,6 +14,7 @@
 /* ── 终端容器 CSS 变量默认值（JS 主题切换时覆盖） ── */
 :root {
   --term-container-bg: #0e1218;
+  --term-tint: transparent;
   --term-status-bg: var(--surface-raised);
   --term-status-border: 1px solid var(--border-subtle);
   --term-status-color: #818fa0;
@@ -22,6 +23,7 @@
   --term-input-bar-border: 1px solid var(--border-subtle);
   --term-input-bg: var(--surface-sunken);
   --term-input-color: #eaf0f7;
+  --term-input-placeholder: #5a6578;
   --term-btn-border: rgba(77,158,255,0.1);
   --term-separator: rgba(77,158,255,0.08);
   --term-muted: #5a6578;
@@ -30,6 +32,28 @@
   --term-context-shadow: 0 8px 32px rgba(0,5,20,0.6), 0 2px 8px rgba(0,5,20,0.4);
   --term-scrollbar-thumb: rgba(140, 165, 195, 0.28);
   --term-scrollbar-thumb-hover: rgba(160, 190, 225, 0.55);
+}
+
+body.theme-light {
+  --term-container-bg: #f7f9fc;
+  --term-tint: transparent;
+  --term-status-bg: var(--surface-raised);
+  --term-status-border: 1px solid var(--border-subtle);
+  --term-status-color: #1d4ed8;
+  --term-server-color: var(--text-primary);
+  --term-input-bar-bg: var(--surface-raised);
+  --term-input-bar-border: 1px solid var(--border-subtle);
+  --term-input-bg: var(--surface-sunken);
+  --term-input-color: var(--text-primary);
+  --term-input-placeholder: var(--text-muted);
+  --term-btn-border: var(--border);
+  --term-separator: var(--border-subtle);
+  --term-muted: var(--text-muted);
+  --term-context-bg: var(--surface-overlay);
+  --term-context-border: 1px solid var(--border-subtle);
+  --term-context-shadow: 0 8px 32px rgba(28,25,23,0.12), 0 2px 8px rgba(28,25,23,0.06);
+  --term-scrollbar-thumb: rgba(100, 116, 139, 0.35);
+  --term-scrollbar-thumb-hover: rgba(71, 85, 105, 0.6);
 }
 
 /* ── 彻底消除 xterm-viewport 的原生浏览器滚动条，避免空视口常驻滚动条槽位 ── */

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -622,6 +622,23 @@ const THEME_COMPONENT_CSS_VARS = [
   '--tab-active-border',
   '--tab-active-text',
   '--tab-radius',
+  '--term-container-bg',
+  '--term-tint',
+  '--term-status-bg',
+  '--term-status-border',
+  '--term-status-color',
+  '--term-server-color',
+  '--term-input-bar-bg',
+  '--term-input-bar-border',
+  '--term-input-bg',
+  '--term-input-color',
+  '--term-input-placeholder',
+  '--term-btn-border',
+  '--term-separator',
+  '--term-muted',
+  '--term-context-bg',
+  '--term-context-border',
+  '--term-context-shadow',
 ];
 
 // 主题包 token 键（与 buildBaseThemeTokens 对齐）。切换主题前先清掉，避免旧包内联值残留盖住 CSS。
@@ -654,6 +671,8 @@ function applyComponentThemeVariables(themePackage: ThemePackage | null | undefi
   if (!target) return;
   const fileManager = getResolvedThemeComponentTheme(themePackage, 'fileManager');
   const topbar = getResolvedThemeComponentTheme(themePackage, 'topbar');
+  const terminal = getTerminalTheme();
+  const c = terminal.container || {};
   const mappings: Record<string, string | undefined> = {
     '--file-manager-panel-bg': fileManager.panelBg,
     '--file-manager-toolbar-bg': fileManager.toolbarBg,
@@ -670,6 +689,23 @@ function applyComponentThemeVariables(themePackage: ThemePackage | null | undefi
     '--topbar-bg': topbar.background,
     '--topbar-border-color': topbar.borderBottomColor,
     '--topbar-title-color': topbar.titleColor,
+    '--term-container-bg': c.containerBg,
+    '--term-tint': c.tint || 'transparent',
+    '--term-status-bg': c.statusBarBg,
+    '--term-status-border': c.statusBarBorder,
+    '--term-status-color': c.statusBarColor,
+    '--term-server-color': c.serverNameColor,
+    '--term-input-bar-bg': c.inputBarBg,
+    '--term-input-bar-border': c.inputBarBorder,
+    '--term-input-bg': c.inputBg,
+    '--term-input-color': c.inputColor,
+    '--term-input-placeholder': c.inputPlaceholder || c.mutedColor,
+    '--term-btn-border': c.btnBorder,
+    '--term-separator': c.separator,
+    '--term-muted': c.mutedColor,
+    '--term-context-bg': c.contextBg,
+    '--term-context-border': c.contextBorder,
+    '--term-context-shadow': c.contextShadow,
   };
   Object.entries(mappings).forEach(([cssVar, value]) => {
     if (value) {


### PR DESCRIPTION
### 问题背景与原因

在浅色模式下新建连接并进入终端时，底部的命令输入框及相关容器元素会在连接初期闪现深色样式，随后才变为浅色：

1. **CSS 变量兜底缺失浅色规则**：`xterm.css` 中仅在 `:root` 定义了深色主题的 `--term-*` 默认值，缺少 `body.theme-light` 对应的浅色变量兜底。
2. **异步 `useEffect` 引起首帧延迟**：`useTerminalTheme` 中通过 `useEffect` 在组件挂载后异步向 `wrapperRef` 注入 CSS 变量，导致浏览器在首帧绘制时回退到了 `:root` 的深色变量，随后变量更新触发过渡动画造成明显闪烁。
3. **全局主题变量同步缺失终端变量**：`applyStoredThemePackage` 未向 `document.body` 注入终端相关的全局 CSS 变量。

### 修复方案

1. **补全浅色主题 CSS 变量兜底**：在 `xterm.css` 中补充 `body.theme-light` 作用域下的 `--term-*` 变量。
2. **同步注入容器样式**：在 `useTerminalTheme` 中通过 `useMemo` 计算 `terminalContainerStyle`，并在 `Terminal.tsx` 根容器直接绑定 `style={terminalContainerStyle}`，确保挂载首帧即带有正确的主题变量。
3. **全局主题同步支持**：在 `theme.ts` 的 `applyComponentThemeVariables` 与 `THEME_COMPONENT_CSS_VARS` 中同步管理终端容器变量。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化终端主题样式，支持背景、状态栏、输入区、按钮、菜单、边框、阴影及滚动条等区域的动态配色。
  * 新增浅色主题下的终端配色与输入占位符样式。
  * 终端容器可根据当前主题即时应用样式，减少初始显示时的主题闪烁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->