### PR TITLE
feat(settings): 顶栏按钮开关增加对应图标

### DIFF
--- a/frontend/src/components/settings/AppearanceTab.tsx
+++ b/frontend/src/components/settings/AppearanceTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { t as $t } from '../../i18n.ts';
-import { Sun, Monitor, Moon } from 'lucide-react';
+import { Sun, Monitor, Moon, MonitorUp, Bot, SunMoon } from 'lucide-react';
 import { cn } from '../../utils/cn.ts';
 import { Button } from '../ui';
 import { SettingRow, SettingsDivider, SettingsPanel, SettingsSectionTitle, SettingsTabRoot, ToggleSwitch } from './SharedComponents';
@@ -148,11 +148,44 @@ export default function AppearanceTab({
       <div>
         <SettingsSectionTitle definition={appearanceSettings.sections.topbar} />
         <SettingsPanel>
-          <SettingRow title={$t('数据大屏')} description={$t('在顶栏显示数据大屏按钮')} action={<ToggleSwitch checked={showBigScreenQuickEntry} onChange={onToggleBigScreenQuickEntry} />} />
+          <SettingRow
+            title={(
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex items-center justify-center w-7 h-7 text-secondary shrink-0">
+                  <MonitorUp size={16} />
+                </span>
+                {$t('数据大屏')}
+              </span>
+            )}
+            description={$t('在顶栏显示数据大屏按钮')}
+            action={<ToggleSwitch checked={showBigScreenQuickEntry} onChange={onToggleBigScreenQuickEntry} />}
+          />
           <SettingsDivider />
-          <SettingRow title={$t('主题切换')} description={$t('在顶栏显示主题切换按钮')} action={<ToggleSwitch checked={showThemeQuickEntry} onChange={onToggleThemeQuickEntry} />} />
+          <SettingRow
+            title={(
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex items-center justify-center w-7 h-7 text-secondary shrink-0">
+                  <SunMoon size={16} />
+                </span>
+                {$t('主题切换')}
+              </span>
+            )}
+            description={$t('在顶栏显示主题切换按钮')}
+            action={<ToggleSwitch checked={showThemeQuickEntry} onChange={onToggleThemeQuickEntry} />}
+          />
           <SettingsDivider />
-          <SettingRow title={$t('AI助手')} description={$t('在顶栏显示 AI 助手按钮')} action={<ToggleSwitch checked={showAIQuickEntry} onChange={onToggleAIQuickEntry} />} />
+          <SettingRow
+            title={(
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex items-center justify-center w-7 h-7 text-secondary shrink-0">
+                  <Bot size={16} />
+                </span>
+                {$t('AI助手')}
+              </span>
+            )}
+            description={$t('在顶栏显示 AI 助手按钮')}
+            action={<ToggleSwitch checked={showAIQuickEntry} onChange={onToggleAIQuickEntry} />}
+          />
         </SettingsPanel>
       </div>
 

--- a/frontend/src/components/settings/SharedComponents.tsx
+++ b/frontend/src/components/settings/SharedComponents.tsx
@@ -61,7 +61,7 @@ export function SettingsPanel({ children, style = {}, className, ...rest }: Sett
 
 export interface SettingsFieldProps {
   definition?: SettingsDefinitionNode;
-  title?: string;
+  title?: React.ReactNode;
   description?: React.ReactNode;
   action?: React.ReactNode;
   children?: React.ReactNode;


### PR DESCRIPTION
### 需求

设置 → 外观 → 顶栏按钮 三个开关（数据大屏 / 主题切换 / AI助手）仅有文字，用户无法一眼对应到顶栏实际的图标按钮。希望在开关标题前/后增加对应图标，提升辨识度。

### 改动

1. **`frontend/src/components/settings/SharedComponents.tsx`**
   - `SettingsFieldProps.title` 由 `string` 改为 `React.ReactNode`，允许标题中嵌入图标等 JSX，便于扩展

2. **`frontend/src/components/settings/AppearanceTab.tsx`**
   - 新增引入 `MonitorUp, Bot, SunMoon`（与 `AppTopbar.tsx` 顶栏真实按钮保持一致）
   - 顶栏按钮三项标题前增加扁平图标（`w-7 h-7 + text-secondary`，`size 16`，无背景无边框）：
     - 数据大屏 → `MonitorUp`
     - 主题切换 → `SunMoon`（对应顶栏 `Sun / Moon` 切换）
     - AI助手 → `Bot`
   - 使用 `inline-flex + gap-2` 与文字对齐，去除了 `bg-sunken / border` 的徽标背景，按反馈采用更轻量的扁平风格，视觉更干净

### 效果

- 设置页中可直接看到每个开关对应的顶栏图标，与顶栏实际按钮一一对应
- 无背景扁平图标在深色主题下更通透，已对比过带背景的徽标版本，当前版本更简洁

### 验证

- `frontend` 本地 `vite build` 通过
- 外观设置面板中顶栏按钮三项正常显示图标，开关功能不变
- 顶栏实际按钮（数据大屏 / 主题切换 / AI助手）显隐逻辑不受影响

### 分支

- `fix/settings-topbar-button-icons` -> `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **界面优化**
  - 设置页顶栏快捷入口改为带图标、标题和描述的分层布局，信息展示更清晰。
  - 快捷入口的开关操作保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->