### PR TITLE
fix(filemanager): 修复重命名时双击选中文字误触发打开文件

### DIFF
--- a/frontend/src/components/filemanager/FileManagerVirtualRow.tsx
+++ b/frontend/src/components/filemanager/FileManagerVirtualRow.tsx
@@ -169,7 +169,13 @@ export function renderFileManagerVirtualRow(fm: FileManagerController, row: VRow
           setFileManagerPaneDropTarget('');
         } : undefined}
         onClick={isInteractive ? handleItemClick : undefined}
-        onDoubleClick={isInteractive ? () => {
+        onDoubleClick={isInteractive ? (event) => {
+          // 重命名时双击输入框应仅选中文字，不应冒泡触发打开文件
+          if (renamingItem) {
+            const target = event.target as HTMLElement | null;
+            if (target?.closest?.('#fm-rename-input')) return;
+            if (renamingItem.name === item.name) return;
+          }
           if (isDeletedPlaceholder) return;
           setSelectedPaths([itemPath]);
           lastClickedPathRef.current = itemPath;

--- a/frontend/src/components/filemanager/RenameInput.tsx
+++ b/frontend/src/components/filemanager/RenameInput.tsx
@@ -8,6 +8,8 @@ import type { RenameInputProps } from './fileManagerTypes.ts';
 //   - 非受控（defaultValue + ref 读值），避免受控渲染竞态丢字符。
 //   - suppressDragOutClick 抑制"框内 mousedown 拖出 mouseup"派生的 click，
 //     防止冒泡到行级 onClick 抢焦点、触发 onBlur 误提交。
+//   - onClick / onDoubleClick 均 stopPropagation，阻止冒泡到行级：
+//     单击不触发选中，双击仅在输入框内选中文字（按词选区），不触发行的双击打开文件。
 //   - committedRef 保证 onBlur / Enter / 外部取消 三条提交路径只生效一次。
 //   - 虚拟化卸载（Virtuoso 把该行滚出视口）时 React 不触发 onBlur，renamingItem
 //     会残留——卸载后 cleanup 故意保留已脱离 DOM 的元素引用，
@@ -59,6 +61,7 @@ export default function RenameInput({ initialValue, isDirectory, onConfirm, onCa
         }
       }}
       onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
       autoFocus
     />
   );


### PR DESCRIPTION
### 问题描述

文件管理器中，对文件重命名时，在输入框内双击想选中某个单词（按词选区），会意外触发行的 `onDoubleClick`，导致打开文件/进入目录。

复现步骤：
1. 在文件管理器中右键或点击重命名按钮，进入行内重命名状态
2. 在输入框内双击文件名中的单词，期望仅选中该词
3. 实际会冒泡触发行的双击打开逻辑

### 原因

`RenameInput` 之前只拦截了 `onClick` 的冒泡，未拦截 `onDoubleClick`，事件冒泡到 `FileManagerVirtualRow` 的行级 `onDoubleClick` 处理器，执行了 `navigate / handleEdit / handleOpenSystemEditor` 等打开逻辑。

### 修复方案

1. **`frontend/src/components/filemanager/RenameInput.tsx`**
   - 新增 `onDoubleClick={(e) => e.stopPropagation()}`，与 `onClick` 一致阻止冒泡
   - 更新注释说明双击仅在输入框内做词级选中，不触发行打开
   - 双击选中为浏览器原生行为，拦截冒泡后不再触发外层打开

2. **`frontend/src/components/filemanager/FileManagerVirtualRow.tsx`**
   - 行级 `onDoubleClick` 改为接收 `event` 参数
   - 增加 `renamingItem` 守卫：
     - 若 `event.target.closest('#fm-rename-input')` 命中输入框，直接 `return`
     - 若 `renamingItem.name === item.name`（正在重命名的同行），直接 `return`
   - 作为 `RenameInput` 拦截的防御性二次兜底，避免事件模型差异或合成事件时序导致的漏拦截

### 验证

- `frontend` 本地 `vite build` 通过
- 重命名状态下，双击输入框内的文字仅选中对应单词，不再打开文件/进入目录
- 非重命名状态的双击打开行为保持不变（目录进入、文件编辑/预览、压缩包/二进制拦截等）

### 关联分支

- `fix/filemanager-rename-doubleclick-select` -> `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复文件重命名时双击输入框会意外打开文件的问题。
  * 点击或双击重命名输入框时，不再触发行级选择或文件打开操作。
  * 双击输入框现在可正常选择文本，其他文件双击行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->