### PR TITLE
fix(transfer): 修复 SFTP 下载大文件静默截断与损坏

### DIFF
--- a/internal/sshmanager/ssh.go
+++ b/internal/sshmanager/ssh.go
@@ -904,7 +904,9 @@ func (m *SSHManager) ApplyTransferTuning(settings TransferTuningSettings) {
 
 func (m *SSHManager) newSharedSFTPClient(client *ssh.Client) (*sftp.Client, error) {
 	if m.transferService.Tuning().ApplyToSharedClient {
-		return m.transferService.NewSFTPClient(client)
+		// 共享 client 读方向固定 32KB 互操作安全长度,避免部分服务器对超长
+		// READ 返回短读/提前 EOF 造成下载静默截断(issue #334)。
+		return m.transferService.NewSharedSFTPClient(client)
 	}
 	return sftp.NewClient(client)
 }

--- a/internal/sshmanager/ssh_transfer_ops.go
+++ b/internal/sshmanager/ssh_transfer_ops.go
@@ -243,6 +243,10 @@ func (m *SSHManager) copyWithProgress(dst io.Writer, src io.Reader, sessionId st
 	close(reporterDone)
 	<-reporterFinished
 	tracker.emit(writer.copied.Load())
+	if err == nil && totalSize > 0 && writer.copied.Load() < totalSize {
+		// 与 transfer 包下载路径相同的截断守卫(issue #334)
+		return fmt.Errorf("transfer incomplete: copied %d of %d bytes", writer.copied.Load(), totalSize)
+	}
 	return err
 }
 

--- a/internal/transfer/download.go
+++ b/internal/transfer/download.go
@@ -249,10 +249,21 @@ func copyReaderWithProgressContext(ctx context.Context, dst io.Writer, src io.Re
 	if copyErr != nil {
 		return copyErr
 	}
+	if err := ensureContextActive(ctx); err != nil {
+		return err
+	}
+	// 部分服务器对超长 READ 只回短数据甚至提前 EOF,pkg/sftp 的并发读会把它当
+	// 正常结束(io.Copy 返回 nil)。这里校验实际字节数,把静默截断变成显式失败,
+	// 让上层 cleanup 删除半成品而不是留下损坏文件(issue #334)。
+	if totalSize > 0 {
+		if copied := writer.copied.Load(); copied < totalSize {
+			return fmt.Errorf("download incomplete: received %d of %d bytes (remote returned short reads or early EOF)", copied, totalSize)
+		}
+	}
 	if onProgress != nil {
 		onProgress(writer.copied.Load(), totalSize)
 	}
-	return ensureContextActive(ctx)
+	return nil
 }
 
 func sanitizeDownloadArchiveName(name string) string {

--- a/internal/transfer/download_shortread_test.go
+++ b/internal/transfer/download_shortread_test.go
@@ -1,0 +1,227 @@
+package transfer
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+)
+
+// 本文件针对 issue #334(下载大文件不完整/损坏)的回归测试。
+//
+// 背景:部分 SFTP 服务器对超过 32KB 的 READ 请求只返回 32KB 数据(短读),
+// 并对越过文件末尾的 READ 返回 EOF。pkg/sftp v1.13.x 的并发读路径会把短读
+// 当作正常数据(造成数据缺口与错位)、把提前 EOF 当作正常结束,io.Copy 因此
+// 静默返回成功,本地留下一个远小于原文件且内容损坏的文件。
+//
+// shortReadServerBackend 借助 sftp.NewRequestServer 复现这类服务器:
+// RequestServer 的 defaultMaxTxPacket 恰为 32KB,对任何超过 32KB 的 READ
+// 请求都只回 32KB 数据,与 issue 中的服务器行为一致。
+
+const shortReadServerPath = "/remote.bin"
+
+type shortReadServerBackend struct {
+	content []byte
+}
+
+func (b *shortReadServerBackend) Fileread(r *sftp.Request) (io.ReaderAt, error) {
+	if !r.Pflags().Read {
+		return nil, os.ErrInvalid
+	}
+	return bytes.NewReader(b.content), nil
+}
+
+func (b *shortReadServerBackend) Filewrite(r *sftp.Request) (io.WriterAt, error) {
+	return nil, os.ErrInvalid
+}
+
+func (b *shortReadServerBackend) Filecmd(r *sftp.Request) error { return nil }
+
+func (b *shortReadServerBackend) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
+	if r.Method != "Stat" && r.Method != "Lstat" {
+		return nil, os.ErrNotExist
+	}
+	return shortReadListerAt{fakeRemoteFileInfo{name: "remote.bin", size: int64(len(b.content))}}, nil
+}
+
+type fakeRemoteFileInfo struct {
+	name string
+	size int64
+}
+
+func (f fakeRemoteFileInfo) Name() string       { return f.name }
+func (f fakeRemoteFileInfo) Size() int64        { return f.size }
+func (f fakeRemoteFileInfo) Mode() os.FileMode  { return 0o644 }
+func (f fakeRemoteFileInfo) ModTime() time.Time { return time.Unix(0, 0).UTC() }
+func (f fakeRemoteFileInfo) IsDir() bool        { return false }
+func (f fakeRemoteFileInfo) Sys() any           { return nil }
+
+type shortReadListerAt []os.FileInfo
+
+func (l shortReadListerAt) ListAt(ls []os.FileInfo, offset int64) (int, error) {
+	if offset >= int64(len(l)) {
+		return 0, io.EOF
+	}
+	n := copy(ls, l[offset:])
+	if n < len(ls) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// newShortReadServerClient 在 net.Pipe 上搭建一对 SFTP 客户端/服务器,
+// 服务器对超过 32KB 的 READ 请求只回 32KB 数据。
+func newShortReadServerClient(t *testing.T, content []byte, opts ...sftp.ClientOption) *sftp.Client {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	backend := &shortReadServerBackend{content: content}
+	server := sftp.NewRequestServer(serverConn, sftp.Handlers{
+		FileGet:  backend,
+		FilePut:  backend,
+		FileCmd:  backend,
+		FileList: backend,
+	})
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve() }()
+	client, err := sftp.NewClientPipe(clientConn, clientConn, opts...)
+	if err != nil {
+		t.Fatalf("sftp.NewClientPipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+		select {
+		case <-serveDone:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	return client
+}
+
+// shortReadTestContent 生成约 1.5MB 非重复数据:足以跨越多个 128KB/32KB 请求
+// 边界,末尾故意不对齐,以覆盖最后一块的部分读取。
+func shortReadTestContent() []byte {
+	content := make([]byte, 3*128*1024+257*1024+3)
+	seed := byte(0x5A)
+	for i := range content {
+		seed = seed*131 + 7
+		content[i] = seed
+	}
+	return content
+}
+
+func openShortReadServerFile(t *testing.T, client *sftp.Client) (*sftp.File, int64) {
+	t.Helper()
+	src, err := client.Open(shortReadServerPath)
+	if err != nil {
+		t.Fatalf("client.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	info, err := src.Stat()
+	if err != nil {
+		t.Fatalf("src.Stat: %v", err)
+	}
+	if info.Size() <= 128*1024 {
+		t.Fatalf("test file too small to exercise concurrent reads: %d", info.Size())
+	}
+	return src, info.Size()
+}
+
+// 拷贝层守卫:实际接收字节数少于声明大小时必须报错,而不是静默成功。
+func TestCopyReaderWithProgressContextRejectsShortStream(t *testing.T) {
+	src := io.LimitReader(bytes.NewReader([]byte("0123456789")), 5)
+	var dst bytes.Buffer
+	err := copyReaderWithProgressContext(context.Background(), &dst, src, 10, nil)
+	if err == nil {
+		t.Fatal("short stream accepted: expected error, got nil")
+	}
+	if dst.Len() != 5 {
+		t.Fatalf("copied = %d bytes, want 5", dst.Len())
+	}
+}
+
+func TestCopyReaderWithProgressContextAcceptsFullStream(t *testing.T) {
+	src := bytes.NewReader([]byte("0123456789"))
+	var dst bytes.Buffer
+	if err := copyReaderWithProgressContext(context.Background(), &dst, src, 10, nil); err != nil {
+		t.Fatalf("full stream rejected: %v", err)
+	}
+	if dst.String() != "0123456789" {
+		t.Fatalf("content = %q, want %q", dst.String(), "0123456789")
+	}
+}
+
+func TestCopyReaderWithProgressContextAcceptsEmptyStream(t *testing.T) {
+	var dst bytes.Buffer
+	if err := copyReaderWithProgressContext(context.Background(), &dst, bytes.NewReader(nil), 0, nil); err != nil {
+		t.Fatalf("empty stream rejected: %v", err)
+	}
+}
+
+// MCP 传输路径的拷贝守卫:短流必须报错。
+func TestRunMCPTransferCopyRejectsShortStream(t *testing.T) {
+	src := io.LimitReader(bytes.NewReader([]byte("0123456789")), 4)
+	var dst bytes.Buffer
+	if err := runMCPTransferCopy(context.Background(), &dst, src, 10, nil); err == nil {
+		t.Fatal("short stream accepted: expected error, got nil")
+	}
+}
+
+// 集成复现:短读服务器 + 旧调优选项(128KB 读长)时,拷贝层必须把截断报告为
+// 错误。修复前 io.Copy 静默返回 nil,本地只得到约 1/4 的数据且内容错位。
+func TestDownloadShortReadServerTunedOptionsMustFail(t *testing.T) {
+	content := shortReadTestContent()
+	client := newShortReadServerClient(t, content, buildTunedSFTPOptions(DefaultTuning())...)
+	src, totalSize := openShortReadServerFile(t, client)
+
+	var dst bytes.Buffer
+	err := copyReaderWithProgressContext(context.Background(), &dst, src, totalSize, nil)
+	if err == nil {
+		t.Fatalf("silent truncation: expected error, got nil (copied %d of %d bytes)", dst.Len(), totalSize)
+	}
+}
+
+// 集成验证:共享 client 选项(互操作安全的读长)必须能从短读服务器完整下载,
+// 且内容逐字节一致。
+func TestDownloadShortReadServerSharedOptionsCompletes(t *testing.T) {
+	content := shortReadTestContent()
+	client := newShortReadServerClient(t, content, SharedSFTPClientOptions(DefaultTuning())...)
+	src, totalSize := openShortReadServerFile(t, client)
+
+	var dst bytes.Buffer
+	if err := copyReaderWithProgressContext(context.Background(), &dst, src, totalSize, nil); err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+	if int64(dst.Len()) != totalSize {
+		t.Fatalf("downloaded %d bytes, want %d", dst.Len(), totalSize)
+	}
+	if !bytes.Equal(dst.Bytes(), content) {
+		t.Fatal("downloaded content differs from remote file")
+	}
+}
+
+// MCP 下载走 File.Read(2MB 缓冲),并发 ReadAt 同样受短读影响;共享 client
+// 选项下也必须完整。
+func TestMCPDownloadShortReadServerSharedOptionsCompletes(t *testing.T) {
+	content := shortReadTestContent()
+	client := newShortReadServerClient(t, content, SharedSFTPClientOptions(DefaultTuning())...)
+	src, totalSize := openShortReadServerFile(t, client)
+
+	var dst bytes.Buffer
+	if err := runMCPTransferCopy(context.Background(), &dst, src, totalSize, nil); err != nil {
+		t.Fatalf("mcp download failed: %v", err)
+	}
+	if int64(dst.Len()) != totalSize {
+		t.Fatalf("downloaded %d bytes, want %d", dst.Len(), totalSize)
+	}
+	if !bytes.Equal(dst.Bytes(), content) {
+		t.Fatal("downloaded content differs from remote file")
+	}
+}

--- a/internal/transfer/mcp.go
+++ b/internal/transfer/mcp.go
@@ -411,10 +411,18 @@ func runMCPTransferCopy(ctx context.Context, dst io.Writer, src io.Reader, total
 			return readErr
 		}
 	}
+	if err := ensureContextActive(ctx); err != nil {
+		return err
+	}
+	// 与 copyReaderWithProgressContext 相同的截断守卫:远端流提前结束(io.EOF)
+	// 不代表传完了声明的大小,必须比对实际字节数(issue #334)。
+	if totalSize > 0 && copied < totalSize {
+		return fmt.Errorf("transfer incomplete: received %d of %d bytes (remote returned short reads or early EOF)", copied, totalSize)
+	}
 	if onProgress != nil {
 		onProgress(copied, totalSize)
 	}
-	return ensureContextActive(ctx)
+	return nil
 }
 
 func (s *Service) transferUploadFileContext(ctx context.Context, transferID string, sessionID string, localFullPath string, remoteFullPath string) (int64, error) {

--- a/internal/transfer/sftp_shared_client.go
+++ b/internal/transfer/sftp_shared_client.go
@@ -1,0 +1,42 @@
+package transfer
+
+import (
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// sftpInteropSafeReadBytes 是 SFTPv3 规范保证所有服务器都能正确返回的
+// 单次读请求长度(32768)。超过它的 READ 依赖服务器宽容:部分服务器/网关
+// (旧 OpenSSH、Dropbear、存储设备等)只返回 32KB 短数据甚至提前 EOF,
+// 而 pkg/sftp 的并发读会把短读当正常数据、提前 EOF 当正常结束,表现为
+// 下载静默截断且文件损坏(issue #334)。共享 client 承载全部下载流量,
+// 读方向必须固定在这个互操作安全长度;上传池 client 只写不读,仍用调优包长。
+const sftpInteropSafeReadBytes = 32 * 1024
+
+// SharedSFTPClientOptions 返回共享 SFTP client(下载与常规远程文件操作)的
+// 构建选项。包长固定 32KB;未显式配置并发数时按"SSH 通道窗口 / 包长"放大
+// 并发请求数(2MB/32KB = 64),保持与 128KB×16 调优相同的在途数据量,
+// 避免高延迟链路吞吐退化;用户显式配置过并发数则尊重其上限。
+func SharedSFTPClientOptions(tuning Tuning) []sftp.ClientOption {
+	tuning = NormalizeTuning(tuning)
+	requests := tuning.MaxRequestsPerFile
+	if !tuning.Configured {
+		if bounded := sshChannelWindowBytes / sftpInteropSafeReadBytes; bounded > requests {
+			requests = bounded
+		}
+	}
+	return []sftp.ClientOption{
+		sftp.MaxPacketChecked(sftpInteropSafeReadBytes),
+		sftp.MaxConcurrentRequestsPerFile(requests),
+		sftp.UseConcurrentWrites(tuning.ConcurrentWrites),
+	}
+}
+
+// NewSharedSFTPClient 基于既有 SSH 连接构建共享 SFTP client。
+func NewSharedSFTPClient(sshClient *ssh.Client, tuning Tuning) (*sftp.Client, error) {
+	return sftp.NewClient(sshClient, SharedSFTPClientOptions(tuning)...)
+}
+
+func (s *Service) NewSharedSFTPClient(sshClient *ssh.Client) (*sftp.Client, error) {
+	return NewSharedSFTPClient(sshClient, s.Tuning())
+}

--- a/internal/transfer/upload_chunk.go
+++ b/internal/transfer/upload_chunk.go
@@ -69,10 +69,6 @@ func NewSFTPClient(sshClient *ssh.Client, tuning Tuning) (*sftp.Client, error) {
 	return sftp.NewClient(sshClient)
 }
 
-func (s *Service) NewSFTPClient(sshClient *ssh.Client) (*sftp.Client, error) {
-	return NewSFTPClient(sshClient, s.Tuning())
-}
-
 func newSFTPUploadPool(sshClient *ssh.Client, maxClients int, tuning Tuning) *sftpUploadPool {
 	if maxClients < 1 {
 		maxClients = 1


### PR DESCRIPTION
Fixes #334

## 问题

用户反馈下载大文件后文件损坏，实际只有 304M（约为原文件 1.2GB 的 25%），且下载过程提示成功、无任何报错。

## 根因

数据路径完全在 Go 后端（`io.Copy` ← `sftp.File.WriteTo`），存在两个叠加缺陷：

1. **读请求长度超出互操作安全值**：共享 SFTP client 默认应用调优选项 `MaxPacketUnchecked(128KB)`，而 SFTPv3 规范保证所有服务器都能正确返回的单次读长度是 **32KB**。部分服务器/网关（旧 OpenSSH、Dropbear、存储设备等）对超过 32KB 的 READ 只返回 32KB 短数据，甚至提前返回 EOF。
2. **pkg/sftp v1.13.x 并发读把异常当正常**：并发 `WriteTo` 的派发循环对短读只拷实际返回字节但 offset 无条件前进（数据缺口 + 错位），Reduce 阶段收到 EOF 直接 `return written, nil`（提前结束也算成功）。
3. **完成判定不校验大小**：`io.Copy` 返回 nil 即成功，整条链路（含 MCP 传输与 legacy 路径）没有一处比对“实际拷贝字节数 == 远端文件大小”。

三者叠加：每个 128KB 请求只拿到 32KB → 本地文件恰好剩 25%（304MB），内容错位损坏，且前后端都判定“下载成功”。

## 修复（三层防御）

| 层 | 位置 | 改动 |
|---|---|---|
| 治本 | `internal/transfer/sftp_shared_client.go`（新增） | 共享 client 读方向固定 32KB（`MaxPacketChecked`）；未显式配置并发数时按通道窗口放大并发请求数（2MB/32KB=64），在途数据量与原 128KB×16 相同，高延迟链路吞吐不退化。上传池只写不读，仍用调优包长 |
| 兜底 | `download.go` / `mcp.go` / `ssh_transfer_ops.go` | 拷贝完成后校验实际字节数，不足即报错并由现有 cleanup 删除半成品——把一切静默截断（含提前 EOF 类服务器）变成显式失败 |
| 清理 | `upload_chunk.go` | 移除无调用方的 `Service.NewSFTPClient` |

## 测试

新增 `internal/transfer/download_shortread_test.go`（4 单元 + 3 集成）。集成测试用 `net.Pipe` + `sftp.NewRequestServer` 搭建短读服务器——其 `defaultMaxTxPacket` 恰为 32KB，天然复现 issue 中的服务器行为：

- **修复前（RED）**：656387 字节文件只下到 164867 字节（25.1%，与 1.2GB→304MB 同比例），`io.Copy` 返回 nil 无任何错误；MCP 路径（`File.Read` 2MB 缓冲）只拿到第一个 32KB 块
- **修复后（GREEN）**：同一坏服务器 + 共享 client 新选项 → 完整下载、逐字节一致；沿用 128KB 旧选项时 → 明确报错而非静默成功

全仓库测试无回归，`go vet` 干净。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 SFTP 大文件下载可能因短读或提前结束而静默生成不完整文件的问题。
  * 传输未达到预期大小时，现在会明确报告传输不完整。
  * 提升与不同 SFTP 服务器的兼容性，确保共享客户端下载内容完整一致。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->