### PR TITLE
fix(ui): 修复弹层滚动条穿透残留与背景 reflow（Linux/Windows 双修）

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "i18n:orphans": "node scripts/check-i18n-orphans.mjs",
     "styles:check": "node scripts/check-styles.mjs",
     "styles:baseline": "node scripts/check-styles.mjs --baseline",
+    "overlay:check": "node scripts/check-overlay-lock.mjs",
     "lint": "oxlint src",
     "lint:fix": "oxlint --fix src"
   },

--- a/frontend/scripts/check-overlay-lock.mjs
+++ b/frontend/scripts/check-overlay-lock.mjs
@@ -1,0 +1,67 @@
+// check-overlay-lock.mjs — 校验所有 createPortal 弹层已接入 useOverlayScrollLock
+//
+// 背景：Linux WebKitGTK 会把滚动条（::-webkit-scrollbar 自绘 thumb 与原生 overlay
+// indicator）绘制为独立合成层，盖过 position:fixed 弹层（#299）。portal 到 body 的
+// 交互弹层必须调用 useOverlayScrollLock(open) 锁定背景滚动，否则滚动后立即打开弹层
+// 时背景 thumb 会穿透到弹层上（GlobalContextMenu 曾遗漏，见 fix 分支记录）。
+//
+// 规则：src/**/*.tsx 中出现 createPortal 的文件必须出现 useOverlayScrollLock，
+// 否则需在下方 EXEMPT 清单登记并写明原因（portal 内容为已加锁组件 / 非模态瞬时提示等）。
+//
+// 用法：node scripts/check-overlay-lock.mjs（已挂 npm run overlay:check）
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const srcRoot = path.join(root, 'src');
+
+/** 豁免清单：portal 内容本身已加锁，或为非模态瞬时提示，无需重复接锁 */
+const EXEMPT = new Map([
+  // portal 内容为 ui/ContextMenu，其内部已调用 useOverlayScrollLock(true)
+  ['components/QuickCommands.tsx', 'portal 内容为已加锁的 ui/ContextMenu'],
+  ['components/filemanager/FileManagerOverlays.tsx', 'portal 内容为已加锁的 ui/ContextMenu；拖拽提示为瞬时非交互'],
+  // 主体为 ui/Modal（已加锁），portal 的历史下拉是 Modal 内二级浮层，背景已被 Modal 锁定
+  ['components/terminal/TerminalQuickCmdConfirm.tsx', '主体 ui/Modal 已加锁，portal 为 Modal 内二级下拉'],
+  // tooltip 为非模态悬浮提示，锁定背景滚动会破坏 hover 浏览体验；穿透窗口仅滚动后 ~1s
+  ['components/Tiptop.tsx', 'tooltip 非模态瞬时提示，不锁背景滚动'],
+]);
+
+function walk(dir, out = []) {
+  for (const name of fs.readdirSync(dir).sort()) {
+    const full = path.join(dir, name);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) walk(full, out);
+    else if (name.endsWith('.tsx')) out.push(full);
+  }
+  return out;
+}
+
+const violations = [];
+const report = [];
+for (const file of walk(srcRoot)) {
+  const rel = path.relative(srcRoot, file).split(path.sep).join('/');
+  const source = fs.readFileSync(file, 'utf8');
+  if (!source.includes('createPortal')) continue;
+  if (source.includes('useOverlayScrollLock')) {
+    report.push(`ok: ${rel}`);
+    continue;
+  }
+  const reason = EXEMPT.get(rel);
+  if (reason) {
+    report.push(`exempt: ${rel} — ${reason}`);
+  } else {
+    violations.push(rel);
+  }
+}
+
+for (const line of report) console.log(line);
+if (violations.length > 0) {
+  console.error('\n[check-overlay-lock] 以下文件使用 createPortal 但未接入 useOverlayScrollLock：');
+  for (const rel of violations) console.error(`  - ${rel}`);
+  console.error('portal 到 body 的交互弹层须调用 useOverlayScrollLock(open)（Linux WebKitGTK 滚动条穿透，见 hooks/useOverlayScrollLock.ts）；');
+  console.error('若确属无需加锁（内容已加锁/非模态瞬时提示），请在 scripts/check-overlay-lock.mjs 的 EXEMPT 登记原因。');
+  process.exit(1);
+}
+console.log(`\n[check-overlay-lock] ${report.length} 个 portal 弹层全部合规（含 ${[...EXEMPT.keys()].length} 个豁免登记）`);

