### PR TITLE
fix(window): 边缘缩放陈旧状态按坐标复核清理，修复误触发的原生缩放循环（#327）

### DIFF
--- a/frontend/src/components/app/WindowResizeBorders.tsx
+++ b/frontend/src/components/app/WindowResizeBorders.tsx
@@ -70,6 +70,7 @@ export default function WindowResizeBorders() {
 
   // 兜底：触屏/笔输入没有前置 mousemove、flags.resizeEdge 为空时，由热区自身发起缩放
   const startResize = (e: React.MouseEvent, edge: string) => {
+    if (e.button !== 0) return; // 仅主键进入缩放，右键/中键不得触发原生缩放循环
     e.preventDefault();
     e.stopPropagation();
     const w = window as unknown as {

--- a/frontend/src/hooks/useWindowState.ts
+++ b/frontend/src/hooks/useWindowState.ts
@@ -45,6 +45,17 @@ function clearWindowResizeState(): void {
   }
 }
 
+/**
+ * 指针是否位于窗口边缘缩放带内。clientX/Y 与 innerWidth/innerHeight 同为 CSS
+ * 像素坐标系；不复用 wails runtime 基于 outerWidth 的边缘判定，避免高 DPI
+ * 缩放下两套坐标错位导致的误判。
+ */
+function isPointInWindowEdgeBand(e: { clientX: number; clientY: number }, thickness = RESIZE_BORDER_THICKNESS): boolean {
+  return e.clientX < thickness || e.clientY < thickness
+    || window.innerWidth - e.clientX < thickness
+    || window.innerHeight - e.clientY < thickness;
+}
+
 /** 指针是否落在元素的原生滚动条像素上（边缘缩放判定带内调用） */
 function isOverNativeScrollbar(e: MouseEvent, el: HTMLElement): boolean {
   // 右侧竖向 / 底部横向：Chromium 中滚动条不占用 client 区，命中坐标越过 client 即滚动条
@@ -109,20 +120,28 @@ export default function useWindowState(): () => Promise<void> {
     const doc = document.documentElement;
 
     const onMouseMove = (e: MouseEvent) => {
-      if (isMaxRef.current) return;
       const flags = getWailsFlags();
-      if (!flags || flags.enableResize === false) return;
-      if (flags.borderThickness !== RESIZE_BORDER_THICKNESS) {
+      if (!flags) return;
+      const resizeActive = !isMaxRef.current && flags.enableResize !== false;
+      if (resizeActive && flags.borderThickness !== RESIZE_BORDER_THICKNESS) {
         flags.borderThickness = RESIZE_BORDER_THICKNESS;
       }
 
       const edge = flags.resizeEdge;
-      if (edge) {
+      if (edge && resizeActive && isPointInWindowEdgeBand(e)) {
         if (doc.getAttribute(RESIZE_EDGE_ATTR) !== edge) {
           doc.setAttribute(RESIZE_EDGE_ATTR, edge);
         }
-      } else if (doc.hasAttribute(RESIZE_EDGE_ATTR)) {
-        doc.removeAttribute(RESIZE_EDGE_ATTR);
+        return;
+      }
+      // flags.resizeEdge 只在 mousemove 事件流里被 wails runtime 维护：原生缩放
+      // 模态循环吃掉后续鼠标事件、触屏/笔输入没有前置 mousemove、指针离开窗口、
+      // 最大化/禁用缩放期间两侧 mousemove 都提前返回——这些空洞都会让边缘状态
+      // 残留。残留时 data 属性会让全局 cursor:inherit 生效（光标异常），mousedown
+      // 还会把普通点击误判成边缘缩放（点击无法聚焦、键盘快捷键失效）。
+      // 这里按坐标现场复核：指针不在边缘带内即为陈旧状态，兜底清理。
+      if (edge || doc.hasAttribute(RESIZE_EDGE_ATTR)) {
+        clearWindowResizeState();
       }
     };
 
@@ -130,6 +149,13 @@ export default function useWindowState(): () => Promise<void> {
       if (isMaxRef.current) return;
       const flags = getWailsFlags();
       if (!flags?.resizeEdge) return;
+      // 按下瞬间复核指针真的在边缘带内且为主键：resizeEdge 可能是事件流空洞
+      // 留下的陈旧值，不复核时一次普通点击（如点终端获取焦点）会被转成原生
+      // 窗口缩放模态循环，吞掉点击与键盘输入
+      if (e.button !== 0 || !isPointInWindowEdgeBand(e)) {
+        clearWindowResizeState();
+        return;
+      }
       // 指针落在原生滚动条像素上时，浏览器强制显示箭头光标（CSS 改不了），
       // 此时按住应为滚动而非缩放：命中滚动条就取消边缘状态，让滚动条接管，
       // 保证"显示缩放光标的地方按下才会缩放"，判定与光标始终一致


### PR DESCRIPTION
## 修复内容

### #327 v1.3.2 鼠标指针异常、复制粘贴快捷键失效（1.3.1 正常）

**根因**：边缘缩放状态 `flags.resizeEdge` 只在 mousemove 事件流中由 Wails runtime 维护。原生缩放模态循环吞掉后续鼠标事件、触屏/笔输入没有前置 mousemove、指针离开窗口后事件中断、最大化/禁用缩放期间两侧 mousemove 均提前返回——这些事件空洞会让边缘状态残留。残留期间：

- `html[data-wails-resize-edge] *` 的 `cursor: inherit !important` 持续生效，光标不再随内容变化（指针异常）；
- `useWindowState` 的 capture 阶段 mousedown 不校验坐标，把普通点击（如点击终端获取焦点）误判为边缘缩放，`WailsInvoke('resize:*')` 进入原生窗口缩放模态循环，吞掉点击与键盘输入——复制粘贴快捷键失效。

**修复**：
- mousemove 镜像与 mousedown 触发前，均按 `clientX/Y` 对 `innerWidth/innerHeight`（同一 CSS 像素坐标系，无 DPI 错位）复核指针确实处于边缘带内，否则视为陈旧状态兜底清理；
- 陈旧状态清理不再受最大化 / `enableResize` 早退影响；
- 边缘缩放仅响应主键，右键/中键不再进入原生缩放循环。

**验证**：模拟陈旧状态的浏览器回归测试（真实组件 + 模拟 wails flags）：修复前中央点击触发 `resize:*` 且 data 属性/光标/标志残留（1/7）；修复后 7/7（中央点击不触发、边缘点击仍可缩放、右键不触发、无前置移动的点击安全）。另 `tsc`（改动文件 0 错误）、`oxlint` 0 告警、`vite build` 成功。

> 说明：本 PR 初版还包含 #319（编辑器分栏切换终端后打不开）的修复；因上游 836fb37d 已以更完整的方案修复该问题（传输队列与分栏 host 解耦、失活无条件回收宽度），已从本 PR 移除，仅保留 #327 修复。

修复 #327