--- a/frontend/src/components/GlobalContextMenu.tsx
+++ b/frontend/src/components/GlobalContextMenu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from '../i18n.ts';
 import { formatShortcut } from '../utils/platform.ts';
+import { useOverlayScrollLock } from '../hooks/useOverlayScrollLock.ts';
 import { GLOBAL_CONTEXT_MENU_OPEN_EVENT, type GlobalContextMenuDetail } from '../utils/contextMenu.ts';
 import {
   type ContextMenuItemInput,
@@ -35,6 +36,8 @@ export default function GlobalContextMenu() {
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [openSubmenuKey, setOpenSubmenuKey] = useState<string | null>(null);
   const [submenuAnchor, setSubmenuAnchor] = useState<SubmenuAnchor | null>(null);
+  // 菜单打开期间锁定背景滚动（Linux WebKitGTK 滚动条穿透，见 useOverlayScrollLock）
+  useOverlayScrollLock(menu !== null);
   // 防止子菜单切换时触发 MenuList 的自动 onClose 关闭整个菜单（同 ServerList 模式）
   const submenuToggleRef = useRef(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -290,6 +293,7 @@ export default function GlobalContextMenu() {
   return createPortal(
     <div
       ref={menuRef}
+      data-context-menu="true"
       onMouseDown={(event) => {
         event.stopPropagation();
       }}

--- a/frontend/src/components/GlobalContextMenu.tsx
+++ b/frontend/src/components/GlobalContextMenu.tsx
@@ -306,7 +306,7 @@ export default function GlobalContextMenu() {
         style={{
           left: menu.x,
           top: menu.y,
-          zIndex: Z.MENU,
+          zIndex: Z.CONTEXT_MENU,
           overflow: hasSubmenu ? 'visible' : undefined,
         }}
       >
@@ -328,8 +328,8 @@ export default function GlobalContextMenu() {
             className="fixed animate-[fadeIn_0.12s_ease]"
             style={
               submenuToLeft
-                ? { top: anchor.top - 5, right: window.innerWidth - anchor.left + 2, zIndex: Z.SUBMENU }
-                : { top: anchor.top - 5, left: anchor.right + 2, zIndex: Z.SUBMENU }
+                ? { top: anchor.top - 5, right: window.innerWidth - anchor.left + 2, zIndex: Z.CONTEXT_SUBMENU }
+                : { top: anchor.top - 5, left: anchor.right + 2, zIndex: Z.CONTEXT_SUBMENU }
             }
           >
             <MenuList items={toUiItems(activeParent.children)} onClose={closeMenu} />

--- a/frontend/src/components/quickCommands/QuickCommandDetail.tsx
+++ b/frontend/src/components/quickCommands/QuickCommandDetail.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { Rocket, Save, SquarePen, Trash2, Zap } from 'lucide-react';
 import { Z } from '../../constants/zIndex.ts';
 import { useTranslation } from '../../i18n.ts';
+import { useOverlayScrollLock } from '../../hooks/useOverlayScrollLock.ts';
 import { extractQuickCommandParams } from '../../utils/quickCommandParams.ts';
 import { Button, EmptyState, Select } from '../ui';
 import {
@@ -58,6 +59,8 @@ export function QuickCommandDetail({
   toggleAddCR,
 }: QuickCommandDetailProps) {
   const { t } = useTranslation();
+  // 历史下拉打开期间锁定背景滚动（Linux WebKitGTK 滚动条穿透，见 useOverlayScrollLock）
+  useOverlayScrollLock(historyDropdown !== null);
 
   if (selectedItem && selectedItem.type === 'group') {
     return (

--- a/frontend/src/constants/zIndex.ts
+++ b/frontend/src/constants/zIndex.ts
@@ -52,6 +52,11 @@ export const Z = {
   SETTINGS_DIALOG: 39001,
   SYSTEM_DIALOG: 39002,
 
+  // ── 全局右键菜单（document 级监听，可能从任意弹层内的输入框触发，
+  //    必须盖过所有弹层；仍低于 toast 与窗口缩放热区） ──
+  CONTEXT_MENU: 39500,
+  CONTEXT_SUBMENU: 39501,
+
   // ── Absolute top (toasts / system notices) ──
   TOAST: 40000,
 

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -24,6 +24,13 @@ import { isLinuxWebKit } from '../utils/platform';
  * - **仅 Linux WebKitGTK 生效**（`isLinuxWebKit`）：Windows/macOS 的滚动条可被
  *   弹层正常裁剪，无穿透问题，不加 `modal-open` 避免无谓的全局重绘。
  *
+ * 已实验排除的替代方案（2026-09 Linux 实测，勿重试）：
+ * - 仅靠结构层修复（portal 到 body + isolation + 滚动条样式作用域收敛）：穿透仍复现；
+ * - 弹层去进场动画（排除合成层提升触发）：无效；
+ * - 滚动容器提升合成层（will-change:scroll-position，含 Virtuoso）：无效。
+ * 结论：WebKitGTK 的滚动条层不受页面合成结构控制，弹层打开期间让背景滚动条
+ * 不可见（透明化）是该环境下防穿透的唯一手段；透明化保持槽位不动故无 reflow。
+ *
  * @param open - 弹层/菜单/下拉是否可见，`true` 时加锁，`false` 或卸载时解锁
  *
  * @usage

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -5,24 +5,24 @@ import { isLinuxWebKit } from '../utils/platform';
  * useOverlayScrollLock — Linux WebKitGTK 滚动条穿透的统一加锁
  *
  * @description
- * Wails Linux 使用 WebKitGTK，其原生 overlay scrollbar 在滚动后 1s 内处于
- * 淡出动画中，thumb 以独立合成层（GTK GtkOverlay）绘制在所有 `position:fixed`
- * 之上，`z-index`/`isolation` 无法压制。若弹层打开时背景容器仍为
- * `overflow:auto`，thumb 会穿透到弹层上（表现为一条 6px 细线，滚动后立即
- * 开弹层必现，静置 1s 后自动消失）。`base.css` 结合 `html.modal-open` 在
- * `paint` 前将背景 `overflow` 切为 `hidden` 才能瞬间隐藏。
+ * Wails Linux 使用 WebKitGTK，其滚动条以独立合成层绘制在所有 `position:fixed`
+ * 之上，`z-index`/`isolation` 无法压制。滚动后立即打开弹层时，背景 thumb 会
+ * 穿透到弹层上（表现为一条 6px 细线，静置 1s 后自动消失）。
  *
- * 本 hook 与 `frontend/src/styles/base.css:124-210` 配套：
- * - `base.css` 将 `*` 的滚动条样式收敛到 `.app-layout/[data-modal-overlay]/.modal-overlay`
- *   并在 `html.modal-open .app-layout *{scrollbar-width:none; overflow:hidden}` 隐藏背景；
+ * 本 hook 与 `frontend/src/styles/base.css` 配套：
+ * - `base.css` 在 `html.modal-open` 时把背景 `.app-layout` 的滚动条 thumb/track
+ *   **透明化**（`scrollbar-color: transparent` / `::-webkit-scrollbar-*` 背景透明）。
+ *   早期方案用 `scrollbar-width:none + overflow:hidden` 强制隐藏，但会移除滚动条
+ *   槽位、改变布局（overflow:hidden 打在 * 上还破坏 sticky），导致背景 reflow
+ *   （文件列表丢滚动位置、面板排版跳动、虚拟列表闪烁，Windows/Linux 均受影响）；
+ *   透明化保持滚动条结构与槽位不动，零布局变化，GTK 画到弹层上的 thumb 同样透明。
  *   弹层自身通过 `[data-modal-overlay]`/`.modal-overlay`/`[data-select-dropdown]` 等
- *   恢复为 `thin`，`portaled` 到 `body` 的弹层天然在 `.app-layout` 外不受影响。
- * - 本 hook 负责在 `paint` 前同步给 `html/body` 加 `modal-open`，并通过
- *   `body.dataset.modalCount` 计数保证多层嵌套（例：设置弹层内再开二次确认）时
- *   仅在最后一层关闭才解锁。
- * - **仅 Linux WebKitGTK 生效**（`isLinuxWebKit`）：Windows 经典滚动条占布局空间，
- *   隐藏会引发背景 reflow（Virtuoso 丢滚动位置、面板排版跳动）；macOS 可正常裁剪。
- *   非 Linux 平台本 hook 为 no-op，不加 `modal-open`，`base.css` 的锁定规则随之不触发。
+ *   恢复可见，`portaled` 到 `body` 的弹层天然在 `.app-layout` 外不受影响。
+ * - 本 hook 负责在 `paint` 前同步给 `html/body` 加 `modal-open`（首帧即生效，防
+ *   滚动后立即开弹层的首帧穿透），并通过 `body.dataset.modalCount` 计数保证多层
+ *   嵌套（例：设置弹层内再开二次确认）时仅在最后一层关闭才解锁。
+ * - **仅 Linux WebKitGTK 生效**（`isLinuxWebKit`）：Windows/macOS 的滚动条可被
+ *   弹层正常裁剪，无穿透问题，不加 `modal-open` 避免无谓的全局重绘。
  *
  * @param open - 弹层/菜单/下拉是否可见，`true` 时加锁，`false` 或卸载时解锁
  *
@@ -76,11 +76,9 @@ import { isLinuxWebKit } from '../utils/platform';
  */
 export function useOverlayScrollLock(open: boolean) {
   useLayoutEffect(() => {
-    // 仅 Linux WebKitGTK 需要加锁：其 overlay 滚动条是独立合成层会穿透 fixed 弹层。
-    // Windows WebView2 的经典滚动条占据布局空间，modal-open 的 scrollbar-width:none
-    // 会使滚动条瞬间消失引发背景 reflow（虚拟列表丢失滚动位置、面板排版跳动）；
-    // macOS WKWebView 滚动条可被弹层正常裁剪。非 Linux 平台保持 PR #299 之前的
-    // 无锁行为，靠弹层 z-index 自然盖住背景。
+    // 仅 Linux WebKitGTK 需要加锁：其滚动条绘制为独立合成层会穿透 fixed 弹层，
+    // modal-open 时 base.css 将背景滚动条透明化以隐藏穿透（零布局变化）。
+    // Windows/macOS 的滚动条可被弹层正常裁剪，不加锁避免无谓的全局重绘。
     if (!open || !isLinuxWebKit) return undefined;
 
     const docEl = document.documentElement;

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from 'react';
+import { isLinuxWebKit } from '../utils/platform';
 
 /**
  * useOverlayScrollLock — Linux WebKitGTK 滚动条穿透的统一加锁
@@ -19,6 +20,9 @@ import { useLayoutEffect } from 'react';
  * - 本 hook 负责在 `paint` 前同步给 `html/body` 加 `modal-open`，并通过
  *   `body.dataset.modalCount` 计数保证多层嵌套（例：设置弹层内再开二次确认）时
  *   仅在最后一层关闭才解锁。
+ * - **仅 Linux WebKitGTK 生效**（`isLinuxWebKit`）：Windows 经典滚动条占布局空间，
+ *   隐藏会引发背景 reflow（Virtuoso 丢滚动位置、面板排版跳动）；macOS 可正常裁剪。
+ *   非 Linux 平台本 hook 为 no-op，不加 `modal-open`，`base.css` 的锁定规则随之不触发。
  *
  * @param open - 弹层/菜单/下拉是否可见，`true` 时加锁，`false` 或卸载时解锁
  *
@@ -69,7 +73,12 @@ import { useLayoutEffect } from 'react';
  */
 export function useOverlayScrollLock(open: boolean) {
   useLayoutEffect(() => {
-    if (!open) return undefined;
+    // 仅 Linux WebKitGTK 需要加锁：其 overlay 滚动条是独立合成层会穿透 fixed 弹层。
+    // Windows WebView2 的经典滚动条占据布局空间，modal-open 的 scrollbar-width:none
+    // 会使滚动条瞬间消失引发背景 reflow（虚拟列表丢失滚动位置、面板排版跳动）；
+    // macOS WKWebView 滚动条可被弹层正常裁剪。非 Linux 平台保持 PR #299 之前的
+    // 无锁行为，靠弹层 z-index 自然盖住背景。
+    if (!open || !isLinuxWebKit) return undefined;
 
     const docEl = document.documentElement;
     const body = document.body;

--- a/frontend/src/hooks/useOverlayScrollLock.ts
+++ b/frontend/src/hooks/useOverlayScrollLock.ts
@@ -55,7 +55,10 @@ import { isLinuxWebKit } from '../utils/platform';
  * ```
  *
  * @rules
- * - 已使用 `ui/Modal` 的组件无需再调用，`Modal.tsx:65` 已内置。
+ * - 已使用 `ui/Modal` 的组件无需再调用，`Modal.tsx` 已内置。
+ * - **任何 `createPortal` 到 body 的交互弹层必须接入本 hook**：`npm run overlay:check`
+ *   （scripts/check-overlay-lock.mjs）会扫描校验，遗漏时登记豁免清单需写明原因。
+ *   GlobalContextMenu 曾因遗漏导致 Linux 上输入框右键菜单被背景滚动条穿透。
  * - 全屏遮罩会盖住顶栏导致窗口无法拖动：新的全屏弹层（`.modal-overlay` 或
  *   `fixed inset-0` 的模态类遮罩）首个子节点需放 `<ModalDragStrip />`
  *   （见 `ui/ModalDragStrip.tsx`），恢复遮罩打开时的顶栏拖动/双击最大化。

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -205,52 +205,37 @@
   background: transparent;
 }
 
-/* 弹层打开时，仅隐藏背景 .app-layout 的滚动条；portal 到 body 的弹层不受影响。
-   Linux WebKitGTK 的 overlay scrollbar 是独立合成层：滚动后 1s 内处于淡出动画中，
-   若仅用 scrollbar-width:none 且用 useEffect（paint 后才加类），首帧会把动画中的 thumb 画到 fixed 层之上。
-   因此：① Modal 改用 useLayoutEffect 同步加类（paint 前生效）；② 这里同时把背景滚动容器的 overflow 设为 hidden，
-   使 GTK 的 overlay indicator 立即失去可滚动依据而瞬间隐藏，而非等淡出超时。 */
+/* 弹层打开时，将背景 .app-layout 的滚动条透明化（而非隐藏/锁定 overflow）。
+   Linux WebKitGTK 的滚动条绘制为独立合成层，会盖过 position:fixed 弹层（穿透）。
+   曾用 scrollbar-width:none + overflow:hidden 强制隐藏，但两者都会移除滚动条槽位、
+   改变布局（overflow:hidden 打在 * 上还会破坏 sticky/虚拟列表的容器假设），导致背景
+   reflow——文件列表丢失滚动位置、监控面板排版跳动、虚拟列表闪烁（Windows/Linux 均受影响）。
+   改为仅把 thumb/track 绘制为透明：滚动条结构、槽位、overflow 全部不动，零布局变化；
+   GTK 画到弹层之上的 thumb 同样透明，穿透随之不可见。
+   注意：useLayoutEffect 同步加类（paint 前生效）仍是前提，避免滚动后立即开弹层的首帧穿透。 */
 html.modal-open .app-layout,
 html.modal-open .app-layout *,
 body.modal-open .app-layout,
 body.modal-open .app-layout * {
-  scrollbar-width: none !important;
-  -ms-overflow-style: none !important;
+  scrollbar-color: transparent transparent !important;
 }
-html.modal-open .app-layout::-webkit-scrollbar,
-html.modal-open .app-layout *::-webkit-scrollbar,
-body.modal-open .app-layout::-webkit-scrollbar,
-body.modal-open .app-layout *::-webkit-scrollbar {
-  display: none !important;
-  width: 0 !important;
-  height: 0 !important;
-}
-/* 背景滚动锁定：文件管理器(Virtuoso)、探针、首页等任意在 .app-layout 内的可滚动容器
-   在 Linux WebKitGTK 上滚动后 1s 内 overlay indicator 仍在淡出，scrollbar-width:none 无法瞬间隐藏
-   动画中的 native thumb，需 overflow:hidden。采用通用选择器而非枚举，避免遗漏 Virtuoso 等动态
-   生成的滚动容器（文件管理器截图即为此类）。portaled 弹层在 body 外不受影响，.modal-overlay 例外保留。 */
-html.modal-open .app-layout .dashboard-server-editor-body,
-html.modal-open .app-layout .hosts-scroll-area,
-html.modal-open .app-layout .data-page-scroll,
-html.modal-open .app-layout .probe-panel,
-html.modal-open .app-layout .terminal-tab-list-items,
-html.modal-open .app-layout .context-menu,
-html.modal-open .app-layout .term-quick-cmd-preview,
-/* 通用兜底：任意 .app-layout 内元素（排除仍在 .app-layout 内的 GlobalDialog） */
-html.modal-open .app-layout *:not(.modal-overlay):not(.modal-overlay *):not([data-modal-overlay]):not([data-modal-overlay] *),
-body.modal-open .app-layout .dashboard-server-editor-body,
-body.modal-open .app-layout .hosts-scroll-area,
-body.modal-open .app-layout .data-page-scroll,
-body.modal-open .app-layout .probe-panel,
-body.modal-open .app-layout .terminal-tab-list-items,
-body.modal-open .app-layout .context-menu,
-body.modal-open .app-layout .term-quick-cmd-preview,
-body.modal-open .app-layout *:not(.modal-overlay):not(.modal-overlay *):not([data-modal-overlay]):not([data-modal-overlay] *) {
-  overflow: hidden !important;
-}
-html.modal-open,
-body.modal-open {
-  overflow: hidden !important;
+html.modal-open .app-layout::-webkit-scrollbar-thumb,
+html.modal-open .app-layout *::-webkit-scrollbar-thumb,
+html.modal-open .app-layout::-webkit-scrollbar-thumb:hover,
+html.modal-open .app-layout *::-webkit-scrollbar-thumb:hover,
+html.modal-open .app-layout::-webkit-scrollbar-track,
+html.modal-open .app-layout *::-webkit-scrollbar-track,
+html.modal-open .app-layout::-webkit-scrollbar-corner,
+html.modal-open .app-layout *::-webkit-scrollbar-corner,
+body.modal-open .app-layout::-webkit-scrollbar-thumb,
+body.modal-open .app-layout *::-webkit-scrollbar-thumb,
+body.modal-open .app-layout::-webkit-scrollbar-thumb:hover,
+body.modal-open .app-layout *::-webkit-scrollbar-thumb:hover,
+body.modal-open .app-layout::-webkit-scrollbar-track,
+body.modal-open .app-layout *::-webkit-scrollbar-track,
+body.modal-open .app-layout::-webkit-scrollbar-corner,
+body.modal-open .app-layout *::-webkit-scrollbar-corner {
+  background: transparent !important;
 }
 
 /* 弹层自身始终保持 isolate 合成层，确保在 Linux 上盖过背景滚动条层 */
@@ -259,7 +244,8 @@ body.modal-open {
   isolation: isolate;
 }
 
-/* 若弹层仍在 .app-layout 内（如 GlobalDialog 未 portal），上面 .app-layout 隐藏会误伤弹层自身；显式恢复弹层滚动条 */
+/* 若弹层仍在 .app-layout 内（如 GlobalDialog 未 portal、仪表盘内的 Select 下拉），
+   上面的背景透明化会误伤弹层自身滚动条；显式恢复弹层滚动条可见 */
 html.modal-open [data-modal-overlay],
 html.modal-open [data-modal-overlay] *,
 html.modal-open .modal-overlay,

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -72,7 +72,9 @@
 [data-tab-context-menu],
 [data-tab-context-menu] *,
 [data-context-menu],
-[data-context-menu] * {
+[data-context-menu] *,
+[data-history-dropdown],
+[data-history-dropdown] * {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent;
 }
@@ -92,7 +94,9 @@
 [data-tab-context-menu]::-webkit-scrollbar,
 [data-tab-context-menu] *::-webkit-scrollbar,
 [data-context-menu]::-webkit-scrollbar,
-[data-context-menu] *::-webkit-scrollbar {
+[data-context-menu] *::-webkit-scrollbar,
+[data-history-dropdown]::-webkit-scrollbar,
+[data-history-dropdown] *::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
@@ -111,7 +115,9 @@
 [data-tab-context-menu]::-webkit-scrollbar-button,
 [data-tab-context-menu] *::-webkit-scrollbar-button,
 [data-context-menu]::-webkit-scrollbar-button,
-[data-context-menu] *::-webkit-scrollbar-button {
+[data-context-menu] *::-webkit-scrollbar-button,
+[data-history-dropdown]::-webkit-scrollbar-button,
+[data-history-dropdown] *::-webkit-scrollbar-button {
   display: none !important;
   width: 0 !important;
   height: 0 !important;
@@ -131,7 +137,9 @@
 [data-tab-context-menu]::-webkit-scrollbar-track,
 [data-tab-context-menu] *::-webkit-scrollbar-track,
 [data-context-menu]::-webkit-scrollbar-track,
-[data-context-menu] *::-webkit-scrollbar-track {
+[data-context-menu] *::-webkit-scrollbar-track,
+[data-history-dropdown]::-webkit-scrollbar-track,
+[data-history-dropdown] *::-webkit-scrollbar-track {
   background: transparent;
 }
 .app-layout::-webkit-scrollbar-thumb,
@@ -149,7 +157,9 @@
 [data-tab-context-menu]::-webkit-scrollbar-thumb,
 [data-tab-context-menu] *::-webkit-scrollbar-thumb,
 [data-context-menu]::-webkit-scrollbar-thumb,
-[data-context-menu] *::-webkit-scrollbar-thumb {
+[data-context-menu] *::-webkit-scrollbar-thumb,
+[data-history-dropdown]::-webkit-scrollbar-thumb,
+[data-history-dropdown] *::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35));
   border-radius: var(--radius-full);
   transition: background 0.15s ease;
@@ -169,7 +179,9 @@
 [data-tab-context-menu]::-webkit-scrollbar-thumb:hover,
 [data-tab-context-menu] *::-webkit-scrollbar-thumb:hover,
 [data-context-menu]::-webkit-scrollbar-thumb:hover,
-[data-context-menu] *::-webkit-scrollbar-thumb:hover {
+[data-context-menu] *::-webkit-scrollbar-thumb:hover,
+[data-history-dropdown]::-webkit-scrollbar-thumb:hover,
+[data-history-dropdown] *::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover, rgba(140, 165, 195, 0.6));
 }
 .app-layout::-webkit-scrollbar-corner,
@@ -187,7 +199,9 @@
 [data-tab-context-menu]::-webkit-scrollbar-corner,
 [data-tab-context-menu] *::-webkit-scrollbar-corner,
 [data-context-menu]::-webkit-scrollbar-corner,
-[data-context-menu] *::-webkit-scrollbar-corner {
+[data-context-menu] *::-webkit-scrollbar-corner,
+[data-history-dropdown]::-webkit-scrollbar-corner,
+[data-history-dropdown] *::-webkit-scrollbar-corner {
   background: transparent;
 }
 
@@ -271,11 +285,16 @@ body.modal-open .modal-overlay *::-webkit-scrollbar {
 }
 
 /* Select 下拉在 .app-layout 内时（仪表盘/文件管理器等），其自身滚动需保留
-   （Select 的 useOverlayScrollLock 会在下拉打开时触发 modal-open） */
+   （Select 的 useOverlayScrollLock 会在下拉打开时触发 modal-open）。
+   [data-history-dropdown]（快捷命令历史下拉）同理由 useOverlayScrollLock 加锁，一并恢复 */
 html.modal-open [data-select-dropdown],
 html.modal-open [data-select-dropdown] *,
+html.modal-open [data-history-dropdown],
+html.modal-open [data-history-dropdown] *,
 body.modal-open [data-select-dropdown],
-body.modal-open [data-select-dropdown] * {
+body.modal-open [data-select-dropdown] *,
+body.modal-open [data-history-dropdown],
+body.modal-open [data-history-dropdown] * {
   scrollbar-width: thin !important;
   scrollbar-color: var(--scrollbar-thumb, rgba(120, 140, 165, 0.35)) transparent !important;
   overflow-y: auto !important;
@@ -283,8 +302,12 @@ body.modal-open [data-select-dropdown] * {
 }
 html.modal-open [data-select-dropdown]::-webkit-scrollbar,
 html.modal-open [data-select-dropdown] *::-webkit-scrollbar,
+html.modal-open [data-history-dropdown]::-webkit-scrollbar,
+html.modal-open [data-history-dropdown] *::-webkit-scrollbar,
 body.modal-open [data-select-dropdown]::-webkit-scrollbar,
-body.modal-open [data-select-dropdown] *::-webkit-scrollbar {
+body.modal-open [data-select-dropdown] *::-webkit-scrollbar,
+body.modal-open [data-history-dropdown]::-webkit-scrollbar,
+body.modal-open [data-history-dropdown] *::-webkit-scrollbar {
   display: block !important;
   width: 6px !important;
   height: 6px !important;

--- a/frontend/src/utils/platform.ts
+++ b/frontend/src/utils/platform.ts
@@ -1,6 +1,23 @@
 // 平台检测工具
 export const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
 
+/**
+ * Linux WebKitGTK 环境（Wails Linux 端）。
+ * 其原生 overlay 滚动条以独立合成层绘制、不占布局空间，会穿透 position:fixed 弹层，
+ * 仅此环境需要弹层打开时锁定背景滚动（见 useOverlayScrollLock）；
+ * Windows WebView2 的经典滚动条占据布局空间，隐藏会引发背景 reflow；
+ * macOS WKWebView 的滚动条可被弹层正常裁剪，均无需加锁。
+ * 判定与 themeTransition.ts 的 WebKitGTK 检测保持一致：AppleWebKit（排除 Chrome/Chromium）且 Linux/X11。
+ */
+export const isLinuxWebKit = (() => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent || '';
+  const isAppleWebKit = /AppleWebKit/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua);
+  if (!isAppleWebKit) return false;
+  const platform = (navigator as unknown as { platform?: string }).platform || '';
+  return /Linux|X11/.test(ua) || /Linux/.test(platform);
+})();
+
 /** 修饰键事件（键盘/鼠标事件共有的 ctrlKey、metaKey 字段） */
 interface ModifierKeyEvent {
   ctrlKey: boolean;


### PR DESCRIPTION
## 背景

#299 为修复 Linux WebKitGTK 滚动条穿透引入了 `useOverlayScrollLock`（弹层打开时对背景加 `modal-open`，隐藏背景滚动条）。本 PR 修复其引入/遗留的四类问题，并沉淀防遗漏机制。

## 问题

1. **背景 reflow（Windows/Linux 均有）**：`modal-open` 规则用 `scrollbar-width:none` + `overflow:hidden` 隐藏背景滚动条，两者都会改变布局——滚动条槽位消失使内容区变宽，`overflow:hidden` 打在 `*` 上还破坏 sticky 与虚拟列表的容器假设。表现为弹层/右键菜单打开时文件列表丢失滚动位置、监控面板排版跳动、AI 虚拟列表滚动闪烁（Windows WebView2 的经典滚动条与 Linux 上自定义 `::-webkit-scrollbar` 均占布局空间）。
2. **Linux 残留穿透**：`GlobalContextMenu`（document 级输入框右键菜单）与快捷命令参数历史下拉漏接 `useOverlayScrollLock`，滚动后右键输入框时背景滚动条仍穿透压在菜单上。
3. **弹层内右键菜单被盖**：菜单 z-index 用背景档的 `Z.MENU`(200)，远低于 Modal(35000)/设置弹窗(39001)——在设置弹窗输入框上右键，菜单渲染在弹层之下。

## 修复

- **平台守卫**：`utils/platform.ts` 新增 `isLinuxWebKit`，`useOverlayScrollLock` 仅在 Linux WebKitGTK 上加锁；Windows/macOS 滚动条可被弹层正常裁剪，不加锁避免无谓的全局重绘。
- **透明化替代隐藏**：弹层打开时仅将背景滚动条 thumb/track 绘制透明（`scrollbar-color: transparent` + `::-webkit-scrollbar-*` 背景透明）——滚动条结构、槽位、overflow 全部不动，**零布局变化**；GTK 画到弹层之上的 thumb 同样透明，穿透不可见。移除整套 `scrollbar-width:none` / `overflow:hidden` 规则。
- **补漏**：`GlobalContextMenu`、`QuickCommandDetail` 历史下拉接入 `useOverlayScrollLock` 并补 data 标记；base.css 滚动条样式与恢复规则同步覆盖 `[data-history-dropdown]`。
- **z 层级**：新增 `CONTEXT_MENU`(39500)/`CONTEXT_SUBMENU`(39501)，右键菜单盖过所有弹层、仍低于 Toast 与窗口缩放热区。
- **防遗漏**：新增 `scripts/check-overlay-lock.mjs`（`npm run overlay:check`），扫描所有使用 `createPortal` 的文件强制要求接入 `useOverlayScrollLock`，豁免须在脚本内登记原因——从机制上杜绝后续新增弹层再漏接。

## 实验结论（Linux 真机实测，已排除的替代方案）

- 仅靠结构层修复（portal 到 body + `isolation` + 滚动条样式作用域收敛）：穿透仍复现
- 弹层去进场动画（排除合成层提升触发穿透）：无效
- 滚动容器提升合成层（`will-change: scroll-position`，含 Virtuoso）：无效

结论：WebKitGTK 的滚动条层不受页面合成结构控制，「弹层打开期间背景滚动条透明化」是该环境下防穿透且零布局副作用的唯一手段（结论已沉淀至 `useOverlayScrollLock.ts` 文档）。

## 测试

- **Windows（WebView2）**：实测确认右键菜单/弹层打开时背景布局零变化、滚动位置保留（wails dev 注入对比：clientWidth/scrollHeight 无变化，旧方案分别 +10px / 937→452）。
- **Linux（WebKitGTK 真机）**：确认穿透消失、reflow 消失、弹层内输入框右键菜单位于弹层之上、关闭弹层后滚动条恢复显示。

## 行为说明

Linux 上弹层打开期间背景滚动条不可见（防穿透的必要代价），关闭后立即恢复——与 #299 以来的可见行为一致，区别是不再引发布局跳动与滚动位置丢失。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化右键菜单及子菜单的显示层级，减少与提示、窗口操作区域的遮挡冲突。
  - 在右键菜单和历史下拉菜单打开时，改善背景滚动控制。

- **改进**
  - Linux WebKit 环境下，弹层打开时保持页面布局稳定，避免滚动条变化造成界面跳动。
  - 优化历史下拉菜单及其他弹层内的滚动条显示与滚动体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->